### PR TITLE
prevent segfault for unknown protocol in test app

### DIFF
--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1319,7 +1319,14 @@ int MQTTClient_connect(MQTTClient handle, MQTTClient_connectOptions* options)
 	}
 
 	if (options->struct_version < 2 || options->serverURIcount == 0)
+	{
+		if ( !m )
+		{
+			rc = MQTTCLIENT_NULL_PARAMETER;
+			goto exit;
+		}
 		rc = MQTTClient_connectURI(handle, options, m->serverURI);
+	}
 	else
 	{
 		int i;
@@ -1354,7 +1361,7 @@ int MQTTClient_connect(MQTTClient handle, MQTTClient_connectOptions* options)
 	}
 
 exit:
-	if (m->c->will)
+	if (m && m->c && m->c->will)
 	{
 		if (m->c->will->payload)
 			free(m->c->will->payload);


### PR DESCRIPTION
This patch updates the source code to not seg fault when an unknown
protocol is specified on the command line in the test app: paho_cs_pub

Previously the output would be:
```
./paho_cs_pub my/topic --host bad://test.mosquitto.org --port 8081
Using topic my/topic
Connecting
Segmentation fault (core dumped)
```

After this patch the output is:
```
./paho_cs_pub my/topic --host bad://test.mosquitto.org --port 8081
Using topic my/topic
Connecting
Failed to connect
```

Signed-off-by: Keith Holman <keith.holman@windriver.com>