### PR TITLE
Bumps RPM version to 1.2.0 for release packaging

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.1.0
+VERSION=1.2.0
 
 rpm-prep:
 	mkdir -p ${HOME}/rpmbuild/SOURCES/

--- a/dist/paho-c.spec
+++ b/dist/paho-c.spec
@@ -3,8 +3,8 @@
 
 Summary:            MQTT C Client
 Name:               paho-c
-Version:            1.1.0
-Release:            1%{?dist}
+Version:            1.2.0
+Release:            0%{?dist}
 License:            Eclipse Distribution License 1.0 and Eclipse Public License 1.0
 Group:              Development/Tools
 Source:             paho-c-%{version}.tar.gz


### PR DESCRIPTION
Adjust the RPM spec and related Makefile for the upcoming release.

The update RPMs generated successfully on Fedora's COPR infrastructure: https://copr.fedorainfracloud.org/coprs/orpiske/paho-testing/build/573191/

Signed-off-by: Otavio R. Piske <opiske@redhat.com>