### PR TITLE
Compile static ssl libraries with OPENSSL=1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -161,6 +161,11 @@ IF (PAHO_WITH_SSL)
 
         TARGET_LINK_LIBRARIES(paho-mqtt3cs-static ${OPENSSL_LIBRARIES} ${LIBS_SYSTEM})
         TARGET_LINK_LIBRARIES(paho-mqtt3as-static ${OPENSSL_LIBRARIES} ${LIBS_SYSTEM})
+        SET_TARGET_PROPERTIES(
+        paho-mqtt3cs-static paho-mqtt3as-static PROPERTIES
+        VERSION ${CLIENT_VERSION}
+        SOVERSION ${PAHO_VERSION_MAJOR}
+        COMPILE_DEFINITIONS "OPENSSL=1")
 
         INSTALL(TARGETS paho-mqtt3cs-static
             ARCHIVE DESTINATION lib


### PR DESCRIPTION
Explicitly enable OPENSSL=1 for the static ssl enabled libraries.
Otherwise a linker error is generated when using the libraries.

Fixes #257 

Signed-off-by: Marcus Hoffmann <m.hoffmann@cartelsol.com>