### PR TITLE
Fedora upstream changes

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,5 +1,8 @@
 VERSION=1.2.0
 
+check:
+	rpmlint -i dist/paho-c.spec
+
 rpm-prep:
 	mkdir -p ${HOME}/rpmbuild/SOURCES/
 	tar --transform="s/\./paho-c-${VERSION}/" -cf ${HOME}/rpmbuild/SOURCES/v${VERSION}.tar.gz --exclude=./build.paho --exclude=.git --exclude=*.bz ./ --gzip

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -2,7 +2,7 @@ VERSION=1.2.0
 
 rpm-prep:
 	mkdir -p ${HOME}/rpmbuild/SOURCES/
-	tar --transform="s/\./paho-c-${VERSION}/" -cf ${HOME}/rpmbuild/SOURCES/paho-c-${VERSION}.tar.gz --exclude=./build.paho --exclude=.git --exclude=*.bz ./ --gzip
+	tar --transform="s/\./paho-c-${VERSION}/" -cf ${HOME}/rpmbuild/SOURCES/v${VERSION}.tar.gz --exclude=./build.paho --exclude=.git --exclude=*.bz ./ --gzip
 
 rpm: rpm-prep
 	rpmbuild -ba dist/paho-c.spec

--- a/dist/paho-c.spec
+++ b/dist/paho-c.spec
@@ -4,10 +4,10 @@
 Summary:            MQTT C Client
 Name:               paho-c
 Version:            1.2.0
-Release:            0%{?dist}
+Release:            1%{?dist}
 License:            Eclipse Distribution License 1.0 and Eclipse Public License 1.0
 Group:              Development/Tools
-Source:             paho-c-%{version}.tar.gz
+Source:             https://github.com/eclipse/paho.mqtt.c/archive/v%{version}.tar.gz
 URL:                https://eclipse.org/paho/clients/c/
 BuildRequires:      cmake
 BuildRequires:      gcc

--- a/dist/paho-c.spec
+++ b/dist/paho-c.spec
@@ -4,7 +4,7 @@
 Summary:            MQTT C Client
 Name:               paho-c
 Version:            1.2.0
-Release:            1%{?dist}
+Release:            2%{?dist}
 License:            Eclipse Distribution License 1.0 and Eclipse Public License 1.0
 Group:              Development/Tools
 Source:             https://github.com/eclipse/paho.mqtt.c/archive/v%{version}.tar.gz
@@ -61,5 +61,15 @@ make install DESTDIR=%{buildroot}
 %{_datadir}/*
 
 %changelog
-* Sat Dec 31 2016 Otavio R. Piske <opiske@redhat.com> - 20161231
+* Wed Jun 26 2017 Otavio R. Piske <opiske@redhat.com> - 1.2.0-2
+- Updated changelog to comply with Fedora packaging guidelines
+
+* Wed Jun 26 2017 Otavio R. Piske <opiske@redhat.com> - 1.2.0-1
+- Fixed rpmlint warnings: replaced cmake call with builtin macro
+- Fixed rpmlint warnings: removed buildroot reference from build section
+
+* Fri Jun 30 2017 Otavio R. Piske <opiske@redhat.com> - 1.2.0-0
+- Updated package to version 1.2.0
+
+* Sat Dec 31 2016 Otavio R. Piske <opiske@redhat.com> - 1.1.0
 - Initial packaging

--- a/dist/paho-c.spec
+++ b/dist/paho-c.spec
@@ -42,12 +42,12 @@ Development documentation files for the the Paho MQTT C Client.
 
 %build
 mkdir build.paho && cd build.paho
-cmake -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=TRUE -DPAHO_BUILD_SAMPLES=TRUE -DCMAKE_INSTALL_PREFIX=%{buildroot}/usr ..
-make
+%cmake -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=TRUE -DPAHO_BUILD_SAMPLES=TRUE ..
+make %{?_smp_mflags}
 
 %install
 cd build.paho
-make install
+make install DESTDIR=%{buildroot}
 
 %files
 %doc edl-v10 epl-v10

--- a/dist/paho-c.spec
+++ b/dist/paho-c.spec
@@ -1,6 +1,3 @@
-%global _enable_debug_package 0
-%global debug_package %{nil}
-
 Summary:            MQTT C Client
 Name:               paho-c
 Version:            1.2.0
@@ -61,6 +58,9 @@ make install DESTDIR=%{buildroot}
 %{_datadir}/*
 
 %changelog
+* Thu Jul 27 2017 Otavio R. Piske <opiske@redhat.com> - 1.2.0-4
+- Enabled generation of debuginfo package
+
 * Thu Jul 27 2017 Otavio R. Piske <opiske@redhat.com> - 1.2.0-3
 - Fixed changelog issues pointed by rpmlint
 

--- a/dist/paho-c.spec
+++ b/dist/paho-c.spec
@@ -4,7 +4,7 @@
 Summary:            MQTT C Client
 Name:               paho-c
 Version:            1.2.0
-Release:            2%{?dist}
+Release:            3%{?dist}
 License:            Eclipse Distribution License 1.0 and Eclipse Public License 1.0
 Group:              Development/Tools
 Source:             https://github.com/eclipse/paho.mqtt.c/archive/v%{version}.tar.gz
@@ -61,14 +61,17 @@ make install DESTDIR=%{buildroot}
 %{_datadir}/*
 
 %changelog
-* Wed Jun 26 2017 Otavio R. Piske <opiske@redhat.com> - 1.2.0-2
+* Thu Jul 27 2017 Otavio R. Piske <opiske@redhat.com> - 1.2.0-3
+- Fixed changelog issues pointed by rpmlint
+
+* Thu Jul 27 2017 Otavio R. Piske <opiske@redhat.com> - 1.2.0-2
 - Updated changelog to comply with Fedora packaging guidelines
 
-* Wed Jun 26 2017 Otavio R. Piske <opiske@redhat.com> - 1.2.0-1
+* Wed Jul 26 2017 Otavio R. Piske <opiske@redhat.com> - 1.2.0-1
 - Fixed rpmlint warnings: replaced cmake call with builtin macro
 - Fixed rpmlint warnings: removed buildroot reference from build section
 
-* Fri Jun 30 2017 Otavio R. Piske <opiske@redhat.com> - 1.2.0-0
+* Fri Jun 30 2017 Otavio R. Piske <opiske@redhat.com> - 1.2.0
 - Updated package to version 1.2.0
 
 * Sat Dec 31 2016 Otavio R. Piske <opiske@redhat.com> - 1.1.0


### PR DESCRIPTION
@icraggs, based on our conversation, I am requesting the Eclipse Paho C project inclusion in the Fedora distribution. I would, kindly, request to leave this PR open until the project is officially included in Fedora, because they may request additional changes on packaging. 