### PR TITLE
Proposed enhancement: do not override trace settings from environment

### DIFF
--- a/test/test1.c
+++ b/test/test1.c
@@ -1142,7 +1142,7 @@ int main(int argc, char** argv)
 	fprintf(xml, "<testsuite name=\"test1\" tests=\"%d\">\n", (int)(ARRAY_SIZE(tests) - 1));
 
 	setenv("MQTT_C_CLIENT_TRACE", "ON", 1);
-	setenv("MQTT_C_CLIENT_TRACE_LEVEL", "ERROR", 1);
+	setenv("MQTT_C_CLIENT_TRACE_LEVEL", "ERROR", 0);
 
 	getopts(argc, argv);
 

--- a/test/test2.c
+++ b/test/test2.c
@@ -683,7 +683,7 @@ int main(int argc, char** argv)
 	fprintf(xml, "<testsuite name=\"test1\" tests=\"%d\">\n", (int)(ARRAY_SIZE(tests) - 1));
 
 	setenv("MQTT_C_CLIENT_TRACE", "ON", 1);
-	setenv("MQTT_C_CLIENT_TRACE_LEVEL", "ERROR", 1);
+	setenv("MQTT_C_CLIENT_TRACE_LEVEL", "ERROR", 0);
 
 	getopts(argc, argv);
 

--- a/test/test3.c
+++ b/test/test3.c
@@ -1530,7 +1530,7 @@ int main(int argc, char** argv)
 	fprintf(xml, "<testsuite name=\"test3\" tests=\"%d\">\n", (int)(ARRAY_SIZE(tests) - 1));
     
 	setenv("MQTT_C_CLIENT_TRACE", "ON", 1);
-	setenv("MQTT_C_CLIENT_TRACE_LEVEL", "ERROR", 1);
+	setenv("MQTT_C_CLIENT_TRACE_LEVEL", "ERROR", 0);
 	getopts(argc, argv);
  	if (options.test_no == 0)
 	{ /* run all the tests */


### PR DESCRIPTION
This is a very small patch that prevents the test code from overwriting the trace value already set on the environment. This adds a bit more flexibility to (some of) the test cases by allowing the trace level to be set at dynamically.