### PR TITLE
Extend the willOptions initializer to include the new binary payload fields

### DIFF
--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -595,7 +595,7 @@ typedef struct
 	} payload;
 } MQTTAsync_willOptions;
 
-#define MQTTAsync_willOptions_initializer { {'M', 'Q', 'T', 'W'}, 1, NULL, NULL, 0, 0 }
+#define MQTTAsync_willOptions_initializer { {'M', 'Q', 'T', 'W'}, 1, NULL, NULL, 0, 0, { 0, NULL } }
 
 /**
 * MQTTAsync_sslProperties defines the settings to establish an SSL/TLS connection using the 


### PR DESCRIPTION
The MQTTAsync_willOptions was recently extended with binary payload fields, but the initializer was not extended to zero them out.