### PR TITLE
Add random jitter to exponential backoff time in MQTTAsync client

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -2223,7 +2223,15 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 	m->connect.onSuccess = options->onSuccess;
 	m->connect.onFailure = options->onFailure;
 	m->connect.context = options->context;
-	m->connectTimeoutMs = options->connectTimeout * 1000;
+	// If connect timeout > 1000, assume it's in milliseconds
+	if (options->connectTimeout >= 1000)
+	{
+		m->connectTimeoutMs = options->connectTimeout;
+	}
+	else
+	{
+		m->connectTimeoutMs = options->connectTimeout * 1000;
+	}
 	
 	tostop = 0;
 	if (sendThread_state != STARTING && sendThread_state != RUNNING)

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -311,16 +311,16 @@ typedef struct MQTTAsync_struct
 	MQTTAsync_createOptions* createOptions;
 	int shouldBeConnected;
 
-	/* added for automatic reconnect */
+	/* added for automatic reconnect, intervals are in milliseconds */
 	int automaticReconnect;
-	int minRetryInterval;
-	int maxRetryInterval;
+	int minRetryIntervalMs;
+	int maxRetryIntervalMs;
 	int serverURIcount;
 	char** serverURIs;
-	int connectTimeout;
+	int connectTimeoutMs;
 
-	int currentInterval;
-	int currentIntervalBase;
+	int currentIntervalMs;
+	int currentIntervalBaseMs;
 	START_TIME_TYPE lastConnectionFailedTime;
 	int retrying;
 	int reconnectNow;
@@ -881,21 +881,21 @@ int MQTTAsync_addCommand(MQTTAsync_queuedCommand* command, int command_size)
 	return rc;
 }
 
-
+// Reconnect with exponential backoff (base * 2) after each failed attempt
 void MQTTAsync_startConnectRetry(MQTTAsyncs* m)
 {
 	if (m->automaticReconnect && m->shouldBeConnected)
 	{
 		m->lastConnectionFailedTime = MQTTAsync_start_clock();
 		if (m->retrying) {
-			m->currentIntervalBase = min(m->currentIntervalBase * 2, m->maxRetryInterval);
+			m->currentIntervalBaseMs = min(m->currentIntervalBaseMs * 2, m->maxRetryIntervalMs);
 		}
 		else
 		{
-			m->currentIntervalBase = m->minRetryInterval;
+			m->currentIntervalBaseMs = m->minRetryIntervalMs;
 			m->retrying = 1;
 		}
-		m->currentInterval = MQTTAsync_randomJitter(m->currentIntervalBase, m->minRetryInterval, m->maxRetryInterval);
+		m->currentIntervalMs = MQTTAsync_randomJitter(m->currentIntervalBaseMs, m->minRetryIntervalMs, m->maxRetryIntervalMs);
 	}
 }
 
@@ -913,13 +913,13 @@ int MQTTAsync_reconnect(MQTTAsync handle)
 		if (m->shouldBeConnected)
 		{
 			m->reconnectNow = 1;
-	  		if (m->retrying == 0)
+			if (m->retrying == 0)
 	  		{
-	  			m->currentIntervalBase = m->minRetryInterval;
-	  			m->currentInterval = m->minRetryInterval;
-	  			m->retrying = 1;
-	  		}
-	  		rc = MQTTASYNC_SUCCESS;
+				m->currentIntervalBaseMs = m->minRetryIntervalMs;
+				m->currentIntervalMs = m->minRetryIntervalMs;
+				m->retrying = 1;
+			}
+			rc = MQTTASYNC_SUCCESS;
 		}
 	}
 	else
@@ -1368,7 +1368,7 @@ void MQTTAsync_checkTimeouts()
 		MQTTAsyncs* m = (MQTTAsyncs*)(current->content);
 		
 		/* check connect timeout */
-		if (m->c->connect_state != 0 && MQTTAsync_elapsed(m->connect.start_time) > (m->connectTimeout * 1000))
+		if (m->c->connect_state != 0 && MQTTAsync_elapsed(m->connect.start_time) > m->connectTimeoutMs)
 		{
 			if (MQTTAsync_checkConn(&m->connect, m))
 			{
@@ -1429,7 +1429,7 @@ void MQTTAsync_checkTimeouts()
 
 		if (m->automaticReconnect && m->retrying)
 		{
-			if (m->reconnectNow || MQTTAsync_elapsed(m->lastConnectionFailedTime) > (m->currentInterval * 1000))
+			if (m->reconnectNow || MQTTAsync_elapsed(m->lastConnectionFailedTime) > m->currentIntervalMs)
 			{
 				/* to reconnect put the connect command to the head of the command queue */
 				MQTTAsync_queuedCommand* conn = malloc(sizeof(MQTTAsync_queuedCommand));
@@ -1439,7 +1439,7 @@ void MQTTAsync_checkTimeouts()
 	  			/* make sure that the version attempts are restarted */
 				if (m->c->MQTTVersion == MQTTVERSION_DEFAULT) 
 					conn->command.details.conn.MQTTVersion = 0;
-				Log(TRACE_MIN, -1, "Automatically attempting to reconnect");
+				Log(LOG_PROTOCOL, -1, "Automatically attempting to reconnect after %d milliseconds", m->currentIntervalMs);
 				MQTTAsync_addCommand(conn, sizeof(m->connect));
 				m->reconnectNow = 0;
 			}
@@ -2223,7 +2223,7 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 	m->connect.onSuccess = options->onSuccess;
 	m->connect.onFailure = options->onFailure;
 	m->connect.context = options->context;
-	m->connectTimeout = options->connectTimeout;
+	m->connectTimeoutMs = options->connectTimeout * 1000;
 	
 	tostop = 0;
 	if (sendThread_state != STARTING && sendThread_state != RUNNING)
@@ -2251,8 +2251,27 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 	if (options->struct_version >= 4)
 	{
 		m->automaticReconnect = options->automaticReconnect;
-		m->minRetryInterval = options->minRetryInterval;
-		m->maxRetryInterval = options->maxRetryInterval;
+		// Old retry time params were in seconds, but we want to support
+		// millisecond min retry intervals.
+		// To remain backwards compatible, if the param is under 100, we
+		// assume it's in seconds, otherwise, milliseconds.
+		if (options->minRetryInterval < 100)
+		{
+			m->minRetryIntervalMs = options->minRetryInterval * 1000;
+		}
+		else
+		{
+			m->minRetryIntervalMs = options->minRetryInterval;
+		}
+		// Similar for max interval, if it's under 1000, we assume seconds
+		if (options->maxRetryInterval < 1000)
+		{
+			m->maxRetryIntervalMs = options->maxRetryInterval * 1000;
+		}
+		else
+		{
+			m->maxRetryIntervalMs = options->maxRetryInterval;
+		}
 	}
 
 	if (m->c->will)
@@ -2312,7 +2331,7 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 	m->c->retryInterval = options->retryInterval;
 	m->shouldBeConnected = 1;
 
-	m->connectTimeout = options->connectTimeout;
+	m->connectTimeoutMs = options->connectTimeout * 1000;
 
 	MQTTAsync_freeServerURIs(m);			
 	if (options->struct_version >= 2 && options->serverURIcount > 0)

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -764,14 +764,24 @@ typedef struct
 	int MQTTVersion;
 	/**
 	  * Reconnect automatically in the case of a connection being lost?
+	  * This retries with exponential backoff starting from the minRetryInterval
+	  * up to the maxRetryInterval, +/- 20% random jitter.
 	  */
 	int automaticReconnect;
 	/**
-	  * Minimum retry interval in seconds.  Doubled on each failed retry.
+	  * Minimum retry interval in milliseconds.  Doubled on each failed retry.
+	  * For backwards compatibility, if the value is under 100,
+	  * it is assumed to be in seconds rather than milliseconds.
+	  * Random jitter is applied to the value with +/- 20%
 	  */
 	int minRetryInterval;
 	/**
-	  * Maximum retry interval in seconds.  The doubling stops here on failed retries.
+	  * Maximum retry interval in milliseconds.  The doubling stops here on failed retries.
+	  * For backwards compatibility, if the value is under 1000,
+	  * it is assumed to be in seconds rather than milliseconds.
+	  * Note: due to random jitter, the actual max time interval could be as much as 20% higher,
+	  * but this will change on each retry.
+	  * e.g. for maxRetryInterval of 60 seconds, the actual wait time could be anywhere from 48 to 72 seconds
 	  */
 	int maxRetryInterval;
 } MQTTAsync_connectOptions;

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -712,11 +712,13 @@ typedef struct
       */
 	const char* password;
 	/**
-      * The time interval in seconds to allow a connect to complete.
+      * The time interval in milliseconds to allow a connect to complete.
+      * For backwards compatibility and consistency with the retry intervals
+      * this is considered to be seconds if it is under 1000.
       */
 	int connectTimeout;
 	/**
-	 * The time interval in seconds
+	 * The time interval in seconds to retry a message that isn't acked.
 	 */
 	int retryInterval;
 	/** 


### PR DESCRIPTION
This makes exponential backoff times vary by +/- 20% in order to avoid clustered reconnect calls.
The second commit in this allows specifying connect retry intervals in milliseconds because we want to have the minimum interval be able to be less than 1 second.