### PR TITLE
MQTTAsync_global_init exported properly

### DIFF
--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -206,7 +206,7 @@ typedef struct
  * Global init of mqtt library. Call once on program start to set global behaviour.
  * handle_openssl_init - if mqtt library should handle openssl init (1) or rely on the caller to init it before using mqtt (0)
  */
-void MQTTAsync_global_init(MQTTAsync_init_options* inits);
+DLLExport void MQTTAsync_global_init(MQTTAsync_init_options* inits);
 
 /**
  * A handle representing an MQTT client. A valid client handle is available


### PR DESCRIPTION
The function for telling paho to/not to initialise OpenSSL is included in the header (MQTTAsync.h) but not exported from the shared library. This means it can be compiled fine but will run into an undefined symbol error (or similar) at runtime

Signed-off-by: Callum Attryde