### PR TITLE
Cmake build dir cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dep/
 /build/
+/build.paho/
 *.swp

--- a/build/run_test2am
+++ b/build/run_test2am
@@ -1,1 +1,0 @@
-LD_LIBRARY_PATH=. ./test3 --test_no 3 --hostname localhost --server_key /home/icraggs/nobackup/mosquitto-1.2/pkeys/test-root-ca.crt --client_key /home/icraggs/nobackup/mosquitto-1.2/pkeys/client.pem 

--- a/build/run_test2as
+++ b/build/run_test2as
@@ -1,1 +1,0 @@
-LD_LIBRARY_PATH=. ./test3 --test_no 2 --connection ssl://localhost:8883 --server_key /home/icraggs/nobackup/mosquitto-1.2/pkeys/server.pem --client_key /home/icraggs/nobackup/mosquitto-1.2/pkeys/client.pem 

--- a/build/run_test3s
+++ b/build/run_test3s
@@ -1,1 +1,0 @@
-LD_LIBRARY_PATH=. ./test3 --test_no 7 --connection ssl://localhost:8885 --server_key /home/icraggs/nobackup/mosquitto-1.2/pkeys/server.pem


### PR DESCRIPTION
Ian, these are two very small changes I would like to propose: 
1. Removes specific test scripts from the build directory, since they are now being managed by cmake itself. 
2. Add the build.paho directory to the gitignore, to prevent it from being incorrectly added to the project.