### PR TITLE
Fix usage of serverURIs to prevent segmentation fault

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -1824,7 +1824,8 @@ static thread_return_type WINAPI MQTTAsync_receiveThread(void* n)
 							MQTTAsync_successData data;
 							memset(&data, '\0', sizeof(data));
 							Log(TRACE_MIN, -1, "Calling connect success for client %s", m->c->clientID);
-							if (m->serverURIcount > 0)
+							if ((m->serverURIcount > 0)
+							    && (m->connect.details.conn.currentURI < m->serverURIcount))
 								data.alt.connect.serverURI = m->serverURIs[m->connect.details.conn.currentURI];
 							else
 								data.alt.connect.serverURI = m->serverURI;

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -1168,17 +1168,31 @@ static int MQTTAsync_processCommand(void)
 
 			if (command->client->serverURIcount > 0)
 			{
-				serverURI = command->client->serverURIs[command->command.details.conn.currentURI];
-
-				if (strncmp(URI_TCP, serverURI, strlen(URI_TCP)) == 0)
-					serverURI += strlen(URI_TCP);
-#if defined(OPENSSL)
-				else if (strncmp(URI_SSL, serverURI, strlen(URI_SSL)) == 0)
+				if (command->client->c->MQTTVersion == MQTTVERSION_DEFAULT)
 				{
-					serverURI += strlen(URI_SSL);
-					command->client->ssl = 1;
+					if (command->command.details.conn.MQTTVersion == MQTTVERSION_3_1)
+					{
+						command->command.details.conn.currentURI++;
+						command->command.details.conn.MQTTVersion = MQTTVERSION_DEFAULT;
+					}
 				}
+				else
+					command->command.details.conn.currentURI++;
+
+				if (command->command.details.conn.currentURI < command->client->serverURIcount)
+				{
+					serverURI = command->client->serverURIs[command->command.details.conn.currentURI];
+
+					if (strncmp(URI_TCP, serverURI, strlen(URI_TCP)) == 0)
+						serverURI += strlen(URI_TCP);
+#if defined(OPENSSL)
+					else if (strncmp(URI_SSL, serverURI, strlen(URI_SSL)) == 0)
+					{
+						serverURI += strlen(URI_SSL);
+						command->client->ssl = 1;
+					}
 #endif
+				}
 			}
 
 			if (command->client->c->MQTTVersion == MQTTVERSION_DEFAULT)
@@ -3214,3 +3228,8 @@ MQTTAsync_nameValue* MQTTAsync_getVersionInfo(void)
 	libinfo[i].value = NULL;
 	return libinfo;
 }
+
+/* Local Variables: */
+/* indent-tabs-mode: t */
+/* c-basic-offset: 8 */
+/* End: */

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -1815,9 +1815,12 @@ static thread_return_type WINAPI MQTTAsync_receiveThread(void* n)
 					if (rc == MQTTASYNC_SUCCESS)
 					{
 						int onSuccess = 0;
-						if (m->serverURIcount > 0)
-							Log(TRACE_MIN, -1, "Connect succeeded to %s",
+						if ((m->serverURIcount > 0)
+						    && (m->connect.details.conn.currentURI < m->serverURIcount))
+						{
+							Log(TRACE_MIN, -1, "Connect succeeded to %s", 
 								m->serverURIs[m->connect.details.conn.currentURI]);
+						}
 						onSuccess = (m->connect.onSuccess != NULL); /* save setting of onSuccess callback */
 						if (m->connect.onSuccess)
 						{

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -806,8 +806,10 @@ typedef struct
       * specify either an IP address or a domain name. For instance, to connect to
       * a server running on the local machines with the default MQTT port, specify
       * <i>tcp://localhost:1883</i>.
-      */
-	char* const* serverURIs;
+      * @note Do not modify the related memory as long as this library needs to use this
+      *       serverURIs for (re)connect!
+      */    
+	char** serverURIs;
 	/**
       * Sets the version of MQTT to be used on the connect.
       * MQTTVERSION_DEFAULT (0) = default: start with 3.1.1, and if that fails, fall back to 3.1


### PR DESCRIPTION
The member serverURIs of type MQTTAsync_disconnectOptions was not usable in C++, because it was declared as read-only type: char\* const*
After this change, the server URI can now be provided within
MQTTAsync_disconnectOptions. So that issues as described in
https://github.com/eclipse/paho.mqtt.c/issues/179 could be avoided.

Signed-off-by: Juergen Kosel juergen.kosel@softing.com
