### PR TITLE
Implemented connection timeouts for getaddrinfo() to prevent system hanging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,14 +128,14 @@ MQTTLIB_AS_TARGET = ${blddir}/lib${MQTTLIB_AS}.so.${VERSION}
 MQTTVERSION_TARGET = ${blddir}/MQTTVersion
 
 CCFLAGS_SO = -g -fPIC $(CFLAGS) -D_GNU_SOURCE -Os -Wall -fvisibility=hidden -I$(blddir_work)
-FLAGS_EXE = $(LDFLAGS) -I ${srcdir} ${START_GROUP} -lpthread -lanl ${END_GROUP} -L ${blddir}
-FLAGS_EXES = $(LDFLAGS) -I ${srcdir} ${START_GROUP} -lpthread -lanl -lssl -lcrypto ${END_GROUP} -L ${blddir}
+FLAGS_EXE = $(LDFLAGS) -I ${srcdir} ${START_GROUP} -lpthread ${GAI_LIB} ${END_GROUP} -L ${blddir}
+FLAGS_EXES = $(LDFLAGS) -I ${srcdir} ${START_GROUP} -lpthread ${GAI_LIB} -lssl -lcrypto ${END_GROUP} -L ${blddir}
 
 LDCONFIG ?= /sbin/ldconfig
-LDFLAGS_C = $(LDFLAGS) -shared -Wl,-init,$(MQTTCLIENT_INIT) $(START_GROUP) -lpthread -lanl $(END_GROUP)
-LDFLAGS_CS = $(LDFLAGS) -shared $(START_GROUP) -lpthread -lanl $(EXTRA_LIB) -lssl -lcrypto $(END_GROUP) -Wl,-init,$(MQTTCLIENT_INIT)
-LDFLAGS_A = $(LDFLAGS) -shared -Wl,-init,$(MQTTASYNC_INIT) $(START_GROUP) -lpthread -lanl $(END_GROUP)
-LDFLAGS_AS = $(LDFLAGS) -shared $(START_GROUP) -lpthread -lanl  $(EXTRA_LIB) -lssl -lcrypto $(END_GROUP) -Wl,-init,$(MQTTASYNC_INIT)
+LDFLAGS_C = $(LDFLAGS) -shared -Wl,-init,$(MQTTCLIENT_INIT) $(START_GROUP) -lpthread $(GAI_LIB) $(END_GROUP)
+LDFLAGS_CS = $(LDFLAGS) -shared $(START_GROUP) -lpthread $(GAI_LIB) $(EXTRA_LIB) -lssl -lcrypto $(END_GROUP) -Wl,-init,$(MQTTCLIENT_INIT)
+LDFLAGS_A = $(LDFLAGS) -shared -Wl,-init,$(MQTTASYNC_INIT) $(START_GROUP) -lpthread $(GAI_LIB) $(END_GROUP)
+LDFLAGS_AS = $(LDFLAGS) -shared $(START_GROUP) -lpthread $(GAI_LIB) $(EXTRA_LIB) -lssl -lcrypto $(END_GROUP) -Wl,-init,$(MQTTASYNC_INIT)
 
 SED_COMMAND = sed \
     -e "s/@CLIENT_VERSION@/${release.version}/g" \
@@ -148,6 +148,7 @@ MQTTASYNC_INIT = MQTTAsync_init
 START_GROUP = -Wl,--start-group
 END_GROUP = -Wl,--end-group
 
+GAI_LIB = -lanl
 EXTRA_LIB = -ldl
 
 LDFLAGS_C += -Wl,-soname,lib$(MQTTLIB_C).so.${MAJOR_VERSION}
@@ -162,6 +163,7 @@ MQTTASYNC_INIT = _MQTTAsync_init
 START_GROUP =
 END_GROUP = 
 
+GAI_LIB = 
 EXTRA_LIB = -ldl
 
 CCFLAGS_SO += -Wno-deprecated-declarations -DUSE_NAMED_SEMAPHORES

--- a/Makefile
+++ b/Makefile
@@ -127,15 +127,15 @@ MQTTLIB_A_TARGET = ${blddir}/lib${MQTTLIB_A}.so.${VERSION}
 MQTTLIB_AS_TARGET = ${blddir}/lib${MQTTLIB_AS}.so.${VERSION}
 MQTTVERSION_TARGET = ${blddir}/MQTTVersion
 
-CCFLAGS_SO = -g -fPIC $(CFLAGS) -Os -Wall -fvisibility=hidden -I$(blddir_work)
-FLAGS_EXE = $(LDFLAGS) -I ${srcdir} -lpthread -L ${blddir}
-FLAGS_EXES = $(LDFLAGS) -I ${srcdir} ${START_GROUP} -lpthread -lssl -lcrypto ${END_GROUP} -L ${blddir}
+CCFLAGS_SO = -g -fPIC $(CFLAGS) -D_GNU_SOURCE -Os -Wall -fvisibility=hidden -I$(blddir_work)
+FLAGS_EXE = $(LDFLAGS) -I ${srcdir} ${START_GROUP} -lpthread -lanl ${END_GROUP} -L ${blddir}
+FLAGS_EXES = $(LDFLAGS) -I ${srcdir} ${START_GROUP} -lpthread -lanl -lssl -lcrypto ${END_GROUP} -L ${blddir}
 
 LDCONFIG ?= /sbin/ldconfig
-LDFLAGS_C = $(LDFLAGS) -shared -Wl,-init,$(MQTTCLIENT_INIT) -lpthread
-LDFLAGS_CS = $(LDFLAGS) -shared $(START_GROUP) -lpthread $(EXTRA_LIB) -lssl -lcrypto $(END_GROUP) -Wl,-init,$(MQTTCLIENT_INIT)
-LDFLAGS_A = $(LDFLAGS) -shared -Wl,-init,$(MQTTASYNC_INIT) -lpthread
-LDFLAGS_AS = $(LDFLAGS) -shared $(START_GROUP) -lpthread $(EXTRA_LIB) -lssl -lcrypto $(END_GROUP) -Wl,-init,$(MQTTASYNC_INIT)
+LDFLAGS_C = $(LDFLAGS) -shared -Wl,-init,$(MQTTCLIENT_INIT) $(START_GROUP) -lpthread -lanl $(END_GROUP)
+LDFLAGS_CS = $(LDFLAGS) -shared $(START_GROUP) -lpthread -lanl $(EXTRA_LIB) -lssl -lcrypto $(END_GROUP) -Wl,-init,$(MQTTCLIENT_INIT)
+LDFLAGS_A = $(LDFLAGS) -shared -Wl,-init,$(MQTTASYNC_INIT) $(START_GROUP) -lpthread -lanl $(END_GROUP)
+LDFLAGS_AS = $(LDFLAGS) -shared $(START_GROUP) -lpthread -lanl  $(EXTRA_LIB) -lssl -lcrypto $(END_GROUP) -Wl,-init,$(MQTTASYNC_INIT)
 
 SED_COMMAND = sed \
     -e "s/@CLIENT_VERSION@/${release.version}/g" \

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -1153,13 +1153,13 @@ int MQTTAsync_processCommand()
 
 			Log(TRACE_MIN, -1, "Connecting to serverURI %s with MQTT version %d", serverURI, command->command.details.conn.MQTTVersion);
 #if defined(OPENSSL)
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined(__linux__)
 			rc = MQTTProtocol_connect(serverURI, command->client->c, command->client->ssl, command->command.details.conn.MQTTVersion, 0);
 #else
 			rc = MQTTProtocol_connect(serverURI, command->client->c, command->client->ssl, command->command.details.conn.MQTTVersion);
 #endif
 #else
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined(__linux__)
 			rc = MQTTProtocol_connect(serverURI, command->client->c, command->command.details.conn.MQTTVersion, 0);
 #else
 			rc = MQTTProtocol_connect(serverURI, command->client->c, command->command.details.conn.MQTTVersion);

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -38,7 +38,6 @@
  *
  */
 
-#define _GNU_SOURCE /* for pthread_mutexattr_settype */
 #include <stdlib.h>
 #if !defined(WIN32) && !defined(WIN64)
 	#include <sys/time.h>
@@ -1154,9 +1153,17 @@ int MQTTAsync_processCommand()
 
 			Log(TRACE_MIN, -1, "Connecting to serverURI %s with MQTT version %d", serverURI, command->command.details.conn.MQTTVersion);
 #if defined(OPENSSL)
+#if defined(__GNUC__)
+			rc = MQTTProtocol_connect(serverURI, command->client->c, command->client->ssl, command->command.details.conn.MQTTVersion, 0);
+#else
 			rc = MQTTProtocol_connect(serverURI, command->client->c, command->client->ssl, command->command.details.conn.MQTTVersion);
+#endif
+#else
+#if defined(__GNUC__)
+			rc = MQTTProtocol_connect(serverURI, command->client->c, command->command.details.conn.MQTTVersion, 0);
 #else
 			rc = MQTTProtocol_connect(serverURI, command->client->c, command->command.details.conn.MQTTVersion);
+#endif
 #endif
 			if (command->client->c->connect_state == 0)
 				rc = SOCKET_ERROR;

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -806,13 +806,13 @@ int MQTTClient_connectURIVersion(MQTTClient handle, MQTTClient_connectOptions* o
 
 	Log(TRACE_MIN, -1, "Connecting to serverURI %s with MQTT version %d", serverURI, MQTTVersion);
 #if defined(OPENSSL)
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined(__linux__)
 	rc = MQTTProtocol_connect(serverURI, m->c, m->ssl, MQTTVersion, millisecsTimeout - MQTTClient_elapsed(start));
 #else
 	rc = MQTTProtocol_connect(serverURI, m->c, m->ssl, MQTTVersion);
 #endif
 #else
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined(__linux__)
 	rc = MQTTProtocol_connect(serverURI, m->c, MQTTVersion, millisecsTimeout - MQTTClient_elapsed(start));
 #else
 	rc = MQTTProtocol_connect(serverURI, m->c, MQTTVersion);

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -37,7 +37,6 @@
  *
  */
 
-#define _GNU_SOURCE /* for pthread_mutexattr_settype */
 #include <stdlib.h>
 #if !defined(WIN32) && !defined(WIN64)
 	#include <sys/time.h>
@@ -807,9 +806,17 @@ int MQTTClient_connectURIVersion(MQTTClient handle, MQTTClient_connectOptions* o
 
 	Log(TRACE_MIN, -1, "Connecting to serverURI %s with MQTT version %d", serverURI, MQTTVersion);
 #if defined(OPENSSL)
+#if defined(__GNUC__)
+	rc = MQTTProtocol_connect(serverURI, m->c, m->ssl, MQTTVersion, millisecsTimeout - MQTTClient_elapsed(start));
+#else
 	rc = MQTTProtocol_connect(serverURI, m->c, m->ssl, MQTTVersion);
+#endif
+#else
+#if defined(__GNUC__)
+	rc = MQTTProtocol_connect(serverURI, m->c, MQTTVersion, millisecsTimeout - MQTTClient_elapsed(start));
 #else
 	rc = MQTTProtocol_connect(serverURI, m->c, MQTTVersion);
+#endif
 #endif
 	if (rc == SOCKET_ERROR)
 		goto exit;

--- a/src/MQTTProtocolOut.c
+++ b/src/MQTTProtocolOut.c
@@ -84,13 +84,13 @@ char* MQTTProtocol_addressPort(const char* uri, int* port)
  * @return return code
  */
 #if defined(OPENSSL)
-#if defined (__GNUC__)
+#if defined(__GNUC__) && defined(__linux__)
 int MQTTProtocol_connect(const char* ip_address, Clients* aClient, int ssl, int MQTTVersion, long timeout)
 #else
 int MQTTProtocol_connect(const char* ip_address, Clients* aClient, int ssl, int MQTTVersion)
 #endif
 #else
-#if defined (__GNUC__)
+#if defined(__GNUC__) && defined(__linux__)
 int MQTTProtocol_connect(const char* ip_address, Clients* aClient, int MQTTVersion, long timeout)
 #else
 int MQTTProtocol_connect(const char* ip_address, Clients* aClient, int MQTTVersion)
@@ -104,7 +104,7 @@ int MQTTProtocol_connect(const char* ip_address, Clients* aClient, int MQTTVersi
 	aClient->good = 1;
 
 	addr = MQTTProtocol_addressPort(ip_address, &port);
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined(__linux__)
 	if (timeout < 0)
 		rc = -1;
 	else

--- a/src/MQTTProtocolOut.c
+++ b/src/MQTTProtocolOut.c
@@ -104,7 +104,7 @@ int MQTTProtocol_connect(const char* ip_address, Clients* aClient, int MQTTVersi
 	aClient->good = 1;
 
 	addr = MQTTProtocol_addressPort(ip_address, &port);
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined(__linux__)
 	if (timeout < 0)
 		rc = -1;
 	else

--- a/src/MQTTProtocolOut.h
+++ b/src/MQTTProtocolOut.h
@@ -31,9 +31,17 @@
 
 void MQTTProtocol_reconnect(const char* ip_address, Clients* client);
 #if defined(OPENSSL)
-int MQTTProtocol_connect(const char* ip_address, Clients* acClients, int ssl, int MQTTVersion);
+#if defined (__GNUC__)
+int MQTTProtocol_connect(const char* ip_address, Clients* aClients, int ssl, int MQTTVersion, long timeout);
 #else
-int MQTTProtocol_connect(const char* ip_address, Clients* acClients, int MQTTVersion);
+int MQTTProtocol_connect(const char* ip_address, Clients* aClients, int ssl, int MQTTVersion);
+#endif
+#else
+#if defined (__GNUC__)
+int MQTTProtocol_connect(const char* ip_address, Clients* aClients, int MQTTVersion, long timeout);
+#else
+int MQTTProtocol_connect(const char* ip_address, Clients* aClients, int MQTTVersion);
+#endif
 #endif
 int MQTTProtocol_handlePingresps(void* pack, int sock);
 int MQTTProtocol_subscribe(Clients* client, List* topics, List* qoss, int msgID);

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -613,7 +613,7 @@ int Socket_new(char* addr, int port, int* sock)
 	  ++addr;
 
 #if defined(__GNUC__) && defined(__linux__)
-	struct gaicb ar = {addr, NULL, &hints, result};
+	struct gaicb ar = {addr, NULL, &hints, NULL};
 	struct gaicb *reqs[] = {&ar};
 
 	unsigned long int seconds = timeout / 1000L;
@@ -621,7 +621,9 @@ int Socket_new(char* addr, int port, int* sock)
 	struct timespec timeoutspec = {seconds, nanos};
 
 	rc = getaddrinfo_a(GAI_NOWAIT, reqs, 1, NULL);
-	gai_suspend((const struct gaicb* const *) reqs, 1, &timeoutspec);
+	if (rc == 0)
+		gai_suspend((const struct gaicb* const *) reqs, 1, &timeoutspec);
+	result = ar.ar_result;
 #else
 	rc = getaddrinfo(addr, NULL, &hints, &result);
 #endif

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -616,8 +616,8 @@ int Socket_new(char* addr, int port, int* sock)
 	struct gaicb ar = {addr, NULL, &hints, result};
 	struct gaicb *reqs[] = {&ar};
 
-	__time_t seconds = timeout / 1000L;
-	__syscall_slong_t nanos = (timeout - (seconds * 1000L)) * 1000000L;
+	unsigned long int seconds = timeout / 1000L;
+	unsigned long int nanos = (timeout - (seconds * 1000L)) * 1000000L;
 	struct timespec timeoutspec = {seconds, nanos};
 
 	rc = getaddrinfo_a(GAI_NOWAIT, reqs, 1, NULL);

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -585,7 +585,7 @@ void Socket_close(int socket)
  *  @param timeout the timeout in milliseconds
  *  @return completion code
  */
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined(__linux__)
 int Socket_new(char* addr, int port, int* sock, long timeout)
 #else
 int Socket_new(char* addr, int port, int* sock)
@@ -612,7 +612,7 @@ int Socket_new(char* addr, int port, int* sock)
 	if (addr[0] == '[')
 	  ++addr;
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined(__linux__)
 	struct gaicb ar = {addr, NULL, &hints, result};
 	struct gaicb *reqs[] = {&ar};
 

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -622,8 +622,13 @@ int Socket_new(char* addr, int port, int* sock)
 
 	rc = getaddrinfo_a(GAI_NOWAIT, reqs, 1, NULL);
 	if (rc == 0)
-		gai_suspend((const struct gaicb* const *) reqs, 1, &timeoutspec);
-	result = ar.ar_result;
+		rc = gai_suspend((const struct gaicb* const *) reqs, 1, &timeoutspec);
+
+	if (rc == 0)
+	{
+		rc = gai_error(reqs[0]);
+		result = ar.ar_result;
+	}
 #else
 	rc = getaddrinfo(addr, NULL, &hints, &result);
 #endif

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -118,7 +118,13 @@ int Socket_getch(int socket, char* c);
 char *Socket_getdata(int socket, size_t bytes, size_t* actual_len);
 int Socket_putdatas(int socket, char* buf0, size_t buf0len, int count, char** buffers, size_t* buflens, int* frees);
 void Socket_close(int socket);
+
+#if defined(__GNUC__)
+/* able to use GNU's getaddrinfo_a to make timeouts possible */
+int Socket_new(char* addr, int port, int* socket, long timeout);
+#else
 int Socket_new(char* addr, int port, int* socket);
+#endif
 
 int Socket_noPendingWrites(int socket);
 char* Socket_getpeer(int sock);

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -119,7 +119,7 @@ char *Socket_getdata(int socket, size_t bytes, size_t* actual_len);
 int Socket_putdatas(int socket, char* buf0, size_t buf0len, int count, char** buffers, size_t* buflens, int* frees);
 void Socket_close(int socket);
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined(__linux__)
 /* able to use GNU's getaddrinfo_a to make timeouts possible */
 int Socket_new(char* addr, int port, int* socket, long timeout);
 #else


### PR DESCRIPTION
Socket_new() will now honour the connection timeout on GNU systems (only GNU has an asynchronous version of getaddrinfo()).

Also moved `_GNU_SOURCE` to the compiler flags as it just would not work as a define in the top of `Socket.h`.
