### PR TITLE
Add support for selecting/enforcing a TLS version

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -2221,7 +2221,7 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 	}
 	if (options->struct_version != 0 && options->ssl) /* check validity of SSL options structure */
 	{
-		if (strncmp(options->ssl->struct_id, "MQTS", 4) != 0 || options->ssl->struct_version != 0)
+		if (strncmp(options->ssl->struct_id, "MQTS", 4) != 0 || options->ssl->struct_version < 0 || options->ssl->struct_version > 1)
 		{
 			rc = MQTTASYNC_BAD_STRUCTURE;
 			goto exit;
@@ -2329,6 +2329,7 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 	{
 		m->c->sslopts = malloc(sizeof(MQTTClient_SSLOptions));
 		memset(m->c->sslopts, '\0', sizeof(MQTTClient_SSLOptions));
+		m->c->sslopts->struct_version = options->ssl->struct_version;
 		if (options->ssl->trustStore)
 			m->c->sslopts->trustStore = MQTTStrdup(options->ssl->trustStore);
 		if (options->ssl->keyStore)
@@ -2340,6 +2341,8 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 		if (options->ssl->enabledCipherSuites)
 			m->c->sslopts->enabledCipherSuites = MQTTStrdup(options->ssl->enabledCipherSuites);
 		m->c->sslopts->enableServerCertAuth = options->ssl->enableServerCertAuth;
+		if (m->c->sslopts->struct_version >= 1)
+			m->c->sslopts->sslVersion = options->ssl->sslVersion;
 	}
 #else
 	if (options->struct_version != 0 && options->ssl)

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -630,6 +630,11 @@ typedef struct
 
 #define MQTTAsync_willOptions_initializer { {'M', 'Q', 'T', 'W'}, 1, NULL, NULL, 0, 0, { 0, NULL } }
 
+#define MQTT_SSL_VERSION_DEFAULT 0
+#define MQTT_SSL_VERSION_TLS_1_0 1
+#define MQTT_SSL_VERSION_TLS_1_1 2
+#define MQTT_SSL_VERSION_TLS_1_2 3
+
 /**
 * MQTTAsync_sslProperties defines the settings to establish an SSL/TLS connection using the
 * OpenSSL library. It covers the following scenarios:
@@ -646,7 +651,7 @@ typedef struct
 {
 	/** The eyecatcher for this structure.  Must be MQTS */
 	char struct_id[4];
-	/** The version number of this structure.  Must be 0 */
+	/** The version number of this structure.    Must be 0, or 1 to enable TLS version selection. */
 	int struct_version;
 
 	/** The file in PEM format containing the public digital certificates trusted by the client. */
@@ -677,9 +682,15 @@ typedef struct
     /** True/False option to enable verification of the server certificate **/
     int enableServerCertAuth;
 
+    /** The SSL/TLS version to use. Specify one of MQTT_SSL_VERSION_DEFAULT (0),
+    * MQTT_SSL_VERSION_TLS_1_0 (1), MQTT_SSL_VERSION_TLS_1_1 (2) or MQTT_SSL_VERSION_TLS_1_2 (3).
+    * Only used if struct_version is >= 1.
+    */
+    int sslVersion;
+
 } MQTTAsync_SSLOptions;
 
-#define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 0, NULL, NULL, NULL, NULL, NULL, 1 }
+#define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 1, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT }
 
 /**
  * MQTTAsync_connectOptions defines several settings that control the way the

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1104,6 +1104,7 @@ static int MQTTClient_connectURI(MQTTClient handle, MQTTClient_connectOptions* o
 	{
 		m->c->sslopts = malloc(sizeof(MQTTClient_SSLOptions));
 		memset(m->c->sslopts, '\0', sizeof(MQTTClient_SSLOptions));
+		m->c->sslopts->struct_version = options->ssl->struct_version;
 		if (options->ssl->trustStore)
 			m->c->sslopts->trustStore = MQTTStrdup(options->ssl->trustStore);
 		if (options->ssl->keyStore)
@@ -1115,6 +1116,8 @@ static int MQTTClient_connectURI(MQTTClient handle, MQTTClient_connectOptions* o
 		if (options->ssl->enabledCipherSuites)
 			m->c->sslopts->enabledCipherSuites = MQTTStrdup(options->ssl->enabledCipherSuites);
 		m->c->sslopts->enableServerCertAuth = options->ssl->enableServerCertAuth;
+		if (m->c->sslopts->struct_version >= 1)
+			m->c->sslopts->sslVersion = options->ssl->sslVersion;
 	}
 #endif
 
@@ -1180,7 +1183,7 @@ int MQTTClient_connect(MQTTClient handle, MQTTClient_connectOptions* options)
 #if defined(OPENSSL)
 	if (options->struct_version != 0 && options->ssl) /* check validity of SSL options structure */
 	{
-		if (strncmp(options->ssl->struct_id, "MQTS", 4) != 0 || options->ssl->struct_version != 0)
+		if (strncmp(options->ssl->struct_id, "MQTS", 4) != 0 || options->ssl->struct_version < 0 || options->ssl->struct_version > 1)
 		{
 			rc = MQTTCLIENT_BAD_STRUCTURE;
 			goto exit;

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -482,6 +482,11 @@ typedef struct
 
 #define MQTTClient_willOptions_initializer { {'M', 'Q', 'T', 'W'}, 1, NULL, NULL, 0, 0, {0, NULL} }
 
+#define MQTT_SSL_VERSION_DEFAULT 0
+#define MQTT_SSL_VERSION_TLS_1_0 1
+#define MQTT_SSL_VERSION_TLS_1_1 2
+#define MQTT_SSL_VERSION_TLS_1_2 3
+
 /**
 * MQTTClient_sslProperties defines the settings to establish an SSL/TLS connection using the
 * OpenSSL library. It covers the following scenarios:
@@ -498,7 +503,7 @@ typedef struct
 {
 	/** The eyecatcher for this structure.  Must be MQTS */
 	char struct_id[4];
-	/** The version number of this structure.  Must be 0 */
+	/** The version number of this structure.  Must be 0, or 1 to enable TLS version selection. */
 	int struct_version;
 
 	/** The file in PEM format containing the public digital certificates trusted by the client. */
@@ -529,9 +534,15 @@ typedef struct
     /** True/False option to enable verification of the server certificate **/
     int enableServerCertAuth;
 
+    /** The SSL/TLS version to use. Specify one of MQTT_SSL_VERSION_DEFAULT (0),
+    * MQTT_SSL_VERSION_TLS_1_0 (1), MQTT_SSL_VERSION_TLS_1_1 (2) or MQTT_SSL_VERSION_TLS_1_2 (3).
+    * Only used if struct_version is >= 1.
+    */
+    int sslVersion;
+
 } MQTTClient_SSLOptions;
 
-#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 0, NULL, NULL, NULL, NULL, NULL, 1 }
+#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 1, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT }
 
 /**
  * MQTTClient_connectOptions defines several settings that control the way the

--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -3,11 +3,11 @@
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
- * and Eclipse Distribution License v1.0 which accompany this distribution. 
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
- * The Eclipse Public License is available at 
+ * The Eclipse Public License is available at
  *    http://www.eclipse.org/legal/epl-v10.html
- * and the Eclipse Distribution License is available at 
+ * and the Eclipse Distribution License is available at
  *   http://www.eclipse.org/org/documents/edl-v10.php.
  *
  * Contributors:
@@ -202,8 +202,8 @@ void SSL_CTX_info_callback(const SSL* ssl, int where, int ret)
 {
 	if (where & SSL_CB_LOOP)
 	{
-		Log(TRACE_PROTOCOL, 1, "SSL state %s:%s:%s", 
-                  (where & SSL_ST_CONNECT) ? "connect" : (where & SSL_ST_ACCEPT) ? "accept" : "undef", 
+		Log(TRACE_PROTOCOL, 1, "SSL state %s:%s:%s",
+                  (where & SSL_ST_CONNECT) ? "connect" : (where & SSL_ST_ACCEPT) ? "accept" : "undef",
                     SSL_state_string_long(ssl), SSL_get_cipher_name(ssl));
 	}
 	else if (where & SSL_CB_EXIT)
@@ -215,26 +215,26 @@ void SSL_CTX_info_callback(const SSL* ssl, int where, int ret)
 	else if (where & SSL_CB_ALERT)
 	{
 		Log(TRACE_PROTOCOL, 1, "SSL alert %s:%s:%s",
-                  (where & SSL_CB_READ) ? "read" : "write", 
+                  (where & SSL_CB_READ) ? "read" : "write",
                     SSL_alert_type_string_long(ret), SSL_alert_desc_string_long(ret));
 	}
 	else if (where & SSL_CB_HANDSHAKE_START)
 	{
 		Log(TRACE_PROTOCOL, 1, "SSL handshake started %s:%s:%s",
-                  (where & SSL_CB_READ) ? "read" : "write", 
+                  (where & SSL_CB_READ) ? "read" : "write",
                     SSL_alert_type_string_long(ret), SSL_alert_desc_string_long(ret));
 	}
 	else if (where & SSL_CB_HANDSHAKE_DONE)
 	{
-		Log(TRACE_PROTOCOL, 1, "SSL handshake done %s:%s:%s", 
+		Log(TRACE_PROTOCOL, 1, "SSL handshake done %s:%s:%s",
                   (where & SSL_CB_READ) ? "read" : "write",
                     SSL_alert_type_string_long(ret), SSL_alert_desc_string_long(ret));
-		Log(TRACE_PROTOCOL, 1, "SSL certificate verification: %s", 
+		Log(TRACE_PROTOCOL, 1, "SSL certificate verification: %s",
                     SSL_get_verify_result_string(SSL_get_verify_result(ssl)));
 	}
 	else
 	{
-		Log(TRACE_PROTOCOL, 1, "SSL state %s:%s:%s", SSL_state_string_long(ssl), 
+		Log(TRACE_PROTOCOL, 1, "SSL state %s:%s:%s", SSL_state_string_long(ssl),
                    SSL_alert_type_string_long(ret), SSL_alert_desc_string_long(ret));
 	}
 }
@@ -271,7 +271,7 @@ char* SSLSocket_get_version_string(int version)
 			break;
 		}
 	}
-	
+
 	if (retstring == NULL)
 	{
 		sprintf(buf, "%i", version);
@@ -281,11 +281,11 @@ char* SSLSocket_get_version_string(int version)
 }
 
 
-void SSL_CTX_msg_callback(int write_p, int version, int content_type, const void* buf, size_t len, 
+void SSL_CTX_msg_callback(int write_p, int version, int content_type, const void* buf, size_t len,
         SSL* ssl, void* arg)
-{  
+{
 
-/*  
+/*
 called by the SSL/TLS library for a protocol message, the function arguments have the following meaning:
 
 write_p
@@ -308,9 +308,9 @@ The user-defined argument optionally defined by SSL_CTX_set_msg_callback_arg() o
 
 */
 
-	Log(TRACE_PROTOCOL, -1, "%s %s %d buflen %d", (write_p ? "sent" : "received"), 
+	Log(TRACE_PROTOCOL, -1, "%s %s %d buflen %d", (write_p ? "sent" : "received"),
 		SSLSocket_get_version_string(version),
-		content_type, (int)len);	
+		content_type, (int)len);
 }
 
 
@@ -432,23 +432,23 @@ int SSLSocket_initialize(void)
 	/*int prc;*/
 	int i;
 	int lockMemSize;
-	
+
 	FUNC_ENTRY;
 
 	if (handle_openssl_init)
 	{
 		if ((rc = SSL_library_init()) != 1)
 			rc = -1;
-			
+
 		ERR_load_crypto_strings();
 		SSL_load_error_strings();
-		
-		/* OpenSSL 0.9.8o and 1.0.0a and later added SHA2 algorithms to SSL_library_init(). 
-		Applications which need to use SHA2 in earlier versions of OpenSSL should call 
+
+		/* OpenSSL 0.9.8o and 1.0.0a and later added SHA2 algorithms to SSL_library_init().
+		Applications which need to use SHA2 in earlier versions of OpenSSL should call
 		OpenSSL_add_all_algorithms() as well. */
-		
+
 		OpenSSL_add_all_algorithms();
-		
+
 		lockMemSize = CRYPTO_num_locks() * sizeof(ssl_mutex_type);
 
 		sslLocks = malloc(lockMemSize);
@@ -471,9 +471,9 @@ int SSLSocket_initialize(void)
 		CRYPTO_set_id_callback(SSLThread_id);
 #endif
 		CRYPTO_set_locking_callback(SSLLocks_callback);
-		
+
 	}
-	
+
 	SSL_create_mutex(&sslCoreMutex);
 
 exit:
@@ -484,7 +484,7 @@ exit:
 void SSLSocket_terminate(void)
 {
 	FUNC_ENTRY;
-	
+
 	if (handle_openssl_init)
 	{
 		EVP_cleanup();
@@ -501,9 +501,9 @@ void SSLSocket_terminate(void)
 			free(sslLocks);
 		}
 	}
-	
+
 	SSL_destroy_mutex(&sslCoreMutex);
-	
+
 	FUNC_EXIT;
 }
 
@@ -511,23 +511,54 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts)
 {
 	int rc = 1;
 	const char* ciphers = NULL;
-	
+
 	FUNC_ENTRY;
 	if (net->ctx == NULL)
-		if ((net->ctx = SSL_CTX_new(SSLv23_client_method())) == NULL)	/* SSLv23 for compatibility with SSLv2, SSLv3 and TLSv1 */
+	{
+		int sslVersion = MQTT_SSL_VERSION_DEFAULT;
+		if (opts->struct_version >= 1) sslVersion = opts->sslVersion;
+/* SSL_OP_NO_TLSv1_1 is defined in ssl.h if the library version supports TLSv1.1.
+ * OPENSSL_NO_TLS1 is defined in opensslconf.h or on the compiler command line
+ * if TLS1.x was removed at OpenSSL library build time via Configure options.
+ */
+		switch (sslVersion)
+		{
+		case MQTT_SSL_VERSION_DEFAULT:
+			net->ctx = SSL_CTX_new(SSLv23_client_method()); /* SSLv23 for compatibility with SSLv2, SSLv3 and TLSv1 */
+			break;
+#if defined(SSL_OP_NO_TLSv1) && !defined(OPENSSL_NO_TLS1)
+		case MQTT_SSL_VERSION_TLS_1_0:
+			net->ctx = SSL_CTX_new(TLSv1_client_method());
+			break;
+#endif
+#if defined(SSL_OP_NO_TLSv1_1) && !defined(OPENSSL_NO_TLS1)
+		case MQTT_SSL_VERSION_TLS_1_1:
+			net->ctx = SSL_CTX_new(TLSv1_1_client_method());
+			break;
+#endif
+#if defined(SSL_OP_NO_TLSv1_2) && !defined(OPENSSL_NO_TLS1)
+		case MQTT_SSL_VERSION_TLS_1_2:
+			net->ctx = SSL_CTX_new(TLSv1_2_client_method());
+			break;
+#endif
+		default:
+			break;
+		}
+		if (net->ctx == NULL)
 		{
 			SSLSocket_error("SSL_CTX_new", NULL, net->socket, rc);
 			goto exit;
 		}
-	
+	}
+
 	if (opts->keyStore)
 	{
 		if ((rc = SSL_CTX_use_certificate_chain_file(net->ctx, opts->keyStore)) != 1)
 		{
 			SSLSocket_error("SSL_CTX_use_certificate_chain_file", NULL, net->socket, rc);
 			goto free_ctx; /*If we can't load the certificate (chain) file then loading the privatekey won't work either as it needs a matching cert already loaded */
-		}	
-			
+		}
+
 		if (opts->privateKey == NULL)
 			opts->privateKey = opts->keyStore;   /* the privateKey can be included in the keyStore */
 
@@ -536,7 +567,7 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts)
 			SSL_CTX_set_default_passwd_cb(net->ctx, pem_passwd_cb);
 			SSL_CTX_set_default_passwd_cb_userdata(net->ctx, (void*)opts->privateKeyPassword);
 		}
-		
+
 		/* support for ASN.1 == DER format? DER can contain only one certificate? */
 		rc = SSL_CTX_use_PrivateKey_file(net->ctx, opts->privateKey, SSL_FILETYPE_PEM);
 		if (opts->privateKey == opts->keyStore)
@@ -545,7 +576,7 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts)
 		{
 			SSLSocket_error("SSL_CTX_use_PrivateKey_file", NULL, net->socket, rc);
 			goto free_ctx;
-		}  
+		}
 	}
 
 	if (opts->trustStore)
@@ -554,7 +585,7 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts)
 		{
 			SSLSocket_error("SSL_CTX_load_verify_locations", NULL, net->socket, rc);
 			goto free_ctx;
-		}                               
+		}
 	}
 	else if ((rc = SSL_CTX_set_default_verify_paths(net->ctx)) != 1)
 	{
@@ -563,7 +594,7 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts)
 	}
 
 	if (opts->enabledCipherSuites == NULL)
-		ciphers = "DEFAULT"; 
+		ciphers = "DEFAULT";
 	else
 		ciphers = opts->enabledCipherSuites;
 
@@ -571,15 +602,15 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts)
 	{
 		SSLSocket_error("SSL_CTX_set_cipher_list", NULL, net->socket, rc);
 		goto free_ctx;
-	}       
-	
+	}
+
 	SSL_CTX_set_mode(net->ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 
 	goto exit;
 free_ctx:
 	SSL_CTX_free(net->ctx);
 	net->ctx = NULL;
-	
+
 exit:
 	FUNC_EXIT_RC(rc);
 	return rc;
@@ -589,18 +620,18 @@ exit:
 int SSLSocket_setSocketForSSL(networkHandles* net, MQTTClient_SSLOptions* opts, char* hostname)
 {
 	int rc = 1;
-	
+
 	FUNC_ENTRY;
-	
+
 	if (net->ctx != NULL || (rc = SSLSocket_createContext(net, opts)) == 1)
 	{
 		int i;
 
 		SSL_CTX_set_info_callback(net->ctx, SSL_CTX_info_callback);
 		SSL_CTX_set_msg_callback(net->ctx, SSL_CTX_msg_callback);
-   		if (opts->enableServerCertAuth) 
+   		if (opts->enableServerCertAuth)
 			SSL_CTX_set_verify(net->ctx, SSL_VERIFY_PEER, NULL);
-	
+
 		net->ssl = SSL_new(net->ctx);
 
 		/* Log all ciphers available to the SSL sessions (loaded in ctx) */
@@ -610,20 +641,20 @@ int SSLSocket_setSocketForSSL(networkHandles* net, MQTTClient_SSLOptions* opts, 
 			if (cipher == NULL)
 				break;
 			Log(TRACE_PROTOCOL, 1, "SSL cipher available: %d:%s", i, cipher);
-	    	}	
+	    	}
 		if ((rc = SSL_set_fd(net->ssl, net->socket)) != 1)
 			SSLSocket_error("SSL_set_fd", net->ssl, net->socket, rc);
 
 		if ((rc = SSL_set_tlsext_host_name(net->ssl, hostname)) != 1)
 			SSLSocket_error("SSL_set_tlsext_host_name", NULL, net->socket, rc);
 	}
-		
+
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
 
 
-int SSLSocket_connect(SSL* ssl, int sock)      
+int SSLSocket_connect(SSL* ssl, int sock)
 {
 	int rc = 0;
 
@@ -767,7 +798,7 @@ int SSLSocket_close(networkHandles* net)
 }
 
 
-/* No SSL_writev() provided by OpenSSL. Boo. */  
+/* No SSL_writev() provided by OpenSSL. Boo. */
 int SSLSocket_putdatas(SSL* ssl, int socket, char* buf0, size_t buf0len, int count, char** buffers, size_t* buflens, int* frees)
 {
 	int rc = 0;
@@ -781,7 +812,7 @@ int SSLSocket_putdatas(SSL* ssl, int socket, char* buf0, size_t buf0len, int cou
 	for (i = 0; i < count; i++)
 		iovec.iov_len += (ULONG)buflens[i];
 
-	ptr = iovec.iov_base = (char *)malloc(iovec.iov_len);  
+	ptr = iovec.iov_base = (char *)malloc(iovec.iov_len);
 	memcpy(ptr, buf0, buf0len);
 	ptr += buf0len;
 	for (i = 0; i < count; i++)
@@ -793,10 +824,10 @@ int SSLSocket_putdatas(SSL* ssl, int socket, char* buf0, size_t buf0len, int cou
 	SSL_lock_mutex(&sslCoreMutex);
 	if ((rc = SSL_write(ssl, iovec.iov_base, iovec.iov_len)) == iovec.iov_len)
 		rc = TCPSOCKET_COMPLETE;
-	else 
-	{ 
+	else
+	{
 		sslerror = SSLSocket_error("SSL_write", ssl, socket, rc);
-		
+
 		if (sslerror == SSL_ERROR_WANT_WRITE)
 		{
 			int* sockmem = (int*)malloc(sizeof(int));
@@ -810,7 +841,7 @@ int SSLSocket_putdatas(SSL* ssl, int socket, char* buf0, size_t buf0len, int cou
 			FD_SET(socket, &(s.pending_wset));
 			rc = TCPSOCKET_INTERRUPTED;
 		}
-		else 
+		else
 			rc = SOCKET_ERROR;
 	}
 	SSL_unlock_mutex(&sslCoreMutex);
@@ -825,9 +856,9 @@ int SSLSocket_putdatas(SSL* ssl, int socket, char* buf0, size_t buf0len, int cou
 		{
 			if (frees[i])
 				free(buffers[i]);
-		}	
+		}
 	}
-	FUNC_EXIT_RC(rc); 
+	FUNC_EXIT_RC(rc);
 	return rc;
 }
 
@@ -852,7 +883,7 @@ void SSLSocket_addPendingRead(int sock)
 int SSLSocket_getPendingRead(void)
 {
 	int sock = -1;
-	
+
 	if (pending_reads.count > 0)
 	{
 		sock = *(int*)(pending_reads.first->content);
@@ -864,8 +895,8 @@ int SSLSocket_getPendingRead(void)
 
 int SSLSocket_continueWrite(pending_writes* pw)
 {
-	int rc = 0; 
-	
+	int rc = 0;
+
 	FUNC_ENTRY;
 	if ((rc = SSL_write(pw->ssl, pw->iovecs[0].iov_base, pw->iovecs[0].iov_len)) == pw->iovecs[0].iov_len)
 	{


### PR DESCRIPTION
Add support for selecting/enforcing a TLS version through a new `sslVersion` field in the `MQTTClient_SSLOptions` struct. This affects which `*_client_method()` function is called in SSLSocket.c: 
  * 0 (`MQTT_SSL_VERSION_DEFAULT`) -> `SSLv23_client_method()`
  * 1 (`MQTT_SSL_VERSION_TLS_1_0`) -> `TLSv1_client_method()`
  * 2 (`MQTT_SSL_VERSION_TLS_1_1`) -> `TLSv1_1_client_method()`
  * 3 (`MQTT_SSL_VERSION_TLS_1_2`) -> `TLSv1_2_client_method()`

We use this in macchina.io.