### PR TITLE
Fix double free at Log_terminate()

### DIFF
--- a/src/Log.c
+++ b/src/Log.c
@@ -221,10 +221,14 @@ void Log_terminate()
 			fclose(trace_destination);
 		trace_destination = NULL;
 	}
-	if (trace_destination_name)
+	if (trace_destination_name) {
 		free(trace_destination_name);
-	if (trace_destination_backup_name)
+		trace_destination_name = NULL;
+	}
+	if (trace_destination_backup_name) {
 		free(trace_destination_backup_name);
+		trace_destination_backup_name = NULL;
+	}
 	start_index = -1;
 	next_index = 0;
 	trace_output_level = -1;


### PR DESCRIPTION
Set to `NULL` the two static char pointers, `trace_destination_name` and `trace_destination_backup_name`. Otherwise, there is a double free if someone tries to release the same memory more than once (calling the Log_terminate() function twice).

```
==5781== Invalid free() / delete / delete[] / realloc()
==5781==    at 0x4C29CF0: free (vg_replace_malloc.c:530)
==5781==    by 0x40DF4C: Log_terminate (Log.c:225)
==5781==  Address 0x5495c20 is 0 bytes inside a block of size 13 free'd
==5781==    at 0x4C29CF0: free (vg_replace_malloc.c:530)
==5781==    by 0x40DF4C: Log_terminate (Log.c:225)
==5781==  Block was alloc'd at
==5781==    at 0x4C28BF6: malloc (vg_replace_malloc.c:299)
==5781==    by 0x40D881: Log_initialize (Log.c:139)
==5781==
==5781== Invalid free() / delete / delete[] / realloc()
==5781==    at 0x4C29CF0: free (vg_replace_malloc.c:530)
==5781==    by 0x40DF79: Log_terminate (Log.c:227)
==5781==  Address 0x5495c70 is 0 bytes inside a block of size 15 free'd
==5781==    at 0x4C29CF0: free (vg_replace_malloc.c:530)
==5781==    by 0x40DF79: Log_terminate (Log.c:227)
==5781==  Block was alloc'd at
==5781==    at 0x4C28BF6: malloc (vg_replace_malloc.c:299)
==5781==    by 0x40D8B6: Log_initialize (Log.c:141)
```
