### PR TITLE
Proposed fix for OpenSSL compilation issue on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ compiler:
 os:
   - linux
   - osx
-  
+
+before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; brew install openssl ; fi
+
 script:
-  - make
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir build.paho ; cd build.paho; cmake -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=TRUE .. ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
   - osx
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; brew install openssl ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl ; fi
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir build.paho ; cd build.paho; cmake -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=TRUE .. ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
   - osx
 
 before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; brew install openssl ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; brew install openssl ; fi
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir build.paho ; cd build.paho; cmake -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=TRUE .. ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl ; fi
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir build.paho ; cd build.paho; cmake -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=TRUE .. ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir build.paho ; cd build.paho; cmake -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=TRUE .. ; make ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make ; fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,19 +72,22 @@ INSTALL(FILES MQTTAsync.h MQTTClient.h MQTTClientPersistence.h
 IF (PAHO_WITH_SSL)
 SET(OPENSSL_LIB_SEARCH_PATH "" CACHE PATH "Directory containing OpenSSL libraries")
     SET(OPENSSL_INC_SEARCH_PATH "" CACHE PATH "Directory containing OpenSSL includes")
-    SET(OPENSSL_LIBRARIES ssl crypto)
 
-    find_path(OPENSSL_INCLUDE_DIR openssl/ssl.h
-	HINTS ${OPENSSL_INC_SEARCH_PATH}/include)
-    find_library(OPENSSL_LIB NAMES ssl libssl
-	HINTS ${OPENSSL_DIR}/lib ${OPENSSL_DIR}/lib64)
-    find_library(OPENSSLCRYPTO_LIB NAMES ssl libssl
-	HINTS ${OPENSSL_DIR}/lib ${OPENSSL_DIR}/lib64)
+    IF (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+      SET(OPENSSL_BREW_PATH "/usr/local/opt/openssl")
+    ENDIF (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 
-    message(STATUS "OpenSSL hint ${PENSSL_INC_SEARCH_PATH} (includes) / ")
-    message(STATUS "OpenSSL headers found at ${OPENSSL_INCLUDE_DIR}")
-    message(STATUS "OpenSSL library found at ${OPENSSL_LIB}")
-    message(STATUS "OpenSSL Crypto library found at ${OPENSSLCRYPTO_LIB}")
+    FIND_PATH(OPENSSL_INCLUDE_DIR openssl/ssl.h
+        HINTS ${OPENSSL_INC_SEARCH_PATH}/include ${OPENSSL_BREW_PATH}/include/)
+    FIND_LIBRARY(OPENSSL_LIB NAMES ssl libssl
+        HINTS ${OPENSSL_BREW_PATH}/lib ${OPENSSL_DIR}/lib ${OPENSSL_DIR}/lib64)
+    FIND_LIBRARY(OPENSSLCRYPTO_LIB NAMES ssl libssl
+      	HINTS ${OPENSSL_BREW_PATH}/lib ${OPENSSL_DIR}/lib ${OPENSSL_DIR}/lib64)
+
+    MESSAGE(STATUS "OpenSSL hint ${PENSSL_INC_SEARCH_PATH} (includes) / ")
+    MESSAGE(STATUS "OpenSSL headers found at ${OPENSSL_INCLUDE_DIR}")
+    MESSAGE(STATUS "OpenSSL library found at ${OPENSSL_LIB}")
+    MESSAGE(STATUS "OpenSSL Crypto library found at ${OPENSSLCRYPTO_LIB}")
 
     INCLUDE_DIRECTORIES(
         ${OPENSSL_INCLUDE_DIR}
@@ -105,4 +108,3 @@ SET(OPENSSL_LIB_SEARCH_PATH "" CACHE PATH "Directory containing OpenSSL librarie
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib)
 ENDIF()
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,15 +1,15 @@
 #*******************************************************************************
 #  Copyright (c) 2015 logi.cals GmbH
-# 
+#
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
-#  and Eclipse Distribution License v1.0 which accompany this distribution. 
-# 
-#  The Eclipse Public License is available at 
+#  and Eclipse Distribution License v1.0 which accompany this distribution.
+#
+#  The Eclipse Public License is available at
 #     http://www.eclipse.org/legal/epl-v10.html
-#  and the Eclipse Distribution License is available at 
+#  and the Eclipse Distribution License is available at
 #    http://www.eclipse.org/org/documents/edl-v10.php.
-# 
+#
 #  Contributors:
 #     Rainer Poisel - initial version
 #*******************************************************************************/
@@ -56,7 +56,7 @@ ENDIF()
 ADD_EXECUTABLE(MQTTVersion MQTTVersion.c)
 ADD_LIBRARY(paho-mqtt3c SHARED ${common_src} MQTTClient.c)
 ADD_LIBRARY(paho-mqtt3a SHARED ${common_src} MQTTAsync.c)
-TARGET_LINK_LIBRARIES(paho-mqtt3c pthread ${LIBS_SYSTEM}) 
+TARGET_LINK_LIBRARIES(paho-mqtt3c pthread ${LIBS_SYSTEM})
 TARGET_LINK_LIBRARIES(paho-mqtt3a pthread ${LIBS_SYSTEM})
 TARGET_LINK_LIBRARIES(MQTTVersion paho-mqtt3a paho-mqtt3c ${LIBS_SYSTEM})
 SET_TARGET_PROPERTIES(
@@ -70,19 +70,30 @@ INSTALL(FILES MQTTAsync.h MQTTClient.h MQTTClientPersistence.h
     DESTINATION include)
 
 IF (PAHO_WITH_SSL)
-    SET(OPENSSL_LIB_SEARCH_PATH "" CACHE PATH "Directory containing OpenSSL libraries")
+SET(OPENSSL_LIB_SEARCH_PATH "" CACHE PATH "Directory containing OpenSSL libraries")
     SET(OPENSSL_INC_SEARCH_PATH "" CACHE PATH "Directory containing OpenSSL includes")
     SET(OPENSSL_LIBRARIES ssl crypto)
-    LINK_DIRECTORIES(
-        ${OPENSSL_LIB_SEARCH_PATH}
-        )
+
+    find_path(OPENSSL_INCLUDE_DIR openssl/ssl.h
+	HINTS ${OPENSSL_INC_SEARCH_PATH}/include)
+    find_library(OPENSSL_LIB NAMES ssl libssl
+	HINTS ${OPENSSL_DIR}/lib ${OPENSSL_DIR}/lib64)
+    find_library(OPENSSLCRYPTO_LIB NAMES ssl libssl
+	HINTS ${OPENSSL_DIR}/lib ${OPENSSL_DIR}/lib64)
+
+    message(STATUS "OpenSSL hint ${PENSSL_INC_SEARCH_PATH} (includes) / ")
+    message(STATUS "OpenSSL headers found at ${OPENSSL_INCLUDE_DIR}")
+    message(STATUS "OpenSSL library found at ${OPENSSL_LIB}")
+    message(STATUS "OpenSSL Crypto library found at ${OPENSSLCRYPTO_LIB}")
+
     INCLUDE_DIRECTORIES(
-        ${OPENSSL_INC_SEARCH_PATH}
-        )
+        ${OPENSSL_INCLUDE_DIR}
+    )
     ADD_LIBRARY(paho-mqtt3cs SHARED ${common_src} MQTTClient.c SSLSocket.c)
     ADD_LIBRARY(paho-mqtt3as SHARED ${common_src} MQTTAsync.c SSLSocket.c)
-    TARGET_LINK_LIBRARIES(paho-mqtt3cs pthread ${OPENSSL_LIBRARIES} ${LIBS_SYSTEM})
-    TARGET_LINK_LIBRARIES(paho-mqtt3as pthread ${OPENSSL_LIBRARIES} ${LIBS_SYSTEM})
+
+    TARGET_LINK_LIBRARIES(paho-mqtt3cs pthread ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB} ${LIBS_SYSTEM})
+    TARGET_LINK_LIBRARIES(paho-mqtt3as pthread ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB} ${LIBS_SYSTEM})
     SET_TARGET_PROPERTIES(
         paho-mqtt3cs paho-mqtt3as PROPERTIES
         VERSION ${CLIENT_VERSION}


### PR DESCRIPTION
This is a proposed fix for the compilation issue on newer versions of OS X. This has made the compilation fail on OS X - thus causing the build errors seem on Travis CI. The patch modifies the build so that it uses OpenSSL files provided by Brew. It also switches to FIND_PATH/FIND_LIBRARY functions provided by cmake. 

A sample build result is available here: https://travis-ci.org/orpiske/paho.mqtt.c/builds/192594544.