### PR TITLE
Support for VxWorks 6.9

### DIFF
--- a/src/Heap.c
+++ b/src/Heap.c
@@ -35,7 +35,6 @@
 char* Broker_recordFFDC(char* symptoms);
 #endif /* HEAP_UNIT_TESTS */
 
-#include <memory.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -228,7 +227,7 @@ static int Internal_heap_unlink(char* file, int line, void* p)
 		Log(TRACE_MAX, -1, "Freeing %d bytes in heap at file %s line %d, heap use now %d bytes\n",
 											 s->size, file, line, state.current_size);
 		checkEyecatchers(file, line, p, s->size);
-		//free(s->ptr);
+		/* free(s->ptr); */
 		free(s->file);
 		state.current_size -= s->size;
 		TreeRemoveNodeIndex(&heap, e, 0);

--- a/src/Heap.h
+++ b/src/Heap.h
@@ -24,7 +24,6 @@
 #endif
 
 #include <stdio.h>
-#include <memory.h>
 #include <stdlib.h>
 
 #if !defined(NO_HEAP_TRACKING)

--- a/src/LinkedList.c
+++ b/src/LinkedList.c
@@ -28,7 +28,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <memory.h>
 
 #include "Heap.h"
 
@@ -474,7 +473,7 @@ int main(int argc, char *argv[])
 	while (ListPrevElement(l, &current) != NULL)
 		printf("List element: %d\n", *((int*)(current->content)));
 
-	//if ListFindItem(l, *ip, intcompare)->content
+	/* if ListFindItem(l, *ip, intcompare)->content */
 
 	printf("List contents having deleted element %d:\n", *todelete);
 	ListRemove(l, todelete);

--- a/src/LinkedList.h
+++ b/src/LinkedList.h
@@ -19,7 +19,7 @@
 #if !defined(LINKEDLIST_H)
 #define LINKEDLIST_H
 
-#include <stdlib.h> // for size_t definition
+#include <stdlib.h> /* for size_t definition */
 
 /*BE
 defm defList(T)

--- a/src/Log.c
+++ b/src/Log.c
@@ -301,7 +301,7 @@ static char* Log_formatTraceEntry(traceEntry* cur_entry)
 	int buf_pos = 31;
 
 #if defined(GETTIMEOFDAY)
-	timeinfo = localtime(&cur_entry->ts.tv_sec);
+	timeinfo = localtime((time_t *)&cur_entry->ts.tv_sec);
 #else
 	timeinfo = localtime(&cur_entry->ts.time);
 #endif

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -43,6 +43,7 @@
 
 #define _GNU_SOURCE /* for pthread_mutexattr_settype */
 #include <stdlib.h>
+#include <string.h>
 #if !defined(WIN32) && !defined(WIN64)
 	#include <sys/time.h>
 #endif
@@ -58,6 +59,7 @@
 #include "SocketBuffer.h"
 #include "StackTrace.h"
 #include "Heap.h"
+#include "OsWrapper.h"
 
 #define URI_TCP "tcp://"
 
@@ -156,7 +158,11 @@ void MQTTAsync_init(void)
 	int rc;
 
 	pthread_mutexattr_init(&attr);
+#if !defined(_WRS_KERNEL)
 	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+#else
+	/* #warning "no pthread_mutexattr_settype" */
+#endif
 	if ((rc = pthread_mutex_init(mqttasync_mutex, &attr)) != 0)
 		printf("MQTTAsync: error %d initializing async_mutex\n", rc);
 	if ((rc = pthread_mutex_init(mqttcommand_mutex, &attr)) != 0)

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -82,7 +82,9 @@
  */
 
 
+/*
 /// @cond EXCLUDE
+*/
 #if defined(__cplusplus)
  extern "C" {
 #endif
@@ -99,7 +101,9 @@
 #endif
 
 #include <stdio.h>
+/*
 /// @endcond
+*/
 
 #if !defined(NO_PERSISTENCE)
 #include "MQTTClientPersistence.h"

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -42,6 +42,7 @@
 
 #define _GNU_SOURCE /* for pthread_mutexattr_settype */
 #include <stdlib.h>
+#include <string.h>
 #if !defined(WIN32) && !defined(WIN64)
 	#include <sys/time.h>
 #endif
@@ -64,6 +65,8 @@
 #else
 #define URI_SSL "ssl://"
 #endif
+
+#include "OsWrapper.h"
 
 #define URI_TCP "tcp://"
 
@@ -149,7 +152,11 @@ void MQTTClient_init(void)
 	int rc;
 
 	pthread_mutexattr_init(&attr);
+#if !defined(_WRS_KERNEL)
 	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+#else
+	/* #warning "no pthread_mutexattr_settype" */
+#endif /* !defined(_WRS_KERNEL) */
 	if ((rc = pthread_mutex_init(mqttclient_mutex, &attr)) != 0)
 		printf("MQTTClient: error %d initializing client_mutex\n", rc);
 	if ((rc = pthread_mutex_init(socket_mutex, &attr)) != 0)

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -100,7 +100,9 @@
  * @endcond
  */
 
+/*
 /// @cond EXCLUDE
+*/
 #if defined(__cplusplus)
  extern "C" {
 #endif
@@ -116,7 +118,9 @@
 #endif
 
 #include <stdio.h>
+/*
 /// @endcond
+*/
 
 #if !defined(NO_PERSISTENCE)
 #include "MQTTClientPersistence.h"

--- a/src/MQTTClientPersistence.h
+++ b/src/MQTTClientPersistence.h
@@ -53,10 +53,14 @@
  * may be required to diagnose a persistence mechanism failure.
  */
 
+/*
 /// @cond EXCLUDE
+*/
 #if !defined(MQTTCLIENTPERSISTENCE_H)
 #define MQTTCLIENTPERSISTENCE_H
+/*
 /// @endcond
+*/
 
 /**
   * This <i>persistence_type</i> value specifies the default file system-based 

--- a/src/MQTTPacketOut.c
+++ b/src/MQTTPacketOut.c
@@ -178,7 +178,7 @@ int MQTTPacket_send_subscribe(List* topics, List* qoss, int msgid, int dup, netw
 	header.bits.qos = 1;
 	header.bits.retain = 0;
 
-	datalen = 2 + topics->count * 3; // utf length + char qos == 3
+	datalen = 2 + topics->count * 3; /* utf length + char qos == 3 */
 	while (ListNextElement(topics, &elem))
 		datalen += (int)strlen((char*)(elem->content));
 	ptr = data = malloc(datalen);
@@ -251,7 +251,7 @@ int MQTTPacket_send_unsubscribe(List* topics, int msgid, int dup, networkHandles
 	header.bits.qos = 1;
 	header.bits.retain = 0;
 
-	datalen = 2 + topics->count * 2; // utf length == 2
+	datalen = 2 + topics->count * 2; /* utf length == 2 */
 	while (ListNextElement(topics, &elem))
 		datalen += (int)strlen((char*)(elem->content));
 	ptr = data = malloc(datalen);

--- a/src/MQTTPersistence.c
+++ b/src/MQTTPersistence.c
@@ -367,7 +367,7 @@ int MQTTPersistence_put(int socket, char* buf0, size_t buf0len, int count,
 			bufs[i+1] = buffers[i];
 		}
 
-		// key
+		/* key */
 		if ( scr == 0 )
 		{  /* sending */
 			if (htype == PUBLISH)   /* PUBLISH QoS1 and QoS2*/

--- a/src/MQTTPersistenceDefault.c
+++ b/src/MQTTPersistenceDefault.c
@@ -29,6 +29,8 @@
 
 #if !defined(NO_PERSISTENCE)
 
+#include "OsWrapper.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
@@ -53,7 +55,6 @@
 #include "MQTTPersistenceDefault.h"
 #include "StackTrace.h"
 #include "Heap.h"
-
 
 /** Create persistence directory for the client: context/clientID-serverURI.
  *  See ::Persistence_open
@@ -128,7 +129,11 @@ int pstmkdir( char *pPathname )
 	{
 #else
 	/* Create a directory with read, write and execute access for the owner and read access for the group */
+#if !defined(_WRS_KERNEL)
 	if ( mkdir( pPathname, S_IRWXU | S_IRGRP ) != 0 )
+#else
+	if ( mkdir( pPathname ) != 0 )
+#endif /* !defined(_WRS_KERNEL) */
 	{
 #endif
 		if ( errno != EEXIST )
@@ -739,7 +744,7 @@ int main (int argc, char *argv[])
 		buflens[i]=strlen(bufs[i]);
 
 	/* open */
-	//printf("Persistence directory : %s\n", perdir);
+	/* printf("Persistence directory : %s\n", perdir); */
 	rc = pstopen((void**)&handle, clientID, serverURI, perdir);
 	printf("%s Persistence directory for client %s : %s\n", RC, clientID, handle);
 

--- a/src/MQTTProtocolClient.c
+++ b/src/MQTTProtocolClient.c
@@ -28,6 +28,7 @@
 
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "MQTTProtocolClient.h"
 #if !defined(NO_PERSISTENCE)

--- a/src/MQTTProtocolOut.c
+++ b/src/MQTTProtocolOut.c
@@ -30,6 +30,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "MQTTProtocolOut.h"
 #include "StackTrace.h"

--- a/src/MQTTVersion.c
+++ b/src/MQTTVersion.c
@@ -15,12 +15,14 @@
  *******************************************************************************/
 
 #include <stdio.h>
+
+#if !defined(_WRS_KERNEL)
+
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/types.h>
-#include <memory.h>
 #include <ctype.h>
 #include "MQTTAsync.h"
 
@@ -219,3 +221,10 @@ int main(int argc, char** argv)
 
 	return 0;
 }
+#else
+int main(void)
+{
+    fprintf(stderr, "This tool is not supported on this platform yet.\n");
+    return 1;
+}
+#endif /* !defined(_WRS_KERNEL) */

--- a/src/Messages.c
+++ b/src/Messages.c
@@ -26,7 +26,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <memory.h>
 #include <string.h>
 
 #include "Heap.h"

--- a/src/OsWrapper.c
+++ b/src/OsWrapper.c
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 logi.cals GmbH
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Gunter Raidl - timer support for VxWorks
+ *    Rainer Poisel - reusability
+ *******************************************************************************/
+
+#include "OsWrapper.h"
+
+#if defined(_WRS_KERNEL)
+void usleep(useconds_t useconds)
+{
+	struct timespec tv;
+	tv.tv_sec = useconds / 1000000;
+	tv.tv_nsec = (useconds % 1000000) * 1000;
+	nanosleep(&tv, NULL);
+}
+#endif /* defined(_WRS_KERNEL) */

--- a/src/OsWrapper.h
+++ b/src/OsWrapper.h
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 logi.cals GmbH
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Gunter Raidl - timer support for VxWorks
+ *    Rainer Poisel - reusability
+ *******************************************************************************/
+
+#if !defined(OSWRAPPER_H)
+#define OSWRAPPER_H
+
+#if defined(_WRS_KERNEL)
+#include <time.h>
+
+#define lstat stat
+
+typedef unsigned long useconds_t;
+void usleep(useconds_t useconds);
+
+#define timersub(a, b, result) \
+	do \
+	{ \
+		(result)->tv_sec = (a)->tv_sec - (b)->tv_sec; \
+		(result)->tv_usec = (a)->tv_usec - (b)->tv_usec; \
+		if ((result)->tv_usec < 0) \
+		{ \
+			--(result)->tv_sec; \
+			(result)->tv_usec += 1000000L; \
+		} \
+	} while (0)
+#endif /* defined(_WRS_KERNEL) */
+
+#endif /* OSWRAPPER_H */

--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -68,7 +68,7 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts);
 void SSLSocket_destroyContext(networkHandles* net);
 void SSLSocket_addPendingRead(int sock);
 
-/// 1 ~ we are responsible for initializing openssl; 0 ~ openssl init is done externally 
+/* 1 ~ we are responsible for initializing openssl; 0 ~ openssl init is done externally */
 static int handle_openssl_init = 1;
 static ssl_mutex_type* sslLocks = NULL;
 static ssl_mutex_type sslCoreMutex;

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -36,6 +36,7 @@
 #include "SSLSocket.h"
 #endif
 
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <signal.h>
@@ -98,10 +99,6 @@ int Socket_setnonblocking(int sock)
  */
 int Socket_error(char* aString, int sock)
 {
-#if defined(WIN32) || defined(WIN64)
-	int errno;
-#endif
-
 	FUNC_ENTRY;
 #if defined(WIN32) || defined(WIN64)
 	errno = WSAGetLastError();

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -45,9 +45,14 @@
 #else
 #define INVALID_SOCKET SOCKET_ERROR
 #include <sys/socket.h>
+#if !defined(_WRS_KERNEL)
 #include <sys/param.h>
 #include <sys/time.h>
 #include <sys/select.h>
+#include <sys/uio.h>
+#else
+#include <selectLib.h>
+#endif
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
@@ -57,7 +62,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <sys/uio.h>
 #define ULONG size_t
 #endif
 

--- a/src/SocketBuffer.c
+++ b/src/SocketBuffer.c
@@ -30,7 +30,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <memory.h>
+#include <string.h>
 
 #include "Heap.h"
 

--- a/src/Thread.c
+++ b/src/Thread.c
@@ -45,8 +45,9 @@
 #include <sys/stat.h>
 #include <limits.h>
 #endif
-#include <memory.h>
 #include <stdlib.h>
+
+#include "OsWrapper.h"
 
 /**
  * Start a new thread
@@ -190,10 +191,10 @@ sem_type Thread_create_sem(void)
 	FUNC_ENTRY;
 	#if defined(WIN32) || defined(WIN64)
 		sem = CreateEvent(
-		        NULL,               // default security attributes
-		        FALSE,              // manual-reset event?
-		        FALSE,              // initial state is nonsignaled
-		        NULL                // object name
+		        NULL,               /* default security attributes */
+		        FALSE,              /* manual-reset event? */
+		        FALSE,              /* initial state is nonsignaled */
+		        NULL                /* object name */
 		        );
 	#elif defined(OSX)
 		sem = dispatch_semaphore_create(0L);

--- a/src/Tree.c
+++ b/src/Tree.c
@@ -28,7 +28,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <memory.h>
 
 #include "Heap.h"
 
@@ -533,7 +532,7 @@ int TreeIntCompare(void* a, void* b, int content)
 	int i = *((int*)a);
 	int j = *((int*)b);
 
-	//printf("comparing %d %d\n", *((int*)a), *((int*)b));
+	/* printf("comparing %d %d\n", *((int*)a), *((int*)b)); */
 	return (i > j) ? -1 : (i == j) ? 0 : 1;
 }
 
@@ -581,14 +580,14 @@ int traverse(Tree *t, int lookfor)
 
 	printf("Traversing\n");
 	curnode = TreeNextElement(t, curnode);
-	//printf("content int %d\n", *(int*)(curnode->content));
+	/* printf("content int %d\n", *(int*)(curnode->content)); */
 	while (curnode)
 	{
 		Node* prevnode = curnode;
 
 		curnode = TreeNextElement(t, curnode);
-		//if (curnode)
-		//	printf("content int %d\n", *(int*)(curnode->content));
+		/* if (curnode)
+			printf("content int %d\n", *(int*)(curnode->content)); */
 		if (prevnode && curnode && (*(int*)(curnode->content) < *(int*)(prevnode->content)))
 		{
 			printf("out of order %d < %d\n", *(int*)(curnode->content), *(int*)(prevnode->content));

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -18,7 +18,7 @@
 #if !defined(TREE_H)
 #define TREE_H
 
-#include <stdlib.h> // for size_t definition
+#include <stdlib.h> /* for size_t definition */
 
 /*BE
 defm defTree(T) // macro to define a tree

--- a/src/samples/MQTTAsync_publish.c
+++ b/src/samples/MQTTAsync_publish.c
@@ -25,6 +25,8 @@
 #include <windows.h>
 #endif
 
+#include <OsWrapper.h>
+
 #define ADDRESS     "tcp://m2m.eclipse.org:1883"
 #define CLIENTID    "ExampleClientPub"
 #define TOPIC       "MQTT Examples"
@@ -119,8 +121,6 @@ int main(int argc, char* argv[])
 {
 	MQTTAsync client;
 	MQTTAsync_connectOptions conn_opts = MQTTAsync_connectOptions_initializer;
-	MQTTAsync_message pubmsg = MQTTAsync_message_initializer;
-	MQTTAsync_token token;
 	int rc;
 
 	MQTTAsync_create(&client, ADDRESS, CLIENTID, MQTTCLIENT_PERSISTENCE_NONE, NULL);

--- a/src/samples/MQTTAsync_subscribe.c
+++ b/src/samples/MQTTAsync_subscribe.c
@@ -25,6 +25,8 @@
 #include <windows.h>
 #endif
 
+#include <OsWrapper.h>
+
 #define ADDRESS     "tcp://localhost:1883"
 #define CLIENTID    "ExampleClientSub"
 #define TOPIC       "MQTT Examples"
@@ -111,7 +113,6 @@ void onConnect(void* context, MQTTAsync_successData* response)
 {
 	MQTTAsync client = (MQTTAsync)context;
 	MQTTAsync_responseOptions opts = MQTTAsync_responseOptions_initializer;
-	MQTTAsync_message pubmsg = MQTTAsync_message_initializer;
 	int rc;
 
 	printf("Successful connection\n");
@@ -137,8 +138,6 @@ int main(int argc, char* argv[])
 	MQTTAsync client;
 	MQTTAsync_connectOptions conn_opts = MQTTAsync_connectOptions_initializer;
 	MQTTAsync_disconnectOptions disc_opts = MQTTAsync_disconnectOptions_initializer;
-	MQTTAsync_message pubmsg = MQTTAsync_message_initializer;
-	MQTTAsync_token token;
 	int rc;
 	int ch;
 

--- a/src/samples/paho_c_pub.c
+++ b/src/samples/paho_c_pub.c
@@ -41,10 +41,11 @@
 
 #include <stdio.h>
 #include <signal.h>
-#include <memory.h>
+#include <string.h>
 #include <stdlib.h>
 
 #if defined(WIN32)
+#include <windows.h>
 #define sleep Sleep
 #else
 #include <unistd.h>
@@ -52,6 +53,7 @@
 #include <unistd.h>
 #endif
 
+#include <OsWrapper.h>
 
 volatile int toStop = 0;
 
@@ -132,8 +134,6 @@ void onConnectFailure(void* context, MQTTAsync_failureData* response)
 
 void onConnect(void* context, MQTTAsync_successData* response)
 {
-	MQTTAsync client = (MQTTAsync)context;
-
 	printf("Connected\n");
 	connected = 1;
 }
@@ -175,8 +175,6 @@ void onPublishFailure(void* context, MQTTAsync_failureData* response)
 
 void onPublish(void* context, MQTTAsync_successData* response)
 {
-	MQTTAsync client = (MQTTAsync)context;
-
 	published = 1;
 }
 
@@ -253,7 +251,7 @@ int main(int argc, char** argv)
 			buffer[data_len++] = getchar();
 			if (data_len > delim_len)
 			{
-			//printf("comparing %s %s\n", opts.delimiter, &buffer[data_len - delim_len]);
+			/* printf("comparing %s %s\n", opts.delimiter, &buffer[data_len - delim_len]); */
 			if (strncmp(opts.delimiter, &buffer[data_len - delim_len], delim_len) == 0)
 				break;
 			}

--- a/src/samples/paho_c_sub.c
+++ b/src/samples/paho_c_sub.c
@@ -44,17 +44,19 @@
 
 #include <stdio.h>
 #include <signal.h>
-#include <memory.h>
+#include <string.h>
 #include <stdlib.h>
 
 
 #if defined(WIN32)
+#include <windows.h>
 #define sleep Sleep
 #else
 #include <sys/time.h>
 #include <unistd.h>
 #endif
 
+#include <OsWrapper.h>
 
 volatile int finished = 0;
 char* topic = NULL;
@@ -246,7 +248,6 @@ void onConnect(void* context, MQTTAsync_successData* response)
 {
 	MQTTAsync client = (MQTTAsync)context;
 	MQTTAsync_responseOptions ropts = MQTTAsync_responseOptions_initializer;
-	MQTTAsync_message pubmsg = MQTTAsync_message_initializer;
 	int rc;
 
 	if (opts.showtopics)

--- a/src/samples/paho_cs_pub.c
+++ b/src/samples/paho_cs_pub.c
@@ -40,7 +40,7 @@
 
 #include <stdio.h>
 #include <signal.h>
-#include <memory.h>
+#include <string.h>
 #include <stdlib.h>
 
 #if defined(WIN32)
@@ -166,7 +166,7 @@ int main(int argc, char** argv)
 			buffer[data_len++] = getchar();
 			if (data_len > delim_len)
 			{
-			//printf("comparing %s %s\n", opts.delimiter, &buffer[data_len - delim_len]);
+			/* printf("comparing %s %s\n", opts.delimiter, &buffer[data_len - delim_len]); */
 			if (strncmp(opts.delimiter, &buffer[data_len - delim_len], delim_len) == 0)
 				break;
 			}

--- a/src/samples/paho_cs_sub.c
+++ b/src/samples/paho_cs_sub.c
@@ -43,7 +43,7 @@
 
 #include <stdio.h>
 #include <signal.h>
-#include <memory.h>
+#include <string.h>
 #include <stdlib.h>
 
 

--- a/test/MQTTTest_v2.c
+++ b/test/MQTTTest_v2.c
@@ -34,7 +34,7 @@
  */
 
 
-#include <memory.h>
+#include <string.h>
 #include <MQTTAsync.h>
 #include <MQTTClientPersistence.h>
 #include <signal.h>
@@ -42,7 +42,7 @@
 #include <sys/time.h>
 
 #if defined(WIN32)
-#include <Windows.h>
+#include <windows.h>
 #define sleep Sleep
 #else
 #include <stdlib.h>


### PR DESCRIPTION
These are the modifications we did to make Paho working on VxWorks 6.9. Actually, I'd prefer to create an operating system layer without all these #if and #else directives, but this would be a much more fundamental commit.

All in all, modifications where not severe. C++ comments were modified to ANSI-C style comments and a few operating system functions had to be replaced or customized.