### PR TITLE
Updates the RPM packaging makefile

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -2,7 +2,7 @@ VERSION=1.1.0
 
 rpm-prep:
 	mkdir -p ${HOME}/rpmbuild/SOURCES/
-	tar --transform="s/\./paho-c-${VERSION}/" -cf ${HOME}/rpmbuild/SOURCES/paho-c-${VERSION}.tar.gz --exclude=./build --exclude=.git --exclude=*.bz ./ --gzip
+	tar --transform="s/\./paho-c-${VERSION}/" -cf ${HOME}/rpmbuild/SOURCES/paho-c-${VERSION}.tar.gz --exclude=./build.paho --exclude=.git --exclude=*.bz ./ --gzip
 
 rpm: rpm-prep
 	rpmbuild -ba dist/paho-c.spec


### PR DESCRIPTION
Replaces the build directory with the build.paho directory in the RPM
source tarball creation, otherwise the tarball may contain locally
generated files and fail to properly build the RPM package.

Signed-off-by: Otavio Rodolfo Piske <opiske@redhat.com>