### PR TITLE
Fixed GCC warning

### DIFF
--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -628,7 +628,7 @@ typedef struct
 	} returned;
 } MQTTClient_connectOptions;
 
-#define MQTTClient_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 4, 60, 1, 1, NULL, NULL, NULL, 30, 20, NULL, 0, NULL, 0}
+#define MQTTClient_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 4, 60, 1, 1, NULL, NULL, NULL, 30, 20, NULL, 0, NULL, 0, {NULL, 0, 0} }
 
 /**
   * MQTTClient_libraryInfo is used to store details relating to the currently used


### PR DESCRIPTION
Fixed GCC warning caused by MQTTClient_connectOptions_initializer constant missing a value for the 'returned' sub-structure of MQTTClient_connectOptions structure.

GCC check throwing the warning: 'missing-field-initializers', enabled by option -Wextra
GCC version 4.7.2

Error message:
warning: missing initializer for field 'returned' of 'MQTTClient_connectOptions' [-Wmissing-field-initializers]
     MQTTClient_connectOptions client_opt = MQTTClient_connectOptions_initializer;
     ^
