### PR TITLE
Segfault on missing SSL options

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -2813,7 +2813,7 @@ static int MQTTAsync_connecting(MQTTAsyncs* m)
 			if (hostname != m->serverURI)
 				free(hostname);
 
-			if (setSocketForSSLrc != MQTTASYNC_SUCCESS)
+            if (setSocketForSSLrc == 1) //SSL_SUCCESS
 			{
 				if (m->c->session != NULL)
 					if ((rc = SSL_set_session(m->c->net.ssl, m->c->session)) != 1)

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -889,7 +889,7 @@ static int MQTTClient_connectURIVersion(MQTTClient handle, MQTTClient_connectOpt
 			if (hostname != m->serverURI)
 				free(hostname);
 
-			if (setSocketForSSLrc != MQTTCLIENT_SUCCESS)
+			if (setSocketForSSLrc == 1) //SSL_SUCCESS
 			{
 				if (m->c->session != NULL)
 					if ((rc = SSL_set_session(m->c->net.ssl, m->c->session)) != 1)

--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -513,6 +513,14 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts)
 	const char* ciphers = NULL;
 	
 	FUNC_ENTRY;
+	
+	if (!opts)
+	{
+		rc = -1; 
+		SSLSocket_error("MQTTClient_SSLOptions not filled", NULL, net->socket, rc); 
+		goto exit;
+	}
+
 	if (net->ctx == NULL)
 		if ((net->ctx = SSL_CTX_new(SSLv23_client_method())) == NULL)	/* SSLv23 for compatibility with SSLv2, SSLv3 and TLSv1 */
 		{


### PR DESCRIPTION
https://github.com/eclipse/paho.mqtt.c/issues/334

Please, check SSLSocket_setSocketForSSL return code. I think it should be only 1 if success. 
It's better to add SSL return code define