### PR TITLE
CMakeList.txt: drop redundant lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,16 +44,6 @@ IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
   ENDIF()
 ENDIF()
 
-# Uses the correct directory for libraries on Red Hat-based distributions.
-SET(PAHO_LIBRARY_DIR_NAME "lib")
-IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
-  IF(EXISTS "/etc/redhat-release")
-    IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    	SET(PAHO_LIBRARY_DIR_NAME "lib64")
-    ENDIF()
-  ENDIF()
-ENDIF()
-
 IF(WIN32)
   ADD_DEFINITIONS(-D_CRT_SECURE_NO_DEPRECATE -DWIN32_LEAN_AND_MEAN -MD)
 ELSEIF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")


### PR DESCRIPTION
The patch "Fix the library directory name for RHEL and Fedora" has been merged twice in f0a5cb2 and d729fc3 resulting in two copies of the same chunk in CMakeList.txt.

This PR drops the second copy.