### PR TITLE
RPM Specs for Fedora, RHEL and Centos

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,0 +1,8 @@
+VERSION=1.1.0
+
+rpm-prep:
+	mkdir -p ${HOME}/rpmbuild/SOURCES/
+	tar --transform="s/\./paho-c-${VERSION}/" -cf ${HOME}/rpmbuild/SOURCES/paho-c-${VERSION}.tar.gz --exclude=./build --exclude=.git --exclude=*.bz ./ --gzip
+
+rpm: rpm-prep
+	rpmbuild -ba dist/paho-c.spec

--- a/dist/paho-c.spec
+++ b/dist/paho-c.spec
@@ -1,0 +1,65 @@
+%global _enable_debug_package 0
+%global debug_package %{nil}
+
+Summary:            MQTT C Client
+Name:               paho-c
+Version:            1.1.0
+Release:            1%{?dist}
+License:            Eclipse Distribution License 1.0 and Eclipse Public License 1.0
+Group:              Development/Tools
+Source:             paho-c-%{version}.tar.gz
+URL:                https://eclipse.org/paho/clients/c/
+BuildRequires:      cmake
+BuildRequires:      gcc
+BuildRequires:      graphviz
+BuildRequires:      doxygen
+BuildRequires:      openssl-devel
+Requires:           openssl
+
+
+%description
+The Paho MQTT C Client is a fully fledged MQTT client written in ANSI standard C.
+
+
+%package devel
+Summary:            MQTT C Client development kit
+Group:              Development/Libraries
+Requires:           paho-c
+
+%description devel
+Development files and samples for the the Paho MQTT C Client.
+
+
+%package devel-docs
+Summary:            MQTT C Client development kit documentation
+Group:              Development/Libraries
+
+%description devel-docs
+Development documentation files for the the Paho MQTT C Client.
+
+%prep
+%autosetup -n paho-c-%{version}
+
+%build
+mkdir build.paho && cd build.paho
+cmake -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=TRUE -DPAHO_BUILD_SAMPLES=TRUE -DCMAKE_INSTALL_PREFIX=%{buildroot}/usr ..
+make
+
+%install
+cd build.paho
+make install
+
+%files
+%doc edl-v10 epl-v10
+%{_libdir}/*
+
+%files devel
+%{_bindir}/*
+%{_includedir}/*
+
+%files devel-docs
+%{_datadir}/*
+
+%changelog
+* Sat Dec 31 2016 Otavio R. Piske <opiske@redhat.com> - 20161231
+- Initial packaging


### PR DESCRIPTION
This pull request contains the required changes for packaging Paho C as a RPM. Building the RPM spec as provided in this PR results in 3 separate RPM packages: 
- paho-c 1.1.0: runtime
- paho-c-devel 1.1.0: development files (headers and examples)
- paho-c-devel-docs 1.1.0: development documentation.

I currently have these packages on a testing COPR for Fedora 23 to 26, as well as EL7: https://copr.fedorainfracloud.org/coprs/orpiske/paho-testing/.

Please let me know if you would like any change to be made to this.