### PR TITLE
Compilation fix: using enum SUCCESS instead of MQTTASYNC_SUCCESS

### DIFF
--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -1111,7 +1111,7 @@ typedef struct
 	MQTTAsync_onFailure5* onFailure5;
 } MQTTAsync_disconnectOptions;
 
-#define MQTTAsync_disconnectOptions_initializer { {'M', 'Q', 'T', 'D'}, 1, 0, NULL, NULL, NULL, MQTTProperties_initializer, MQTTASYNC_SUCCESS }
+#define MQTTAsync_disconnectOptions_initializer { {'M', 'Q', 'T', 'D'}, 1, 0, NULL, NULL, NULL, MQTTProperties_initializer, SUCCESS }
 
 
 /**


### PR DESCRIPTION
This commit fixes compilation error:
MQTTAsync.h:1114:143: error: invalid conversion
from ‘int’ to ‘MQTTReasonCodes’ [-fpermissive]

Signed-off-by: Krzysztof Bogucki <kristofbo@gmail.com>