### PR TITLE
Add missing string.h include to SSLSocket.c

### DIFF
--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -37,6 +37,7 @@
 
 #include "Heap.h"
 
+#include <string.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/crypto.h>


### PR DESCRIPTION
Compiling with GCC and a handcrafted Bazel build file errors with implicit declarations of memset, etc. functions.

```
INFO: From Compiling external/paho/src/SSLSocket.c:
external/paho/src/SSLSocket.c: In function 'SSLSocket_error':
external/paho/src/SSLSocket.c:104:13: warning: implicit declaration of function 'strcmp' [-Wimplicit-function-declaration]
         if (strcmp(aString, "shutdown") != 0)
             ^~~~~~
external/paho/src/SSLSocket.c:105:133: warning: implicit declaration of function 'strerror' [-Wimplicit-function-declaration]
          Log(TRACE_MIN, -1, "SSLSocket error %s(%d) in %s for socket %d rc %d errno %d %s\n", buf, error, aString, sock, rc, errno, strerror(errno));
                                                                                                                                     ^~~~~~~~
external/paho/src/SSLSocket.c: In function 'pem_passwd_cb':
external/paho/src/SSLSocket.c:324:3: warning: implicit declaration of function 'strncpy' [-Wimplicit-function-declaration]
   strncpy(buf, (char*)(userdata), size);
   ^~~~~~~
external/paho/src/SSLSocket.c:324:3: warning: incompatible implicit declaration of built-in function 'strncpy'
external/paho/src/SSLSocket.c:324:3: note: include '<string.h>' or provide a declaration of 'strncpy'
external/paho/src/SSLSocket.c:326:13: warning: implicit declaration of function 'strlen' [-Wimplicit-function-declaration]
   rc = (int)strlen(buf);
             ^~~~~~
external/paho/src/SSLSocket.c:326:13: warning: incompatible implicit declaration of built-in function 'strlen'
external/paho/src/SSLSocket.c:326:13: note: include '<string.h>' or provide a declaration of 'strlen'
external/paho/src/SSLSocket.c: In function 'SSLSocket_initialize':
external/paho/src/SSLSocket.c:461:4: warning: implicit declaration of function 'memset' [-Wimplicit-function-declaration]
    memset(sslLocks, 0, lockMemSize);
    ^~~~~~
external/paho/src/SSLSocket.c:461:4: warning: incompatible implicit declaration of built-in function 'memset'
external/paho/src/SSLSocket.c:461:4: note: include '<string.h>' or provide a declaration of 'memset'
external/paho/src/SSLSocket.c: In function 'SSLSocket_putdatas':
external/paho/src/SSLSocket.c:816:2: warning: implicit declaration of function 'memcpy' [-Wimplicit-function-declaration]
  memcpy(ptr, buf0, buf0len);
  ^~~~~~
...
```

This fixes that.