### PR TITLE
Test4issue373

### DIFF
--- a/src/Socket.c
+++ b/src/Socket.c
@@ -685,7 +685,7 @@ int Socket_new(char* addr, int port, int* sock)
 			if (setsockopt(*sock, SOL_SOCKET, SO_NOSIGPIPE, (void*)&opt, sizeof(opt)) != 0)
 				Log(LOG_ERROR, -1, "Could not set SO_NOSIGPIPE for socket %d", *sock);
 #endif
-#if 1
+#if defined(TESTING)
                         {
                             int optsend = 2 * 1440;
                             if (setsockopt(*sock, SOL_SOCKET, SO_SNDBUF, (void*)&optsend, sizeof(optsend)) != 0)

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -504,6 +504,12 @@ int Socket_putdatas(int socket, char* buf0, size_t buf0len, int count, char** bu
 		}
 	}
 exit:
+#if 1
+        if (rc == TCPSOCKET_INTERRUPTED)
+        {
+            Log(LOG_ERROR, -1, "Socket_putdatas: TCPSOCKET_INTERRUPTED");
+        }
+#endif
 	FUNC_EXIT_RC(rc);
 	return rc;
 }

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -679,6 +679,13 @@ int Socket_new(char* addr, int port, int* sock)
 			if (setsockopt(*sock, SOL_SOCKET, SO_NOSIGPIPE, (void*)&opt, sizeof(opt)) != 0)
 				Log(LOG_ERROR, -1, "Could not set SO_NOSIGPIPE for socket %d", *sock);
 #endif
+#if 1
+                        {
+                            int optsend = 2 * 1440;
+                            if (setsockopt(*sock, SOL_SOCKET, SO_SNDBUF, (void*)&optsend, sizeof(optsend)) != 0)
+				Log(LOG_ERROR, -1, "Could not set SO_SNDBUF for socket %d", *sock);
+                        }
+#endif
 
 			Log(TRACE_MIN, -1, "New socket %d for %s, port %d",	*sock, addr, port);
 			if (Socket_addSocket(*sock) == SOCKET_ERROR)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -449,3 +449,13 @@ SET_TESTS_PROPERTIES(
 	test9-6-offline-buffering-max-buffered-binary-will
 	PROPERTIES TIMEOUT 540
 )
+
+ADD_EXECUTABLE(
+	test_issue373
+	test_issue373.c
+)
+
+TARGET_LINK_LIBRARIES(
+	test_issue373
+	paho-mqtt3a
+)

--- a/test/python/controlVMnetworkstate.py
+++ b/test/python/controlVMnetworkstate.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python
+import os
+import sys
+import time
+import subprocess
+import random
+bindir='/usr/bin'
+sys.path.append(bindir)
+
+def input_sel(prompt,max_,selectionoption):
+    # let the user choose the VM and verify selection
+    while True:
+        try:
+            print ('Please select from the list of running VMs\n\n'+'\n'.join(selectionoption))
+            userin = int(raw_input(prompt))
+        except ValueError:
+            print('\nThat was not a number\n\n')
+            continue
+        if userin > max_:
+            print('\nInput must be less than or equal to {0}.\n\n'.format(max_))
+        elif userin < 1:
+            print('\nInput must be greater than or equal to 1\n\n')
+        else:
+            return userin
+
+def statustext(result):
+    if result == 0:
+        status = 'OK'
+    else:
+        status = 'Failed'
+    return status
+
+def controlvmnetworkstate():
+    try:
+        offtime = 600
+        ontime = 14
+        vmdict={}
+        vmlist=[]
+        executable = os.path.join(bindir, 'VBoxManage')
+
+        #retrieve a list of all running VMs
+        runningvms= subprocess.check_output('%s list runningvms' %executable,shell=True).splitlines()
+        if len(runningvms) != 0:
+            for n in range(0, len(runningvms)):
+                vmlist.append('%s: %s' %(n+1,runningvms[n].rsplit(' ',1)[0].strip('"')))
+                vmdict[n+1]=runningvms[n].rsplit(' ',1)[-1]
+            usersel=input_sel('\nEnter the number of the VM: ',len(runningvms),vmlist)
+
+        else:
+            print('Can not retrieve list of running VMs')
+            sys.exit()
+
+        vmuuid=vmdict[usersel]
+        while True:
+            offtime = random.randint(60, 90)
+            ontime = random.randint(10, 90)
+            timenow = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
+            on = subprocess.call('%s controlvm %s setlinkstate1 on' %(executable,vmuuid),
+                                 shell=True)
+            status=statustext(on)
+            print ('%s: Plug Network cable into VM %s for %ds: %s' % (timenow, runningvms[usersel-1].rsplit(' ',1)[0].strip('"'),ontime, str(status)))
+            time.sleep(ontime)
+            timenow = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
+            off = subprocess.call('%s controlvm %s setlinkstate1 off' %(executable,vmuuid),
+                                  shell=True)
+            status = statustext(off)
+            print ('%s: Unplug Network cable from VM %s for %ds: %s' % (timenow, runningvms[usersel-1].rsplit(' ',1)[0].strip('"'),offtime, str(status)))
+            time.sleep(offtime)
+    except KeyboardInterrupt:
+        sys.exit('\nUser Interrupt')
+    except Exception as e:
+        print("Error in %s in function %s: %s" % (__name__, sys._getframe().f_code.co_name, e.message))
+if __name__ == "__main__":
+    sys.exit(controlvmnetworkstate())

--- a/test/test_issue373.c
+++ b/test/test_issue373.c
@@ -338,10 +338,14 @@ int test_373(struct Options options)
 #if !defined(_WINDOWS)
 	mqtt_mem = Heap_get_info();
 	MyLog(LOGA_INFO, "MQTT mem current %ld, max %ld",mqtt_mem->current_size,mqtt_mem->max_size);
-	if (mqtt_mem->current_size > 0) failures++; /* consider any not freed memory as failure */
 #endif
 exit:
 	MQTTAsync_destroy(&mqttasyncContext);
+#if !defined(_WINDOWS)
+	mqtt_mem = Heap_get_info();
+	MyLog(LOGA_INFO, "MQTT mem current %ld, max %ld",mqtt_mem->current_size,mqtt_mem->max_size);
+	if (mqtt_mem->current_size > 0) failures++; /* consider any not freed memory as failure */
+#endif
 	return failures;
 }
 

--- a/test/test_issue373.c
+++ b/test/test_issue373.c
@@ -206,16 +206,17 @@ void test373ConnectionLost(void* context, char* cause)
 
 void test373DeliveryComplete(void* context, MQTTAsync_token token)
 {
-	pendingMessageCnt--;
 }
 
 void test373_onWriteSuccess(void* context, MQTTAsync_successData* response)
 {
+	pendingMessageCnt--;
 	goodPublishCnt++;
 }
 
 void test373_onWriteFailure(void* context, MQTTAsync_failureData* response)
 {
+	pendingMessageCnt--;
 	failedPublishCnt++;
 }
 

--- a/test/test_issue373.c
+++ b/test/test_issue373.c
@@ -25,13 +25,18 @@
 #include "Thread.h"
 
 #if !defined(_WINDOWS)
-	#include <sys/time.h>
-  #include <sys/socket.h>
-	#include <unistd.h>
-  #include <errno.h>
+#include <sys/time.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <errno.h>
 #else
-  #include <windows.h>
+#include <windows.h>
 #endif
+#include "Heap.h" // for Heap_get_info
+// undefine macros from Heap.h:
+#undef malloc
+#undef realloc
+#undef free
 
 char unique[50]; // unique suffix/prefix to add to clientid/topic etc
 
@@ -115,7 +120,7 @@ void MyLog(int LOGA_level, char* format, ...)
 
 	va_start(args, format);
 	vsnprintf(&msg_buf[strlen(msg_buf)], sizeof(msg_buf) - strlen(msg_buf),
-			format, args);
+		  format, args);
 	va_end(args);
 
 	printf("%s\n", msg_buf);
@@ -131,13 +136,203 @@ void MySleep(long milliseconds)
 #endif
 }
 
+#define assert(a, b, c, d) myassert(__FILE__, __LINE__, a, b, c, d)
+
 int tests = 0;
 int failures = 0;
+int connected = 0;
+int pendingMessageCnt = 0; /* counter of messages which are currently queued for publish */
+int pendingMessageCntMax = 0;
+int failedPublishCnt = 0;
+int goodPublishCnt = 0;
+int connectCnt = 0;
+int connecting = 0;
 
+void myassert(char* filename, int lineno, char* description, int value,
+		char* format, ...)
+{
+	++tests;
+	if (!value)
+	{
+		va_list args;
+
+		++failures;
+		MyLog(LOGA_INFO, "Assertion failed, file %s, line %d, description: %s", filename,
+				lineno, description);
+
+		va_start(args, format);
+		vprintf(format, args);
+		va_end(args);
+	}
+	else
+		MyLog(LOGA_DEBUG, "Assertion succeeded, file %s, line %d, description: %s",
+				filename, lineno, description);
+}
+
+
+void test1373OnFailure(void* context, MQTTAsync_failureData* response)
+{
+	MyLog(LOGA_INFO, "In connect onFailure callback, context %p", context);
+	connecting = 0;
+}
+
+void test373OnConnect(void* context, MQTTAsync_successData* response)
+{
+	connected = 1;
+	connecting = 0;
+	connectCnt++;
+	MyLog(LOGA_INFO, "Established MQTT connection to %s",response->alt.connect.serverURI);
+	char MqttVersion[40];
+	switch (response->alt.connect.MQTTVersion)
+	{
+	case MQTTVERSION_3_1:
+		sprintf(MqttVersion," MQTT version 3.1");
+		break;
+	case MQTTVERSION_3_1_1:
+		sprintf(MqttVersion, " MQTT version 3.1.1");
+		break;
+	default:
+		sprintf(MqttVersion, " MQTT version %d",response->alt.connect.MQTTVersion);
+	}
+	MyLog(LOGA_INFO, " %s\n",MqttVersion);
+	MyLog(LOGA_INFO, "connectCnt %d\n",connectCnt);
+}
+
+void test373ConnectionLost(void* context, char* cause)
+{
+	connected = 0;
+	MyLog(LOGA_INFO, "Disconnected from MQTT broker reason %s",cause);
+}
+
+void test373DeliveryComplete(void* context, MQTTAsync_token token)
+{
+	pendingMessageCnt--;
+}
+
+void test373_onWriteSuccess(void* context, MQTTAsync_successData* response)
+{
+	goodPublishCnt++;
+}
+
+void test373_onWriteFailure(void* context, MQTTAsync_failureData* response)
+{
+	failedPublishCnt++;
+}
+
+int test373_messageArrived(void* context, char* topicName, int topicLen, MQTTAsync_message* message)
+{
+	return 0;
+}
+
+static char test373Payload[] = "No one is interested in this payload";
+
+int test373SendPublishMessage(MQTTAsync handle,int id)
+{
+	int rc = 0;
+	MQTTAsync_responseOptions opts = MQTTAsync_responseOptions_initializer;
+	MQTTAsync_message pubmsg = MQTTAsync_message_initializer;
+	char topic[ sizeof(unique) + 40];
+
+	sprintf(topic,"%s/test373/item_%03d",unique,id);
+	opts.onFailure = test373_onWriteFailure;
+	opts.onSuccess = test373_onWriteSuccess;
+
+	pubmsg.payload = test373Payload;
+	pubmsg.payloadlen = sizeof(test373Payload);
+	pubmsg.qos = 0;
+	rc = MQTTAsync_sendMessage( handle, topic,&pubmsg,&opts);
+	if (rc == MQTTASYNC_SUCCESS)
+	{
+		pendingMessageCnt++;
+		if (pendingMessageCnt > pendingMessageCntMax) pendingMessageCntMax = pendingMessageCnt;
+	}
+	return rc;
+}
 
 int test_373(struct Options options)
 {
-    return 0;
+	char* testname = "test373";
+	MQTTAsync mqttasyncContext;
+	MQTTAsync_connectOptions opts = MQTTAsync_connectOptions_initializer;
+	MQTTAsync_willOptions wopts = MQTTAsync_willOptions_initializer;
+	int rc = 0;
+	char clientid[30 + sizeof(unique)];
+	heap_info* mqtt_mem = 0;
+
+	sprintf(clientid, "paho-test373-%s", unique);
+	rc = MQTTAsync_create(&mqttasyncContext, options.proxy_connection, clientid,
+			      MQTTCLIENT_PERSISTENCE_NONE,
+			      NULL);
+	assert("good rc from create", rc == MQTTASYNC_SUCCESS, "rc was %d \n", rc);
+	if (rc != MQTTASYNC_SUCCESS)
+	{
+		goto exit;
+	}
+	opts.connectTimeout = 2;
+	opts.keepAliveInterval = 20;
+	opts.cleansession = 0;
+	opts.MQTTVersion = MQTTVERSION_DEFAULT;
+	opts.onSuccess = test373OnConnect;
+	opts.onFailure = test1373OnFailure;
+	opts.context = mqttasyncContext;
+
+	rc = MQTTAsync_setCallbacks(mqttasyncContext,mqttasyncContext,
+				    test373ConnectionLost,
+				    test373_messageArrived,
+				    test373DeliveryComplete);
+	if (rc != MQTTASYNC_SUCCESS)
+	{
+		goto exit;
+	}
+	MQTTAsync_setTraceLevel(MQTTASYNC_TRACE_ERROR);
+	while (connectCnt < 10)
+	{
+		MyLog(LOGA_INFO, "Connected %d connectCnt %d\n",connected,connectCnt);
+		mqtt_mem = Heap_get_info();
+		MyLog(LOGA_INFO, "PublishCnt %d, FailedCnt %d, Pending %d maxPending %d",
+		      goodPublishCnt,failedPublishCnt,pendingMessageCnt,pendingMessageCntMax);
+		MyLog(LOGA_INFO, "MQTT mem current %ld, max %ld",mqtt_mem->current_size,mqtt_mem->max_size);
+		if (!connected)
+		{
+			/* (re)connect to the broker */
+			if (connecting)
+			{
+				MySleep((1+opts.connectTimeout) * 1000); /* but wait for all pending connect attempts to timeout */
+			}
+			else
+			{
+				rc = MQTTAsync_connect(mqttasyncContext, &opts);
+				if (rc != MQTTASYNC_SUCCESS)
+				{
+					failures++;
+					goto exit;
+				}
+				connecting = 1;
+			}
+		}
+		else
+		{
+			/* while connected send 100 message per second */
+			int topicId;
+			for(topicId=0; topicId < 100; topicId++)
+			{
+				rc = test373SendPublishMessage(mqttasyncContext,topicId);
+				if (rc != MQTTASYNC_SUCCESS) break;
+			}
+			MySleep(1000);
+		}
+	}
+	MySleep(5000);
+	MyLog(LOGA_INFO, "PublishCnt %d, FailedCnt %d, Pending %d maxPending %d",
+	      goodPublishCnt,failedPublishCnt,pendingMessageCnt,pendingMessageCntMax);
+	MyLog(LOGA_INFO, "MQTT mem current %ld, max %ld",mqtt_mem->current_size,mqtt_mem->max_size);
+	MQTTAsync_disconnect(mqttasyncContext, NULL);
+	MyLog(LOGA_INFO, "PublishCnt %d, FailedCnt %d, Pending %d maxPending %d",
+	      goodPublishCnt,failedPublishCnt,pendingMessageCnt,pendingMessageCntMax);
+	MyLog(LOGA_INFO, "MQTT mem current %ld, max %ld",mqtt_mem->current_size,mqtt_mem->max_size);
+exit:
+	MQTTAsync_destroy(&mqttasyncContext);
+	return failures;
 }
 
 void handleTrace(enum MQTTASYNC_TRACE_LEVELS level, char* message)
@@ -149,7 +344,7 @@ int main(int argc, char** argv)
 {
 	int* numtests = &tests;
 	int rc = 0;
-        int (*tests[])() = { NULL, test_373};
+	int (*tests[])() = { NULL, test_373};
 
 	sprintf(unique, "%u", rand());
 	MyLog(LOGA_INFO, "Random prefix/suffix is %s", unique);
@@ -179,3 +374,9 @@ int main(int argc, char** argv)
 
 	return rc;
 }
+
+
+/* Local Variables: */
+/* indent-tabs-mode: t */
+/* c-basic-offset: 8 */
+/* End: */

--- a/test/test_issue373.c
+++ b/test/test_issue373.c
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2017 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *******************************************************************************/
+
+/**
+ * @file
+ * Test for issues 373, 385: Memory leak and segmentation fault during connection lost and reconnect
+ *
+ */
+
+#include "MQTTAsync.h"
+#include <string.h>
+#include <stdlib.h>
+#include "Thread.h"
+
+#if !defined(_WINDOWS)
+	#include <sys/time.h>
+  #include <sys/socket.h>
+	#include <unistd.h>
+  #include <errno.h>
+#else
+  #include <windows.h>
+#endif
+
+char unique[50]; // unique suffix/prefix to add to clientid/topic etc
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+
+void usage(void)
+{
+	printf("help!!\n");
+	exit(EXIT_FAILURE);
+}
+
+struct Options
+{
+	char* connection;            /**< connection to system under test. */
+	char* proxy_connection;      /**< connection to proxy */
+	int verbose;
+	int test_no;
+} options =
+{
+	"iot.eclipse.org:1883",
+	"localhost:1883",
+	0,
+	0,
+};
+
+void getopts(int argc, char** argv)
+{
+	int count = 1;
+
+	while (count < argc)
+	{
+		if (strcmp(argv[count], "--test_no") == 0)
+		{
+			if (++count < argc)
+				options.test_no = atoi(argv[count]);
+			else
+				usage();
+		}
+		else if (strcmp(argv[count], "--connection") == 0)
+		{
+			if (++count < argc)
+				options.connection = argv[count];
+			else
+				usage();
+		}
+		else if (strcmp(argv[count], "--proxy_connection") == 0)
+		{
+			if (++count < argc)
+				options.proxy_connection = argv[count];
+			else
+				usage();
+		}
+		else if (strcmp(argv[count], "--verbose") == 0)
+			options.verbose = 1;
+		count++;
+	}
+}
+
+
+#define LOGA_DEBUG 0
+#define LOGA_INFO 1
+#include <stdarg.h>
+#include <time.h>
+#include <sys/timeb.h>
+void MyLog(int LOGA_level, char* format, ...)
+{
+	static char msg_buf[256];
+	va_list args;
+	struct timeb ts;
+
+	struct tm *timeinfo;
+
+	if (LOGA_level == LOGA_DEBUG && options.verbose == 0)
+		return;
+
+	ftime(&ts);
+	timeinfo = localtime(&ts.time);
+	strftime(msg_buf, 80, "%Y%m%d %H%M%S", timeinfo);
+
+	sprintf(&msg_buf[strlen(msg_buf)], ".%.3hu ", ts.millitm);
+
+	va_start(args, format);
+	vsnprintf(&msg_buf[strlen(msg_buf)], sizeof(msg_buf) - strlen(msg_buf),
+			format, args);
+	va_end(args);
+
+	printf("%s\n", msg_buf);
+	fflush(stdout);
+}
+
+void MySleep(long milliseconds)
+{
+#if defined(WIN32) || defined(WIN64)
+	Sleep(milliseconds);
+#else
+	usleep(milliseconds*1000);
+#endif
+}
+
+int tests = 0;
+int failures = 0;
+
+
+int test_373(struct Options options)
+{
+    return 0;
+}
+
+void handleTrace(enum MQTTASYNC_TRACE_LEVELS level, char* message)
+{
+	printf("%s\n", message);
+}
+
+int main(int argc, char** argv)
+{
+	int* numtests = &tests;
+	int rc = 0;
+        int (*tests[])() = { NULL, test_373};
+
+	sprintf(unique, "%u", rand());
+	MyLog(LOGA_INFO, "Random prefix/suffix is %s", unique);
+
+	MQTTAsync_setTraceCallback(handleTrace);
+	getopts(argc, argv);
+
+	if (options.test_no == 0)
+	{ /* run all the tests */
+		for (options.test_no = 1; options.test_no < ARRAY_SIZE(tests); ++options.test_no)
+		{
+			failures = 0;
+			MQTTAsync_setTraceLevel(MQTTASYNC_TRACE_ERROR);
+			rc += tests[options.test_no](options); /* return number of failures.  0 = test succeeded */
+		}
+	}
+	else
+	{
+		MQTTAsync_setTraceLevel(MQTTASYNC_TRACE_ERROR);
+		rc = tests[options.test_no](options); /* run just the selected test */
+	}
+
+	if (rc == 0)
+		MyLog(LOGA_INFO, "verdict pass");
+	else
+		MyLog(LOGA_INFO, "verdict fail");
+
+	return rc;
+}

--- a/test/test_issue373.c
+++ b/test/test_issue373.c
@@ -247,6 +247,10 @@ int test373SendPublishMessage(MQTTAsync handle,int id)
 		pendingMessageCnt++;
 		if (pendingMessageCnt > pendingMessageCntMax) pendingMessageCntMax = pendingMessageCnt;
 	}
+	else
+	{
+		MyLog(LOGA_INFO, "Failed to queue message for send with retvalue %d",rc);
+	}
 	return rc;
 }
 

--- a/test/test_issue373.c
+++ b/test/test_issue373.c
@@ -326,11 +326,14 @@ int test_373(struct Options options)
 	MySleep(5000);
 	MyLog(LOGA_INFO, "PublishCnt %d, FailedCnt %d, Pending %d maxPending %d",
 	      goodPublishCnt,failedPublishCnt,pendingMessageCnt,pendingMessageCntMax);
+	mqtt_mem = Heap_get_info();
 	MyLog(LOGA_INFO, "MQTT mem current %ld, max %ld",mqtt_mem->current_size,mqtt_mem->max_size);
 	MQTTAsync_disconnect(mqttasyncContext, NULL);
+	mqtt_mem = Heap_get_info();
 	MyLog(LOGA_INFO, "PublishCnt %d, FailedCnt %d, Pending %d maxPending %d",
 	      goodPublishCnt,failedPublishCnt,pendingMessageCnt,pendingMessageCntMax);
 	MyLog(LOGA_INFO, "MQTT mem current %ld, max %ld",mqtt_mem->current_size,mqtt_mem->max_size);
+	if (mqtt_mem->current_size > 0) failures++; /* consider any not freed memory as failure */
 exit:
 	MQTTAsync_destroy(&mqttasyncContext);
 	return failures;

--- a/test/test_issue373.c
+++ b/test/test_issue373.c
@@ -286,15 +286,17 @@ int test_373(struct Options options)
 		goto exit;
 	}
 	MQTTAsync_setTraceLevel(MQTTASYNC_TRACE_ERROR);
-	while (connectCnt < 5)
+	while (connectCnt < 10)
 	{
-		MyLog(LOGA_INFO, "Connected %d connectCnt %d\n",connected,connectCnt);
-		mqtt_mem = Heap_get_info();
-		MyLog(LOGA_INFO, "PublishCnt %d, FailedCnt %d, Pending %d maxPending %d",
-		      goodPublishCnt,failedPublishCnt,pendingMessageCnt,pendingMessageCntMax);
-		MyLog(LOGA_INFO, "MQTT mem current %ld, max %ld",mqtt_mem->current_size,mqtt_mem->max_size);
 		if (!connected)
 		{
+			MyLog(LOGA_INFO, "Connected %d connectCnt %d\n",connected,connectCnt);
+			MyLog(LOGA_INFO, "PublishCnt %d, FailedCnt %d, Pending %d maxPending %d",
+			      goodPublishCnt,failedPublishCnt,pendingMessageCnt,pendingMessageCntMax);
+#if !defined(_WINDOWS)
+			mqtt_mem = Heap_get_info();
+			MyLog(LOGA_INFO, "MQTT mem current %ld, max %ld",mqtt_mem->current_size,mqtt_mem->max_size);
+#endif
 			/* (re)connect to the broker */
 			if (connecting)
 			{
@@ -320,20 +322,24 @@ int test_373(struct Options options)
 				rc = test373SendPublishMessage(mqttasyncContext,topicId);
 				if (rc != MQTTASYNC_SUCCESS) break;
 			}
-			MySleep(1000);
+			MySleep(100);
 		}
 	}
 	MySleep(5000);
 	MyLog(LOGA_INFO, "PublishCnt %d, FailedCnt %d, Pending %d maxPending %d",
 	      goodPublishCnt,failedPublishCnt,pendingMessageCnt,pendingMessageCntMax);
+#if !defined(_WINDOWS)
 	mqtt_mem = Heap_get_info();
 	MyLog(LOGA_INFO, "MQTT mem current %ld, max %ld",mqtt_mem->current_size,mqtt_mem->max_size);
+#endif
 	MQTTAsync_disconnect(mqttasyncContext, NULL);
-	mqtt_mem = Heap_get_info();
 	MyLog(LOGA_INFO, "PublishCnt %d, FailedCnt %d, Pending %d maxPending %d",
 	      goodPublishCnt,failedPublishCnt,pendingMessageCnt,pendingMessageCntMax);
+#if !defined(_WINDOWS)
+	mqtt_mem = Heap_get_info();
 	MyLog(LOGA_INFO, "MQTT mem current %ld, max %ld",mqtt_mem->current_size,mqtt_mem->max_size);
 	if (mqtt_mem->current_size > 0) failures++; /* consider any not freed memory as failure */
+#endif
 exit:
 	MQTTAsync_destroy(&mqttasyncContext);
 	return failures;

--- a/test/test_issue373.c
+++ b/test/test_issue373.c
@@ -286,7 +286,7 @@ int test_373(struct Options options)
 		goto exit;
 	}
 	MQTTAsync_setTraceLevel(MQTTASYNC_TRACE_ERROR);
-	while (connectCnt < 10)
+	while (connectCnt < 5)
 	{
 		MyLog(LOGA_INFO, "Connected %d connectCnt %d\n",connected,connectCnt);
 		mqtt_mem = Heap_get_info();
@@ -313,9 +313,9 @@ int test_373(struct Options options)
 		}
 		else
 		{
-			/* while connected send 100 message per second */
+			/* while connected send 1000 message per second */
 			int topicId;
-			for(topicId=0; topicId < 100; topicId++)
+			for(topicId=0; topicId < 1000; topicId++)
 			{
 				rc = test373SendPublishMessage(mqttasyncContext,topicId);
 				if (rc != MQTTASYNC_SUCCESS) break;


### PR DESCRIPTION
This pull request adds a test for issue #373 
This test needs to be started manually.
You need a broker on some other PC / virtual machine, which is cyclically disconnected and reconnected from the LAN.
Then start the test executable, for example with broker address tcp://SLGB-VM-MQTTSRV.inat.internal:1883:
`test/test_issue373 --proxy_connection tcp://SLGB-VM-MQTTSRV.inat.internal:1883`

I was not able to reproduce the segmentation faults reported in #385 with this test. But the memory leak reported in #373 
