### PR TITLE
Fix Socket_setnonblocking() for Windows (At least if build with MSVC …

### DIFF
--- a/src/Socket.c
+++ b/src/Socket.c
@@ -36,7 +36,9 @@
 #include "SSLSocket.h"
 #endif
 
+#if !defined(WIN32) && !defined(WIN64)
 #include <errno.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <signal.h>
@@ -99,6 +101,10 @@ int Socket_setnonblocking(int sock)
  */
 int Socket_error(char* aString, int sock)
 {
+#if defined(WIN32) || defined(WIN64)
+	int errno;
+#endif
+
 	FUNC_ENTRY;
 #if defined(WIN32) || defined(WIN64)
 	errno = WSAGetLastError();

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -36,9 +36,6 @@
 #include "SSLSocket.h"
 #endif
 
-#if !defined(WIN32) && !defined(WIN64)
-#include <errno.h>
-#endif
 #include <stdlib.h>
 #include <string.h>
 #include <signal.h>


### PR DESCRIPTION
…2010)

Partially revert commit a16cff63cc2c595bb9fd0334495953f5d0be7796 for file
src/Socket.c

- Do not include errno.h for Windows build
- Use errno as a local variable in Socket_setnonblocking() for Windows

Signed-off-by: Juergen Kosel <juergen.kosel@softing.com>