### PR TITLE
Further lockdown of const strings and buffers in the public Async API

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -1566,7 +1566,7 @@ static void MQTTAsync_emptyMessageQueue(Clients* client)
 		{
 			qEntry* qe = (qEntry*)(current->content);
 			free(qe->topicName);
-			free(qe->msg->payload);
+			free((void*) qe->msg->payload);
 			free(qe->msg);
 		}
 		ListEmpty(client->messageQueue);
@@ -1697,7 +1697,7 @@ exit:
 void MQTTAsync_freeMessage(MQTTAsync_message** message)
 {
 	FUNC_ENTRY;
-	free((*message)->payload);
+	free((void*) (*message)->payload);
 	free(*message);
 	*message = NULL;
 	FUNC_EXIT;
@@ -2176,8 +2176,9 @@ void Protocol_processPublication(Publish* publish, Clients* client)
 		mm->payload = publish->payload;
 	else
 	{
-		mm->payload = malloc(publish->payloadlen);
-		memcpy(mm->payload, publish->payload, publish->payloadlen);
+		void *payload = malloc(publish->payloadlen);
+		memcpy(payload, publish->payload, publish->payloadlen);
+		mm->payload = payload;
 	}
 
 	mm->payloadlen = publish->payloadlen;
@@ -2736,7 +2737,7 @@ static int MQTTAsync_countBufferedMessages(MQTTAsyncs* m)
 }
 
 
-int MQTTAsync_send(MQTTAsync handle, const char* destinationName, int payloadlen, void* payload,
+int MQTTAsync_send(MQTTAsync handle, const char* destinationName, int payloadlen, const void* payload,
 							 int qos, int retained, MQTTAsync_responseOptions* response)
 {
 	int rc = MQTTASYNC_SUCCESS;

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -2574,7 +2574,7 @@ static int MQTTAsync_assignMsgId(MQTTAsyncs* m)
 }
 
 
-int MQTTAsync_subscribeMany(MQTTAsync handle, int count, char* const* topic, int* qos, MQTTAsync_responseOptions* response)
+int MQTTAsync_subscribeMany(MQTTAsync handle, int count, const char* const* topic, const int* qos, MQTTAsync_responseOptions* response)
 {
 	MQTTAsyncs* m = handle;
 	int i = 0;
@@ -2644,7 +2644,7 @@ exit:
 int MQTTAsync_subscribe(MQTTAsync handle, const char* topic, int qos, MQTTAsync_responseOptions* response)
 {
 	int rc = 0;
-	char *const topics[] = {(char*)topic};
+	const char *topics[] = {topic};
 	FUNC_ENTRY;
 	rc = MQTTAsync_subscribeMany(handle, 1, topics, &qos, response);
 	FUNC_EXIT_RC(rc);
@@ -2652,7 +2652,7 @@ int MQTTAsync_subscribe(MQTTAsync handle, const char* topic, int qos, MQTTAsync_
 }
 
 
-int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, char* const* topic, MQTTAsync_responseOptions* response)
+int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, const char* const* topic, MQTTAsync_responseOptions* response)
 {
 	MQTTAsyncs* m = handle;
 	int i = 0;
@@ -2713,7 +2713,7 @@ exit:
 int MQTTAsync_unsubscribe(MQTTAsync handle, const char* topic, MQTTAsync_responseOptions* response)
 {
 	int rc = 0;
-	char *const topics[] = {(char*)topic};
+	const char *topics[] = {topic};
 	FUNC_ENTRY;
 	rc = MQTTAsync_unsubscribeMany(handle, 1, topics, response);
 	FUNC_EXIT_RC(rc);

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -243,7 +243,7 @@ typedef struct
 	/** The length of the MQTT message payload in bytes. */
 	int payloadlen;
 	/** A pointer to the payload of the MQTT message. */
-	void* payload;
+	const void* payload;
 	/**
      * The quality of service (QoS) assigned to the message.
      * There are three levels of QoS:
@@ -1011,7 +1011,7 @@ DLLExport int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, char* const
   * @return ::MQTTASYNC_SUCCESS if the message is accepted for publication.
   * An error code is returned if there was a problem accepting the message.
   */
-DLLExport int MQTTAsync_send(MQTTAsync handle, const char* destinationName, int payloadlen, void* payload, int qos, int retained,
+DLLExport int MQTTAsync_send(MQTTAsync handle, const char* destinationName, int payloadlen, const void* payload, int qos, int retained,
 																 MQTTAsync_responseOptions* response);
 
 

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -461,6 +461,11 @@ typedef struct
     * provide access to the context information in the callback.
     */
 	void* context;
+	/**
+	 * This gets the message ID for the packet. 
+	 * The value is assigned by the API call in order to return the token 
+	 * value back to the application. 
+	 */
 	MQTTAsync_token token;   /* output */
 } MQTTAsync_responseOptions;
 
@@ -962,7 +967,7 @@ DLLExport int MQTTAsync_subscribe(MQTTAsync handle, const char* topic, int qos, 
   * An error code is returned if there was a problem registering the
   * subscriptions.
   */
-DLLExport int MQTTAsync_subscribeMany(MQTTAsync handle, int count, char* const* topic, int* qos, MQTTAsync_responseOptions* response);
+DLLExport int MQTTAsync_subscribeMany(MQTTAsync handle, int count, const char* const* topic, const int* qos, MQTTAsync_responseOptions* response);
 
 /**
   * This function attempts to remove an existing subscription made by the
@@ -990,7 +995,7 @@ DLLExport int MQTTAsync_unsubscribe(MQTTAsync handle, const char* topic, MQTTAsy
   * @return ::MQTTASYNC_SUCCESS if the subscriptions are removed.
   * An error code is returned if there was a problem removing the subscriptions.
   */
-DLLExport int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, char* const* topic, MQTTAsync_responseOptions* response);
+DLLExport int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, const char* const* topic, MQTTAsync_responseOptions* response);
 
 
 /**

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -751,7 +751,7 @@ typedef struct
       * application does not make use of the Last Will and Testament feature,
       * set this pointer to NULL.
       */
-	MQTTAsync_willOptions* will;
+	const MQTTAsync_willOptions* will;
 	/**
       * MQTT servers that support the MQTT v3.1 protocol provide authentication
       * and authorisation by user name and password. This is the user name
@@ -776,7 +776,7 @@ typedef struct
       * This is a pointer to an MQTTAsync_SSLOptions structure. If your
       * application does not make use of SSL, set this pointer to NULL.
       */
-	MQTTAsync_SSLOptions* ssl;
+	const MQTTAsync_SSLOptions* ssl;
 	/**
       * A pointer to a callback function to be called if the connect successfully
       * completes.  Can be set to NULL, in which case no indication of successful

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -355,7 +355,7 @@ typedef void MQTTAsync_deliveryComplete(void* context, MQTTAsync_token token);
  * @param cause The reason for the disconnection.
  * Currently, <i>cause</i> is always set to NULL.
  */
-typedef void MQTTAsync_connectionLost(void* context, char* cause);
+typedef void MQTTAsync_connectionLost(void* context, const char* cause);
 
 
 /**
@@ -370,7 +370,7 @@ typedef void MQTTAsync_connectionLost(void* context, char* cause);
  * @param cause The reason for the disconnection.
  * Currently, <i>cause</i> is always set to NULL.
  */
-typedef void MQTTAsync_connected(void* context, char* cause);
+typedef void MQTTAsync_connected(void* context, const char* cause);
 
 
 
@@ -401,12 +401,12 @@ typedef struct
 		struct
 		{
 			MQTTAsync_message message;
-			char* destinationName;
+			const char* destinationName;
 		} pub;
 		/* For connect, the server connected to, MQTT version used, and sessionPresent flag */
 		struct
 		{
-			char* serverURI;
+			const char* serverURI;
 			int MQTTVersion;
 			int sessionPresent;
 		} connect;

--- a/src/samples/MQTTAsync_publish.c
+++ b/src/samples/MQTTAsync_publish.c
@@ -38,7 +38,7 @@ volatile MQTTAsync_token deliveredtoken;
 
 int finished = 0;
 
-void connlost(void *context, char *cause)
+void connlost(void *context, const char *cause)
 {
 	MQTTAsync client = (MQTTAsync)context;
 	MQTTAsync_connectOptions conn_opts = MQTTAsync_connectOptions_initializer;

--- a/src/samples/MQTTAsync_subscribe.c
+++ b/src/samples/MQTTAsync_subscribe.c
@@ -40,7 +40,7 @@ int disc_finished = 0;
 int subscribed = 0;
 int finished = 0;
 
-void connlost(void *context, char *cause)
+void connlost(void *context, const char *cause)
 {
 	MQTTAsync client = (MQTTAsync)context;
 	MQTTAsync_connectOptions conn_opts = MQTTAsync_connectOptions_initializer;

--- a/src/samples/MQTTAsync_subscribe.c
+++ b/src/samples/MQTTAsync_subscribe.c
@@ -64,7 +64,7 @@ void connlost(void *context, char *cause)
 int msgarrvd(void *context, char *topicName, int topicLen, MQTTAsync_message *message)
 {
     int i;
-    char* payloadptr;
+    const char* payloadptr;
 
     printf("Message arrived\n");
     printf("     topic: %s\n", topicName);

--- a/src/samples/paho_c_pub.c
+++ b/src/samples/paho_c_pub.c
@@ -179,7 +179,7 @@ void onPublish(void* context, MQTTAsync_successData* response)
 }
 
 
-void connectionLost(void* context, char* cause)
+void connectionLost(void* context, const char* cause)
 {
 	MQTTAsync client = (MQTTAsync)context;
 	MQTTAsync_connectOptions conn_opts = MQTTAsync_connectOptions_initializer;

--- a/src/samples/paho_c_sub.c
+++ b/src/samples/paho_c_sub.c
@@ -267,7 +267,7 @@ void onConnect(void* context, MQTTAsync_successData* response)
 MQTTAsync_connectOptions conn_opts = MQTTAsync_connectOptions_initializer;
 
 
-void connectionLost(void *context, char *cause)
+void connectionLost(void *context, const char *cause)
 {
 	MQTTAsync client = (MQTTAsync)context;
 	int rc;

--- a/test/test4.c
+++ b/test/test4.c
@@ -381,10 +381,10 @@ int test1(struct Options options)
 	opts.MQTTVersion = options.MQTTVersion;
 
 	opts.will = &wopts;
-	opts.will->message = "will message";
-	opts.will->qos = 1;
-	opts.will->retained = 0;
-	opts.will->topicName = "will topic";
+	wopts.message = "will message";
+	wopts.qos = 1;
+	wopts.retained = 0;
+	wopts.topicName = "will topic";
 	opts.will = NULL;
 	opts.onSuccess = test1_onConnect;
 	opts.onFailure = NULL;
@@ -475,10 +475,10 @@ int test2(struct Options options)
 	opts.MQTTVersion = options.MQTTVersion;
 
 	opts.will = &wopts;
-	opts.will->message = "will message";
-	opts.will->qos = 1;
-	opts.will->retained = 0;
-	opts.will->topicName = "will topic";
+	wopts.message = "will message";
+	wopts.qos = 1;
+	wopts.retained = 0;
+	wopts.topicName = "will topic";
 	opts.will = NULL;
 	opts.onSuccess = test2_onConnect;
 	opts.onFailure = test2_onFailure;
@@ -687,10 +687,10 @@ int test3(struct Options options)
 		opts.MQTTVersion = options.MQTTVersion;
 
 		opts.will = &wopts;
-		opts.will->message = "will message";
-		opts.will->qos = 1;
-		opts.will->retained = 0;
-		opts.will->topicName = "will topic";
+		wopts.message = "will message";
+		wopts.qos = 1;
+		wopts.retained = 0;
+		wopts.topicName = "will topic";
 		opts.onSuccess = test3_onConnect;
 		opts.onFailure = test3_onFailure;
 		opts.context = &clientdata[i];
@@ -875,10 +875,10 @@ int test4(struct Options options)
 	opts.MQTTVersion = options.MQTTVersion;
 
 	opts.will = &wopts;
-	opts.will->message = "will message";
-	opts.will->qos = 1;
-	opts.will->retained = 0;
-	opts.will->topicName = "will topic";
+	wopts.message = "will message";
+	wopts.qos = 1;
+	wopts.retained = 0;
+	wopts.topicName = "will topic";
 	opts.will = NULL;
 	opts.onSuccess = test4_onConnect;
 	opts.onFailure = NULL;
@@ -1268,10 +1268,10 @@ int test7(struct Options options)
 	opts.MQTTVersion = options.MQTTVersion;
 
 	opts.will = &wopts;
-	opts.will->message = "will message";
-	opts.will->qos = 1;
-	opts.will->retained = 0;
-	opts.will->topicName = "will topic";
+	wopts.message = "will message";
+	wopts.qos = 1;
+	wopts.retained = 0;
+	wopts.topicName = "will topic";
 	opts.will = NULL;
 
 	opts.onFailure = NULL;

--- a/test/test6.c
+++ b/test/test6.c
@@ -280,7 +280,7 @@ int control_found = 0;
 long last_completion_time = -1;
 int test_count = 1000;
 
-void control_connectionLost(void* context, char* cause)
+void control_connectionLost(void* context, const char* cause)
 {
 	MyLog(LOGA_ALWAYS, "Control connection lost - stopping");
 
@@ -459,7 +459,7 @@ void client_onReconnectFailure(void* context, MQTTAsync_failureData* response)
 }
 
 
-void connectionLost(void* context, char* cause)
+void connectionLost(void* context, const char* cause)
 {
 	MQTTAsync c = (MQTTAsync)context;
 	int rc = 0;

--- a/test/test6.c
+++ b/test/test6.c
@@ -392,7 +392,7 @@ int messageArrived(void* context, char* topicName, int topicLen,
 	int seqno = -1;
 	char* token = NULL;
 
-	token = strtok(m->payload, " ");
+	token = strtok((void*) m->payload, " ");
 	token = strtok(NULL, " ");
 	token = strtok(NULL, " ");
 

--- a/test/test9.c
+++ b/test/test9.c
@@ -361,7 +361,7 @@ void test1dOnConnect(void* context, MQTTAsync_successData* response)
 
 int test1c_connected = 0;
 
-void test1cConnected(void* context, char* cause)
+void test1cConnected(void* context, const char* cause)
 {
 	MQTTAsync c = (MQTTAsync)context;
 
@@ -637,7 +637,7 @@ void test2dOnConnect(void* context, MQTTAsync_successData* response)
 
 int test2c_connected = 0;
 
-void test2cConnected(void* context, char* cause)
+void test2cConnected(void* context, const char* cause)
 {
 	MQTTAsync c = (MQTTAsync)context;
 
@@ -914,7 +914,7 @@ void test3dOnConnect(void* context, MQTTAsync_successData* response)
 
 int test3c_connected = 0;
 
-void test3cConnected(void* context, char* cause)
+void test3cConnected(void* context, const char* cause)
 {
 	MQTTAsync c = (MQTTAsync)context;
 
@@ -1189,7 +1189,7 @@ void test4dOnConnect(void* context, MQTTAsync_successData* response)
 
 int test4c_connected = 0;
 
-void test4cConnected(void* context, char* cause)
+void test4cConnected(void* context, const char* cause)
 {
 	MQTTAsync c = (MQTTAsync)context;
 
@@ -1462,7 +1462,7 @@ void test5dOnConnect(void* context, MQTTAsync_successData* response)
 		test5Finished = 1;
 }
 
-void test5cConnected(void* context, char* cause)
+void test5cConnected(void* context, const char* cause)
 {
 	MQTTAsync c = (MQTTAsync)context;
 
@@ -1850,7 +1850,7 @@ int test7_messageArrived(void* context, char* topicName, int topicLen, MQTTAsync
 	return 1;
 }
 
-void test7cConnected(void* context, char* cause)
+void test7cConnected(void* context, const char* cause)
 {
 	MQTTAsync c = (MQTTAsync)context;
 

--- a/test/test9.c
+++ b/test/test9.c
@@ -446,10 +446,10 @@ int test1(struct Options options)
 
 	/* let client c go: connect, and send disconnect command to proxy */
 	opts.will = &wopts;
-	opts.will->message = "will message";
-	opts.will->qos = 1;
-	opts.will->retained = 0;
-	opts.will->topicName = willTopic;
+	wopts.message = "will message";
+	wopts.qos = 1;
+	wopts.retained = 0;
+	wopts.topicName = willTopic;
 	opts.onSuccess = test1cOnConnect;
 	opts.onFailure = test1cOnFailure;
 	opts.context = c;
@@ -721,10 +721,10 @@ int test2(struct Options options)
 
 	/* let client c go: connect, and send disconnect command to proxy */
 	opts.will = &wopts;
-	opts.will->message = "will message";
-	opts.will->qos = 1;
-	opts.will->retained = 0;
-	opts.will->topicName = willTopic;
+	wopts.message = "will message";
+	wopts.qos = 1;
+	wopts.retained = 0;
+	wopts.topicName = willTopic;
 	opts.onSuccess = test2cOnConnect;
 	opts.onFailure = test2cOnFailure;
 	opts.context = c;
@@ -999,10 +999,10 @@ int test3(struct Options options)
 
 	/* let client c go: connect, and send disconnect command to proxy */
 	opts.will = &wopts;
-	opts.will->message = "will message";
-	opts.will->qos = 1;
-	opts.will->retained = 0;
-	opts.will->topicName = willTopic;
+	wopts.message = "will message";
+	wopts.qos = 1;
+	wopts.retained = 0;
+	wopts.topicName = willTopic;
 	opts.onSuccess = test3cOnConnect;
 	opts.onFailure = test3cOnFailure;
 	opts.context = c;
@@ -1273,10 +1273,10 @@ int test4(struct Options options)
 
 	/* let client c go: connect, and send disconnect command to proxy */
 	opts.will = &wopts;
-	opts.will->message = "will message";
-	opts.will->qos = 1;
-	opts.will->retained = 0;
-	opts.will->topicName = willTopic;
+	wopts.message = "will message";
+	wopts.qos = 1;
+	wopts.retained = 0;
+	wopts.topicName = willTopic;
 	opts.onSuccess = test4cOnConnect;
 	opts.onFailure = test4cOnFailure;
 	opts.context = c;
@@ -1548,10 +1548,10 @@ int test5(struct Options options)
 
 	/* let client c go: connect, and send disconnect command to proxy */
 	opts.will = &wopts;
-	opts.will->message = "will message";
-	opts.will->qos = 1;
-	opts.will->retained = 0;
-	opts.will->topicName = willTopic;
+	wopts.message = "will message";
+	wopts.qos = 1;
+	wopts.retained = 0;
+	wopts.topicName = willTopic;
 	opts.onSuccess = test5cOnConnect;
 	opts.onFailure = test5cOnFailure;
 	opts.context = c;
@@ -1725,11 +1725,11 @@ int test6(struct Options options)
 
 	/* let client c go: connect, and send disconnect command to proxy */
 	opts.will = &wopts;
-	opts.will->payload.data = "will message";
-	opts.will->payload.len = strlen(opts.will->payload.data) + 1;
-	opts.will->qos = 1;
-	opts.will->retained = 0;
-	opts.will->topicName = willTopic;
+	wopts.payload.data = "will message";
+	wopts.payload.len = strlen(wopts.payload.data) + 1;
+	wopts.qos = 1;
+	wopts.retained = 0;
+	wopts.topicName = willTopic;
 	opts.onSuccess = test5cOnConnect;
 	opts.onFailure = test5cOnFailure;
 	opts.context = c;
@@ -2002,11 +2002,11 @@ int test7(struct Options options)
 
 	/* let client c go: connect, and send disconnect command to proxy */
 	opts.will = &wopts;
-	opts.will->payload.data = "will message";
-	opts.will->payload.len = strlen(opts.will->payload.data) + 1;
-	opts.will->qos = 1;
-	opts.will->retained = 0;
-	opts.will->topicName = willTopic;
+	wopts.payload.data = "will message";
+	wopts.payload.len = strlen(wopts.payload.data) + 1;
+	wopts.qos = 1;
+	wopts.retained = 0;
+	wopts.topicName = willTopic;
 	opts.onSuccess = test7cOnConnectSuccess;
 	opts.onFailure = test7cOnConnectFailure;
 	opts.context = c;

--- a/test/test9.c
+++ b/test/test9.c
@@ -347,7 +347,7 @@ void test1dOnConnect(void* context, MQTTAsync_successData* response)
 	MQTTAsync_responseOptions opts = MQTTAsync_responseOptions_initializer;
 	int rc;
 	int qoss[2] = {2, 2};
-	char* topics[2] = {willTopic, test_topic};
+	const char* topics[2] = {willTopic, test_topic};
 
 	MyLog(LOGA_DEBUG, "In connect onSuccess callback for client c, context %p\n", context);
 	opts.onSuccess = test1donSubscribe;
@@ -623,7 +623,7 @@ void test2dOnConnect(void* context, MQTTAsync_successData* response)
 	MQTTAsync_responseOptions opts = MQTTAsync_responseOptions_initializer;
 	int rc;
 	int qoss[2] = {2, 2};
-	char* topics[2] = {willTopic, test_topic};
+	const char* topics[2] = {willTopic, test_topic};
 
 	MyLog(LOGA_DEBUG, "In connect onSuccess callback for client c, context %p\n", context);
 	opts.onSuccess = test2donSubscribe;
@@ -900,7 +900,7 @@ void test3dOnConnect(void* context, MQTTAsync_successData* response)
 	MQTTAsync_responseOptions opts = MQTTAsync_responseOptions_initializer;
 	int rc;
 	int qoss[2] = {2, 2};
-	char* topics[2] = {willTopic, test_topic};
+	const char* topics[2] = {willTopic, test_topic};
 
 	MyLog(LOGA_DEBUG, "In connect onSuccess callback for client c, context %p\n", context);
 	opts.onSuccess = test3donSubscribe;
@@ -1175,7 +1175,7 @@ void test4dOnConnect(void* context, MQTTAsync_successData* response)
 	MQTTAsync_responseOptions opts = MQTTAsync_responseOptions_initializer;
 	int rc;
 	int qoss[2] = {2, 2};
-	char* topics[2] = {willTopic, test_topic};
+	const char* topics[2] = {willTopic, test_topic};
 
 	MyLog(LOGA_DEBUG, "In connect onSuccess callback for client c, context %p\n", context);
 	opts.onSuccess = test4donSubscribe;
@@ -1450,7 +1450,7 @@ void test5dOnConnect(void* context, MQTTAsync_successData* response)
 	MQTTAsync_responseOptions opts = MQTTAsync_responseOptions_initializer;
 	int rc;
 	int qoss[2] = {2, 2};
-	char* topics[2] = {willTopic, test_topic};
+	const char* topics[2] = {willTopic, test_topic};
 
 	MyLog(LOGA_DEBUG, "In connect onSuccess callback for client c, context %p\n", context);
 	opts.onSuccess = test5donSubscribe;


### PR DESCRIPTION
Good progress has been made in recent versions of the library to mark some strings and buffers as const. But it had not been completed. This attempts to go through and make the rest of them const.

Basically, I tried to go through the Async API and identify the pointers that were not being used to return values back to the application or were expected to be consumed/freed by the application. So anything pointing to a struct or buffer that is not being modified by the library is marked as const.