### PR TITLE
Build CMake static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ STRING(STRIP ${BUILD_TIMESTAMP} BUILD_TIMESTAMP)
 
 ## build options
 SET(PAHO_WITH_SSL FALSE CACHE BOOL "Flag that defines whether to build ssl-enabled binaries too. ")
+SET(PAHO_BUILD_STATIC FALSE CACHE BOOL "Build static library")
 SET(PAHO_BUILD_DOCUMENTATION FALSE CACHE BOOL "Create and install the HTML based API documentation (requires Doxygen)")
 SET(PAHO_BUILD_SAMPLES FALSE CACHE BOOL "Build sample programs")
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Before compiling, determine the value of some variables in order to configure fe
 
 Variable | Default Value | Description
 ------------ | ------------- | -------------
+PAHO_BUILD_STATIC | FALSE | Build a static version of the libraries
 PAHO_WITH_SSL | FALSE | Flag that defines whether to build ssl-enabled binaries too. 
 OPENSSL_INC_SEARCH_PATH | "" (system default) | Directory containing OpenSSL includes
 OPENSSL_LIB_SEARCH_PATH | "" (system default) | Directory containing OpenSSL libraries
@@ -124,6 +125,8 @@ The Paho C client comprises four shared libraries:
  * libmqttv3as.so - asynchronous with SSL
  * libmqttv3c.so - "classic" / synchronous
  * libmqttv3cs.so - "classic" / synchronous with SSL
+
+Optionally, you can build static version of those libraries.
 
 ## Usage and API
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,22 @@ INSTALL(TARGETS paho-mqtt3c paho-mqtt3a
     LIBRARY DESTINATION lib)
 INSTALL(TARGETS MQTTVersion
     RUNTIME DESTINATION bin)
+
+IF (PAHO_BUILD_STATIC)
+    ADD_LIBRARY(paho-mqtt3c-static STATIC $<TARGET_OBJECTS:common_obj> MQTTClient.c)
+    ADD_LIBRARY(paho-mqtt3a-static STATIC $<TARGET_OBJECTS:common_obj> MQTTAsync.c)
+
+    TARGET_LINK_LIBRARIES(paho-mqtt3c-static ${LIBS_SYSTEM})
+    TARGET_LINK_LIBRARIES(paho-mqtt3a-static ${LIBS_SYSTEM})
+
+    INSTALL(TARGETS paho-mqtt3c-static
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib)
+    INSTALL(TARGETS paho-mqtt3a-static
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib)
+ENDIF()
+
 INSTALL(FILES MQTTAsync.h MQTTClient.h MQTTClientPersistence.h
     DESTINATION include)
 
@@ -107,5 +123,21 @@ IF (PAHO_WITH_SSL)
     INSTALL(TARGETS paho-mqtt3as
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib)
+
+    IF (PAHO_BUILD_STATIC)
+        ADD_LIBRARY(paho-mqtt3cs-static STATIC $<TARGET_OBJECTS:common_ssl_obj> MQTTClient.c SSLSocket.c)
+        ADD_LIBRARY(paho-mqtt3as-static STATIC $<TARGET_OBJECTS:common_ssl_obj> MQTTAsync.c SSLSocket.c)
+
+        TARGET_LINK_LIBRARIES(paho-mqtt3cs-static ${OPENSSL_LIBRARIES} ${LIBS_SYSTEM})
+        TARGET_LINK_LIBRARIES(paho-mqtt3as-static ${OPENSSL_LIBRARIES} ${LIBS_SYSTEM})
+
+        INSTALL(TARGETS paho-mqtt3cs-static
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib)
+        INSTALL(TARGETS paho-mqtt3as-static
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib)
+    ENDIF()
+
 ENDIF()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,9 +57,13 @@ ELSEIF (UNIX)
     ENDIF()
 ENDIF()
 
+## common compilation for libpaho-mqtt3c and libpaho-mqtt3a
+ADD_LIBRARY(common_obj OBJECT ${common_src})
+SET_PROPERTY(TARGET common_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 ADD_EXECUTABLE(MQTTVersion MQTTVersion.c)
-ADD_LIBRARY(paho-mqtt3c SHARED ${common_src} MQTTClient.c)
-ADD_LIBRARY(paho-mqtt3a SHARED ${common_src} MQTTAsync.c)
+ADD_LIBRARY(paho-mqtt3c SHARED $<TARGET_OBJECTS:common_obj> MQTTClient.c)
+ADD_LIBRARY(paho-mqtt3a SHARED $<TARGET_OBJECTS:common_obj> MQTTAsync.c)
 TARGET_LINK_LIBRARIES(paho-mqtt3c ${LIBS_SYSTEM})
 TARGET_LINK_LIBRARIES(paho-mqtt3a ${LIBS_SYSTEM})
 TARGET_LINK_LIBRARIES(MQTTVersion paho-mqtt3a paho-mqtt3c ${LIBS_SYSTEM})
@@ -85,8 +89,12 @@ IF (PAHO_WITH_SSL)
     INCLUDE_DIRECTORIES(
         ${OPENSSL_INC_SEARCH_PATH}
         )
-    ADD_LIBRARY(paho-mqtt3cs SHARED ${common_src} MQTTClient.c SSLSocket.c)
-    ADD_LIBRARY(paho-mqtt3as SHARED ${common_src} MQTTAsync.c SSLSocket.c)
+    ## common compilation for libpaho-mqtt3cs and libpaho-mqtt3as
+    ## Note: SSL libraries must be recompiled due ifdefs
+    ADD_LIBRARY(common_ssl_obj OBJECT ${common_src})
+    SET_PROPERTY(TARGET common_ssl_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+    ADD_LIBRARY(paho-mqtt3cs SHARED $<TARGET_OBJECTS:common_ssl_obj> MQTTClient.c SSLSocket.c)
+    ADD_LIBRARY(paho-mqtt3as SHARED $<TARGET_OBJECTS:common_ssl_obj> MQTTAsync.c SSLSocket.c)
     TARGET_LINK_LIBRARIES(paho-mqtt3cs ${OPENSSL_LIBRARIES} ${LIBS_SYSTEM})
     TARGET_LINK_LIBRARIES(paho-mqtt3as ${OPENSSL_LIBRARIES} ${LIBS_SYSTEM})
     SET_TARGET_PROPERTIES(


### PR DESCRIPTION
This branch adds two features to CMake build:

1st) It reduces the compilation time by reusing compiled objects. libpaho-mqtt3a and libpaho-mqtt3c share most of the objects modules, but they were compile twice.

2nd) Add ability to build a static version of each library.
