### PR TITLE
fix issue that MQTTClient_connect hangs on network outage, for windows

### DIFF
--- a/src/Thread.c
+++ b/src/Thread.c
@@ -232,7 +232,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
 
 	FUNC_ENTRY;
 	#if defined(WIN32) || defined(WIN64)
-		rc = WaitForSingleObject(sem, timeout);
+		rc = WaitForSingleObject(sem, timeout < 0 ? 0 : timeout);
   #elif defined(OSX)
 		rc = (int)dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeout*1000000L));
 	#elif defined(USE_TRYWAIT)


### PR DESCRIPTION
On Windows, when there is no network, MQTTClient_connect could hang for very long time. The reason is an negative timeout value could be passed to Thread_wait_sem in Thread.c. On Windows, WaitForSingleObject will be invoked, which expects an DWORD (which is unsigned long), hence the negative timeout value is coverted to an huge DWORD implicitely, hence the thread "hangs".
The fix is: convert negative timeout to zero.

Linux platform does not have the issue, since negative timeout value will not pass the while (++i < count) test, and the function returns immediately.