### PR TITLE
allow user to disable openssl library init

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -60,6 +60,11 @@
 
 #include "VersionInfo.h"
 
+void MQTTAsync_global_init(int handle_openssl_init)
+{
+	SSLSocket_handleOpensslInit(handle_openssl_init);
+}
+
 char* client_timestamp_eye = "MQTTAsyncV3_Timestamp " BUILD_TIMESTAMP;
 char* client_version_eye = "MQTTAsyncV3_Version " CLIENT_VERSION;
 

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -177,6 +177,13 @@
  */
 #define MQTT_BAD_SUBSCRIBE 0x80
 
+/** 
+ * Global init of mqtt library. Call once on program start to set global behaviour.
+ * handle_openssl_init - if mqtt library should handle openssl init (1) or rely on the caller to init it before using mqtt (0)
+ */
+void MQTTAsync_global_init(int handle_openssl_init);
+
+
 /**
  * A handle representing an MQTT client. A valid client handle is available
  * following a successful call to MQTTAsync_create().

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -64,6 +64,11 @@
 
 #include "VersionInfo.h"
 
+void MQTTClient_global_init(int handle_openssl_init)
+{
+	SSLSocket_handleOpensslInit(handle_openssl_init);
+}
+
 char* client_timestamp_eye = "MQTTClientV3_Timestamp " BUILD_TIMESTAMP;
 char* client_version_eye = "MQTTClientV3_Version " CLIENT_VERSION;
 

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -184,6 +184,12 @@
  */
 #define MQTT_BAD_SUBSCRIBE 0x80
 
+/** 
+ * Global init of mqtt library. Call once on program start to set global behaviour.
+ * handle_openssl_init - if mqtt library should handle openssl init (1) or rely on the caller to init it before using mqtt (0)
+ */
+void MQTTClient_global_init(int handle_openssl_init);
+
 /**
  * A handle representing an MQTT client. A valid client handle is available
  * following a successful call to MQTTClient_create().
@@ -628,7 +634,7 @@ typedef struct
 	} returned;
 } MQTTClient_connectOptions;
 
-#define MQTTClient_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 4, 60, 1, 1, NULL, NULL, NULL, 30, 20, NULL, 0, NULL, 0}
+#define MQTTClient_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 4, 60, 1, 1, NULL, NULL, NULL, 30, 20, NULL, 0, NULL, 0, {NULL, 0, 0}}
 
 /**
   * MQTTClient_libraryInfo is used to store details relating to the currently used

--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -43,6 +43,8 @@ extern Sockets s;
 
 void SSLSocket_addPendingRead(int sock);
 
+/// 1 ~ we are responsible for initializing openssl; 0 ~ openssl init is done externally 
+static int handle_openssl_init = 1;
 static ssl_mutex_type* sslLocks = NULL;
 static ssl_mutex_type sslCoreMutex;
 
@@ -392,6 +394,11 @@ extern void SSLLocks_callback(int mode, int n, const char *file, int line)
 	}
 }
 
+void SSLSocket_handleOpensslInit(int bool_value)
+{
+	handle_openssl_init = bool_value;
+}
+
 int SSLSocket_initialize()   
 {
 	int rc = 0;
@@ -401,41 +408,45 @@ int SSLSocket_initialize()
 	
 	FUNC_ENTRY;
 
-	if ((rc = SSL_library_init()) != 1)
-		rc = -1;
+	if (handle_openssl_init)
+	{
+		if ((rc = SSL_library_init()) != 1)
+			rc = -1;
+			
+		ERR_load_crypto_strings();
+		SSL_load_error_strings();
 		
-	ERR_load_crypto_strings();
-	SSL_load_error_strings();
-	
-	/* OpenSSL 0.9.8o and 1.0.0a and later added SHA2 algorithms to SSL_library_init(). 
-	Applications which need to use SHA2 in earlier versions of OpenSSL should call 
-	OpenSSL_add_all_algorithms() as well. */
-	
-	OpenSSL_add_all_algorithms();
-	
-	lockMemSize = CRYPTO_num_locks() * sizeof(ssl_mutex_type);
+		/* OpenSSL 0.9.8o and 1.0.0a and later added SHA2 algorithms to SSL_library_init(). 
+		Applications which need to use SHA2 in earlier versions of OpenSSL should call 
+		OpenSSL_add_all_algorithms() as well. */
+		
+		OpenSSL_add_all_algorithms();
+		
+		lockMemSize = CRYPTO_num_locks() * sizeof(ssl_mutex_type);
 
-	sslLocks = malloc(lockMemSize);
-	if (!sslLocks)
-	{
-		rc = -1;
-		goto exit;
-	}
-	else
-		memset(sslLocks, 0, lockMemSize);
+		sslLocks = malloc(lockMemSize);
+		if (!sslLocks)
+		{
+			rc = -1;
+			goto exit;
+		}
+		else
+			memset(sslLocks, 0, lockMemSize);
 
-	for (i = 0; i < CRYPTO_num_locks(); i++)
-	{
-		/* prc = */SSL_create_mutex(&sslLocks[i]);
-	}
+		for (i = 0; i < CRYPTO_num_locks(); i++)
+		{
+			/* prc = */SSL_create_mutex(&sslLocks[i]);
+		}
 
 #if (OPENSSL_VERSION_NUMBER >= 0x010000000)
-	CRYPTO_THREADID_set_callback(SSLThread_id);
+		CRYPTO_THREADID_set_callback(SSLThread_id);
 #else
-	CRYPTO_set_id_callback(SSLThread_id);
+		CRYPTO_set_id_callback(SSLThread_id);
 #endif
-	CRYPTO_set_locking_callback(SSLLocks_callback);
-
+		CRYPTO_set_locking_callback(SSLLocks_callback);
+		
+	}
+	
 	SSL_create_mutex(&sslCoreMutex);
 
 exit:
@@ -446,19 +457,26 @@ exit:
 void SSLSocket_terminate()
 {
 	FUNC_ENTRY;
-	EVP_cleanup();
-	ERR_free_strings();
-	CRYPTO_set_locking_callback(NULL);
-	if (sslLocks)
+	
+	if (handle_openssl_init)
 	{
-		int i = 0;
-
-		for (i = 0; i < CRYPTO_num_locks(); i++)
+		EVP_cleanup();
+		ERR_free_strings();
+		CRYPTO_set_locking_callback(NULL);
+		if (sslLocks)
 		{
-			SSL_destroy_mutex(&sslLocks[i]);
+			int i = 0;
+
+			for (i = 0; i < CRYPTO_num_locks(); i++)
+			{
+				SSL_destroy_mutex(&sslLocks[i]);
+			}
+			free(sslLocks);
 		}
-		free(sslLocks);
 	}
+	
+	SSL_destroy_mutex(&sslCoreMutex);
+	
 	FUNC_EXIT;
 }
 

--- a/src/SSLSocket.h
+++ b/src/SSLSocket.h
@@ -30,6 +30,9 @@
 
 #define URI_SSL "ssl://"
 
+/** if we should handle openssl initialization (bool_value == 1) or depend on it to be initalized externally (bool_value == 0) */
+void SSLSocket_handleOpensslInit(int bool_value);
+
 int SSLSocket_initialize();
 void SSLSocket_terminate();
 int SSLSocket_setSocketForSSL(networkHandles* net, MQTTClient_SSLOptions* opts);


### PR DESCRIPTION
Hi,

I'm using paho mqtt in application alongside with other libraries that also uses openssl. The thing is, that paho MQTTClient always initialize openssl in _create and deinitialize on _destroy. Which causes havoc for following reasons:
* on calling MQTTClient_create I have openssl library already initalized by external code and paho does the initialization again in time when openssl is already in use
* on calling MQTTClient_create paho overrides the already initialized openssl locking (duplicating the locks)
* on calling MQTTClient_destroy it deinitalizes openssl library that is still in use by other parts of my app

what I propose is to allow user of paho mqtt to set globally who is responsible for openssl library init.

I would appreciate any comments and hope for possible merge to upstream

Thanks

Jirka