### PR TITLE
Build cmake fix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,8 @@ SET_TARGET_PROPERTIES(
 INSTALL(TARGETS paho-mqtt3c paho-mqtt3a MQTTVersion
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib)
+INSTALL(FILES MQTTAsync.h MQTTClient.h MQTTClientPersistence.h
+    DESTINATION include)
 
 IF (PAHO_WITH_SSL)
     SET(OPENSSL_LIB_SEARCH_PATH "" CACHE PATH "Directory containing OpenSSL libraries")

--- a/src/samples/CMakeLists.txt
+++ b/src/samples/CMakeLists.txt
@@ -36,15 +36,25 @@ TARGET_LINK_LIBRARIES(pubsync paho-mqtt3c)
 TARGET_LINK_LIBRARIES(pubasync paho-mqtt3c)
 TARGET_LINK_LIBRARIES(subasync paho-mqtt3c)
 
+ADD_EXECUTABLE(stdinpuba stdinpuba.c)
 ADD_EXECUTABLE(stdoutsuba stdoutsuba.c)
 ADD_EXECUTABLE(MQTTAsync_subscribe MQTTAsync_subscribe.c)
 ADD_EXECUTABLE(MQTTAsync_publish MQTTAsync_publish.c)
 
+TARGET_LINK_LIBRARIES(stdinpuba paho-mqtt3a)
 TARGET_LINK_LIBRARIES(stdoutsuba paho-mqtt3a)
 TARGET_LINK_LIBRARIES(MQTTAsync_subscribe paho-mqtt3a)
 TARGET_LINK_LIBRARIES(MQTTAsync_publish paho-mqtt3a)
 
-INSTALL(TARGETS stdinpub stdoutsub pubsync pubasync subasync stdoutsuba MQTTAsync_subscribe MQTTAsync_publish
+INSTALL(TARGETS stdinpub
+                stdoutsub
+                pubsync
+                pubasync
+                subasync
+                stdinpuba
+                stdoutsuba
+                MQTTAsync_subscribe
+                MQTTAsync_publish
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib)
 


### PR DESCRIPTION
These commits fix two small things in the CMake scripts:
1. Header files MQTTAsync.h, MQTTClient.h and MQTTClientPersistence.h should be copied to include directory on "make install" command. This behavior exists in the regular Makefile, but were missing from CMakeLists.txt;
2. The sample application, stdinpuba, was not in the compilation;
