### PR TITLE
Improve password handling

### DIFF
--- a/src/Clients.h
+++ b/src/Clients.h
@@ -164,7 +164,8 @@ typedef struct
 {
 	char* clientID;					/**< the string id of the client */
 	const char* username;					/**< MQTT v3.1 user name */
-	const char* password;					/**< MQTT v3.1 password */
+	const uint8_t* password;				/**< MQTT v3.1 password */
+	uint16_t passwordLength;				/**< password length in bytes */
 	unsigned int cleansession : 1;	/**< MQTT clean session flag */
 	unsigned int connected : 1;		/**< whether it is currently connected */
 	unsigned int good : 1; 			/**< if we have an error on the socket we turn this off */

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -2167,10 +2167,15 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 			goto exit;
 		}
 	}
-	if ((options->username && !UTF8_validateString(options->username)) ||
-		(options->password && !UTF8_validateString(options->password)))
+	if (options->username && !UTF8_validateString(options->username))
 	{
 		rc = MQTTASYNC_BAD_UTF8_STRING;
+		goto exit;
+	}
+
+	if (options->password && !options->username)
+	{
+		rc = MQTTCLIENT_PASSWORD_WITHOUT_USERNAME;
 		goto exit;
 	}
 
@@ -2263,6 +2268,7 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 
 	m->c->username = options->username;
 	m->c->password = options->password;
+	m->c->passwordLength = options->passwordLength;
 	m->c->retryInterval = options->retryInterval;
 	m->shouldBeConnected = 1;
 

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -94,6 +94,7 @@
 #endif
 
 #include <stdio.h>
+#include <stdint.h>
 /// @endcond
 
 #if !defined(NO_PERSISTENCE)
@@ -710,7 +711,12 @@ typedef struct
       * and authorisation by user name and password. This is the password 
       * parameter.
       */
-	const char* password;
+	const uint8_t* password;
+	/**
+	* The length of the password in bytes.  This variable is only used if
+	* password is not NULL.
+	*/
+	uint16_t passwordLength;
 	/**
       * The time interval in seconds to allow a connect to complete.
       */
@@ -777,8 +783,8 @@ typedef struct
 } MQTTAsync_connectOptions;
 
 
-#define MQTTAsync_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 4, 60, 1, 10, NULL, NULL, NULL, 30, 0,\
-NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 1, 60}
+#define MQTTAsync_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 4, 60, 1, 10, NULL, NULL, \
+NULL, 0,30, 0, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 1, 60}
 
 /**
   * This function attempts to connect a previously-created client (see

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1029,6 +1029,7 @@ int MQTTClient_connectURI(MQTTClient handle, MQTTClient_connectOptions* options,
 
 	m->c->username = options->username;
 	m->c->password = options->password;
+	m->c->passwordLength = options->passwordLength;
 	m->c->retryInterval = options->retryInterval;
 
 	if (options->struct_version >= 3)
@@ -1092,10 +1093,15 @@ int MQTTClient_connect(MQTTClient handle, MQTTClient_connectOptions* options)
 	}
 #endif
 
-	if ((options->username && !UTF8_validateString(options->username)) ||
-		(options->password && !UTF8_validateString(options->password)))
+	if (options->username && !UTF8_validateString(options->username))
 	{
 		rc = MQTTCLIENT_BAD_UTF8_STRING;
+		goto exit;
+	}
+
+	if (options->password && !options->username)
+	{
+		rc = MQTTCLIENT_PASSWORD_WITHOUT_USERNAME;
 		goto exit;
 	}
 

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -114,6 +114,7 @@
   #define DLLExport __attribute__ ((visibility ("default")))
 #endif
 
+#include <stdint.h>
 #include <stdio.h>
 /// @endcond
 
@@ -166,6 +167,10 @@
  * Return code: A QoS value that falls outside of the acceptable range (0,1,2)
  */
 #define MQTTCLIENT_BAD_QOS -9
+/**
+ * Return code: A password was supplied, but a username was not
+ */
+#define MQTTCLIENT_PASSWORD_WITHOUT_USERNAME -10
 
 /**
  * Default MQTT version to connect with.  Use 3.1.1 then fall back to 3.1
@@ -578,13 +583,18 @@ typedef struct
 	const char* username;	
 	/** 
    * MQTT servers that support the MQTT v3.1.1 protocol provide authentication
-   * and authorisation by user name and password. This is the password 
-   * parameter.
+   * and authorisation by user name and password. This is the password
+   * parameter.  An MQTT password is a binary value up to 2**16 bytes in length.
    */
-	const char* password;
+	const uint8_t* password;
 	/**
-   * The time interval in seconds to allow a connect to complete.
-   */
+	* The length of the password in bytes.  This variable is only used if
+	* password is not NULL.
+	*/
+	uint16_t passwordLength;
+	/**
+	* The time interval in seconds to allow a connect to complete.
+	*/
 	int connectTimeout;
 	/**
 	 * The time interval in seconds
@@ -628,7 +638,7 @@ typedef struct
 	} returned;
 } MQTTClient_connectOptions;
 
-#define MQTTClient_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 4, 60, 1, 1, NULL, NULL, NULL, 30, 20, NULL, 0, NULL, 0}
+#define MQTTClient_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 4, 60, 1, 1, NULL, NULL, NULL, 0, 30, 20, NULL, 0, NULL, 0}
 
 /**
   * MQTTClient_libraryInfo is used to store details relating to the currently used

--- a/src/MQTTPacket.c
+++ b/src/MQTTPacket.c
@@ -436,6 +436,17 @@ void writeUTF(char** pptr, const char* string)
 	*pptr += len;
 }
 
+/**
+ * Writes binary data to an output buffer.  The data in the output buffer is
+ * prefixed by its length stored as a 2-byte integer.
+ */
+void writeBinaryData(char** pptr, const uint8_t* data, uint16_t dataLength)
+{
+	writeInt(pptr, dataLength);
+	memcpy(*pptr, data, dataLength);
+	*pptr += dataLength;
+}
+
 
 /**
  * Function used in the new packets table to create packets which have only a header.

--- a/src/MQTTPacket.h
+++ b/src/MQTTPacket.h
@@ -224,6 +224,7 @@ unsigned char readChar(char** pptr);
 void writeChar(char** pptr, char c);
 void writeInt(char** pptr, int anInt);
 void writeUTF(char** pptr, const char* string);
+void writeBinaryData(char** pptr, const uint8_t* data, uint16_t dataLength);
 
 char* MQTTPacket_name(int ptype);
 


### PR DESCRIPTION
Support binary passwords by treating passwords as uint8_t arrays rather than null terminated strings.  This pull request does not include updates to the test or sample code.  I have tried the synchronous client and it seems to work.  I want to gauge whether there is interest in this change before I go through the work of updating the tests and samples.  This change also enforces that a password may not be present without a username.
