### PR TITLE
Fix for bug  484496: Ipv6 on windows

### DIFF
--- a/src/MQTTPersistenceDefault.c
+++ b/src/MQTTPersistenceDefault.c
@@ -73,8 +73,10 @@ int pstopen(void **handle, const char* clientID, const char* serverURI, void* co
 	/* Note that serverURI=address:port, but ":" not allowed in Windows directories */
 	perserverURI = malloc(strlen(serverURI) + 1);
 	strcpy(perserverURI, serverURI);
-	ptraux = strstr(perserverURI, ":");
-	*ptraux = '-' ;
+	do {
+	    ptraux = strstr(perserverURI, ":");
+	    if (ptraux) *ptraux = '-' ;
+	} while (ptraux);
 
 	/* consider '/'  +  '-'  +  '\0' */
 	clientDir = malloc(strlen(dataDir) + strlen(clientID) + strlen(perserverURI) + 3);

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -600,6 +600,9 @@ int Socket_new(char* addr, int port, int* sock)
 	struct addrinfo hints = {0, AF_UNSPEC, SOCK_STREAM, IPPROTO_TCP, 0, NULL, NULL, NULL};
 
 	FUNC_ENTRY;
+#if defined(AF_INET6)
+	memset(&address6,0,sizeof(address6)); // initialize additional fields, e.g. flow label
+#endif
 	*sock = -1;
 
 	if (addr[0] == '[')


### PR DESCRIPTION
Please pull in this fix for bug 484496 (in Eclipse database)
see also https://github.com/eclipse/paho.mqtt.c/issues/7
This is probably also a fix for https://github.com/eclipse/paho.mqtt.c/issues/12
At least this bug report lead me to the fix, adding the missing initialization.

Greetings
  Juergen
