### PR TITLE
Readme: properly document OPENSSL_SEARCH_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ Variable | Default Value | Description
 ------------ | ------------- | -------------
 PAHO_BUILD_STATIC | FALSE | Build a static version of the libraries
 PAHO_WITH_SSL | FALSE | Flag that defines whether to build ssl-enabled binaries too. 
-OPENSSL_INC_SEARCH_PATH | "" (system default) | Directory containing OpenSSL includes
-OPENSSL_LIB_SEARCH_PATH | "" (system default) | Directory containing OpenSSL libraries
+OPENSSL_SEARCH_PATH | "" (system default) | Directory containing your OpenSSL installation (i.e. `/usr/local` when headers are in `/usr/local/include` and libraries are in `/usr/local/lib`)
 PAHO_BUILD_DOCUMENTATION | FALSE | Create and install the HTML based API documentation (requires Doxygen)
 PAHO_BUILD_SAMPLES | FALSE | Build sample programs
 MQTT_TEST_BROKER | tcp://localhost:1883 | MQTT connection URL for a broker to use during test execution


### PR DESCRIPTION
Since 28a3114ce97a5e the documentation regarding openssl search paths we pass
to cmake is out of date.

Properly document the current behaviour.

*Note:* Please consider merging this into master asap because that is the most visible build documentation and it's wrong there too.