### PR TITLE
Clean up the write data queued for the socket in SocketBuffer_cleanup()

### DIFF
--- a/src/Heap.c
+++ b/src/Heap.c
@@ -247,10 +247,13 @@ static int Internal_heap_unlink(char* file, int line, void* p)
  */
 void myfree(char* file, int line, void* p)
 {
-	Thread_lock_mutex(heap_mutex);
-	if (Internal_heap_unlink(file, line, p))
-		free(((int*)p)-1);
-	Thread_unlock_mutex(heap_mutex);
+	if (p) /* it is legal und usual to call free(NULL) */
+	{
+		Thread_lock_mutex(heap_mutex);
+		if (Internal_heap_unlink(file, line, p))
+			free(((int*)p)-1);
+		Thread_unlock_mutex(heap_mutex);
+	}
 }
 
 
@@ -479,3 +482,8 @@ int main(int argc, char *argv[])
 }
 
 #endif /* HEAP_UNIT_TESTS */
+
+/* Local Variables: */
+/* indent-tabs-mode: t */
+/* c-basic-offset: 8 */
+/* End: */

--- a/src/Heap.h
+++ b/src/Heap.h
@@ -59,6 +59,9 @@ typedef struct
 	size_t max_size;		/**< max size the heap has reached in bytes */
 } heap_info;
 
+#if defined(__cplusplus)
+ extern "C" {
+#endif
 
 void* mymalloc(char*, int, size_t size);
 void* myrealloc(char*, int, void* p, size_t size);
@@ -72,5 +75,8 @@ int HeapDump(FILE* file);
 int HeapDumpString(FILE* file, char* str);
 void* Heap_findItem(void* p);
 void Heap_unlink(char* file, int line, void* p);
+#ifdef __cplusplus
+     }
+#endif
 
 #endif

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -1094,9 +1094,11 @@ static void MQTTAsync_writeComplete(int socket)
 				(*(command->onSuccess))(command->context, &data);
 			}
 			m->pending_write = NULL;
-
-			ListDetach(m->responses, com);
-			MQTTAsync_freeCommand(com);
+			if (com)
+			{
+				ListDetach(m->responses, com);
+				MQTTAsync_freeCommand(com);
+			}
 		}
 	}
 	FUNC_EXIT;

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -1038,7 +1038,10 @@ static void MQTTAsync_freeCommand1(MQTTAsync_queuedCommand *command)
 	{
 		/* qos 1 and 2 topics are freed in the protocol code when the flows are completed */
 		if (command->command.details.pub.destinationName)
+		{
 			free(command->command.details.pub.destinationName);
+			command->command.details.pub.destinationName = NULL;
+		}
 		free(command->command.details.pub.payload);
 	}
 }
@@ -1270,7 +1273,6 @@ static int MQTTAsync_processCommand(void)
 			}
 			else
 			{
-				command->command.details.pub.destinationName = NULL; /* this will be freed by the protocol code */
 				command->client->pending_write = &command->command;
 			}
 		}

--- a/src/MQTTPacket.c
+++ b/src/MQTTPacket.c
@@ -734,22 +734,3 @@ int MQTTPacket_send_publish(Publish* pack, int dup, int qos, int retained, netwo
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
-
-
-/**
- * Free allocated storage for a various packet tyoes
- * @param pack pointer to the suback packet structure
- */
-void MQTTPacket_free_packet(MQTTPacket* pack)
-{
-	FUNC_ENTRY;
-	if (pack->header.bits.type == PUBLISH)
-		MQTTPacket_freePublish((Publish*)pack);
-	/*else if (pack->header.type == SUBSCRIBE)
-		MQTTPacket_freeSubscribe((Subscribe*)pack, 1);
-	else if (pack->header.type == UNSUBSCRIBE)
-		MQTTPacket_freeUnsubscribe((Unsubscribe*)pack);*/
-	else
-		free(pack);
-	FUNC_EXIT;
-}

--- a/src/MQTTPacket.c
+++ b/src/MQTTPacket.c
@@ -251,9 +251,11 @@ int MQTTPacket_sends(networkHandles* net, Header header, int count, char** buffe
 		
 	if (rc == TCPSOCKET_COMPLETE)
 		time(&(net->lastSent));
-	
+
+         /* for TCPSOCKET_INTERRUPTED buf should be freed
+          * in Socket_continueWrite() or SocketBuffer_cleanup() */
 	if (rc != TCPSOCKET_INTERRUPTED)
-	  free(buf);
+		free(buf);
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
@@ -711,6 +713,8 @@ int MQTTPacket_send_publish(Publish* pack, int dup, int qos, int retained, netwo
 		ptr = topiclen;
 		writeInt(&ptr, (int)lens[1]);
 		rc = MQTTPacket_sends(net, header, 4, bufs, lens, frees);
+                /* for TCPSOCKET_INTERRUPTED buf should be freed
+                 * in Socket_continueWrite() or SocketBuffer_cleanup() */
 		if (rc != TCPSOCKET_INTERRUPTED)
 			free(buf);
 	}
@@ -724,6 +728,8 @@ int MQTTPacket_send_publish(Publish* pack, int dup, int qos, int retained, netwo
 		writeInt(&ptr, (int)lens[1]);
 		rc = MQTTPacket_sends(net, header, 3, bufs, lens, frees);
 	}
+         /* for TCPSOCKET_INTERRUPTED topiclen should be freed
+          * in Socket_continueWrite() or SocketBuffer_cleanup() */
 	if (rc != TCPSOCKET_INTERRUPTED)
 		free(topiclen);
 	if (qos == 0)

--- a/src/MQTTPacket.h
+++ b/src/MQTTPacket.h
@@ -253,8 +253,6 @@ int MQTTPacket_send_pubrec(int msgid, networkHandles* net, const char* clientID)
 int MQTTPacket_send_pubrel(int msgid, int dup, networkHandles* net, const char* clientID);
 int MQTTPacket_send_pubcomp(int msgid, networkHandles* net, const char* clientID);
 
-void MQTTPacket_free_packet(MQTTPacket* pack);
-
 #if !defined(NO_BRIDGE)
 	#include "MQTTPacketOut.h"
 #endif

--- a/src/SocketBuffer.c
+++ b/src/SocketBuffer.c
@@ -426,6 +426,8 @@ pending_writes* SocketBuffer_updateWrite(int socket, char* topic, char* payload)
 			pw->iovecs[2].iov_base = topic;
 			pw->iovecs[3].iov_base = payload;
 		}
+		else
+			Log(LOG_SEVERE, 0, "Error updating write: unexpected count %d",pw->count);
 	}
 
 	FUNC_EXIT;

--- a/src/SocketBuffer.c
+++ b/src/SocketBuffer.c
@@ -132,7 +132,25 @@ void SocketBuffer_terminate(void)
  */
 void SocketBuffer_cleanup(int socket)
 {
+	pending_writes* pw;
+
 	FUNC_ENTRY;
+	/* Clean up the write data queued for the socket */
+	do
+	{
+		int i;
+
+		pw = SocketBuffer_getWrite(socket);
+		if (pw)
+		{
+			for (i = 0; i < pw->count; i++)
+			{
+				if (pw->frees[i])
+					free(pw->iovecs[i].iov_base);
+			}
+		}
+	}
+	while (pw);
 	SocketBuffer_writeComplete(socket); /* clean up write buffers */
 	if (ListFindItem(queues, &socket, socketcompare))
 	{
@@ -411,3 +429,8 @@ pending_writes* SocketBuffer_updateWrite(int socket, char* topic, char* payload)
 	FUNC_EXIT;
 	return pw;
 }
+
+/* Local Variables: */
+/* indent-tabs-mode: t */
+/* c-basic-offset: 8 */
+/* End: */

--- a/src/SocketBuffer.c
+++ b/src/SocketBuffer.c
@@ -142,15 +142,21 @@ void SocketBuffer_cleanup(int socket)
 		if (pw)
 		{
 			int i;
-
+			Log(LOG_FATAL, -1, "Removing subbuffer of %p",pw);
 			/* clean up data which is referenced only _in_ the write buffer */
 			for (i = 0; i < pw->count; i++)
 			{
 				if (pw->frees[i])
+				{
+					Log(LOG_FATAL, -1, "Removing subbuffer %d: %p",i,pw->iovecs[i].iov_base);
 					free(pw->iovecs[i].iov_base);
+					pw->iovecs[i].iov_base = NULL;
+					pw->frees[i] = 0;
+				}
 			}
-			pw->count = 0;
 		}
+		else
+			Log(LOG_FATAL, -1, "No subbuffer to remove");
 		SocketBuffer_writeComplete(socket); /* clean up write buffers */
 	}
 	while (pw);

--- a/src/SocketBuffer.c
+++ b/src/SocketBuffer.c
@@ -138,20 +138,22 @@ void SocketBuffer_cleanup(int socket)
 	/* Clean up the write data queued for the socket */
 	do
 	{
-		int i;
-
 		pw = SocketBuffer_getWrite(socket);
 		if (pw)
 		{
+			int i;
+
+			/* clean up data which is referenced only _in_ the write buffer */
 			for (i = 0; i < pw->count; i++)
 			{
 				if (pw->frees[i])
 					free(pw->iovecs[i].iov_base);
 			}
+			pw->count = 0;
 		}
+		SocketBuffer_writeComplete(socket); /* clean up write buffers */
 	}
 	while (pw);
-	SocketBuffer_writeComplete(socket); /* clean up write buffers */
 	if (ListFindItem(queues, &socket, socketcompare))
 	{
 		free(((socket_queue*)(queues->current->content))->buf);


### PR DESCRIPTION
To fix https://github.com/eclipse/paho.mqtt.c/issues/373
the function SocketBuffer_cleanup() needs to iterate over all
queued write message of the Socket to clean up and free it,
as it would be done in Socket_writeComplete().

Signed-off-by: Juergen Kosel <juergen.kosel@softing.com>