### PR TITLE
include errno.h before defines socket error codes

### DIFF
--- a/src/Socket.h
+++ b/src/Socket.h
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 
 #if defined(WIN32) || defined(WIN64)
+#include <errno.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #define MAXHOSTNAMELEN 256


### PR DESCRIPTION
I can't understand is it needed more define for Visual Studio. I can check only in 2013 version.

https://github.com/eclipse/paho.mqtt.c/issues/348