### PR TITLE
Fix `serverURIs` iterating in MQTTAsync.c

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -373,11 +373,29 @@ ADD_TEST(
 	COMMAND test8 "--test_no" "4" "--connection" ${MQTT_TEST_BROKER} "--size" "500000"
 )
 
+ADD_TEST(
+	NAME test8-5a-all-ha-connections-out-of-service
+	COMMAND test8 "--test_no" "5" "--connection" ${MQTT_TEST_BROKER}
+)
+
+ADD_TEST(
+	NAME test8-5b-all-ha-connections-out-of-service-except-the-last-one
+	COMMAND test8 "--test_no" "6" "--connection" ${MQTT_TEST_BROKER}
+)
+
+ADD_TEST(
+	NAME test8-5c-all-ha-connections-out-of-service-except-the-first-one
+	COMMAND test8 "--test_no" "7" "--connection" ${MQTT_TEST_BROKER}
+)
+
 SET_TESTS_PROPERTIES(
 	test8-1-basic-connect-subscribe-receive
 	test8-2-connect-timeout
 	test8-3-multiple-client-objects-simultaneous-working
 	test8-4-send-receive-big-messages
+        test8-5a-all-ha-connections-out-of-service
+        test8-5b-all-ha-connections-out-of-service-except-the-last-one
+        test8-5c-all-ha-connections-out-of-service-except-the-first-one
 	PROPERTIES TIMEOUT 540
 )
 


### PR DESCRIPTION
This commit fixes two bugs related to `serverURIs` iterating in MQTTAsync.c

1. Segfault occurs when there is no healthy connection in `serverURIs`

   Two off-by-one errors of the `currentURI` cause the issue. The first
   one happens when doing boundary check of `serverURIs`, and the other
   one happens when accessing `serverURIs` without checking the boundary
   first.

2. The first URI in `serverURIs` gets skipped when restricting
   `MQTTVersion` to a particular value

   `currentURI` gets increased *before* connection attempts in each
   iteration.

Signed-off-by: Lance Chen <cyen0312@gmail.com>