### PR TITLE
Fix missing headers included by MQTTAsync.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,9 @@ install: build
 	$(INSTALL_DATA) ${srcdir}/MQTTAsync.h $(DESTDIR)${includedir}
 	$(INSTALL_DATA) ${srcdir}/MQTTClient.h $(DESTDIR)${includedir}
 	$(INSTALL_DATA) ${srcdir}/MQTTClientPersistence.h $(DESTDIR)${includedir}
+	$(INSTALL_DATA) ${srcdir}/MQTTProperties.h $(DESTDIR)${includedir}
+	$(INSTALL_DATA) ${srcdir}/MQTTReasonCodes.h $(DESTDIR)${includedir}
+	$(INSTALL_DATA) ${srcdir}/MQTTSubscribeOpts.h $(DESTDIR)${includedir}
 
 uninstall:
 	rm $(DESTDIR)${libdir}/lib$(MQTTLIB_C).so.${VERSION}


### PR DESCRIPTION
[This commit](https://github.com/eclipse/paho.mqtt.c/commit/167278c0a86f9be20bf4844361f899c582a03ef4#diff-6ab3a9fbd63bca246817a977fd995db4) included three new header files: `MQTTProperties.h`, `MQTTReasonCodes.h`, `MQTTSubscribeOpts.h`.
`
I believe this should be reflected in the Makefile.