### PR TITLE
Tweaks to ssl hostname verification

### DIFF
--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -686,10 +686,15 @@ int SSLSocket_connect(SSL* ssl, int sock, char* hostname, int verify)
 		addr = MQTTProtocol_addressPort(hostname, &port);
 
 		rc = X509_check_host(cert, addr, strlen(addr), 0, &peername);
-		if (rc == 0)
-			rc = SOCKET_ERROR;
 		Log(TRACE_MIN, -1, "rc from X509_check_host is %d", rc);
 		Log(TRACE_MIN, -1, "peername from X509_check_host is %s", peername);
+		
+		if (peername != NULL)
+			OPENSSL_free(peername);
+
+		// 0 == fail, -1 == SSL internal error
+		if (rc == 0 || rc == -1)
+			rc = SSL_FATAL;
 
 		if (cert)
 			X509_free(cert);


### PR DESCRIPTION
Return SSL_FATAL, not SOCKET_ERROR so that connecting fails with a host we can't verify.
Also return an error for OpenSSL internal errors.
Free peername to avoid a memory leak.

Signed-off-by: Jasper Wallace <jasper@arcolaenergy.com>