### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,7 @@ ${ASYNC_UTILS}: ${blddir}/samples/%: ${srcdir}/samples/%.c ${srcdir}/samples/pub
 	${CC} -o $@ $< -l${MQTTLIB_AS} ${FLAGS_EXES} ${srcdir}/samples/pubsub_opts.c
 
 $(blddir_work)/VersionInfo.h: $(srcdir)/VersionInfo.h.in
+	-mkdir -p $(blddir_work)
 	$(SED_COMMAND) $< > $@
 
 ${MQTTLIB_C_TARGET}: ${SOURCE_FILES_C} ${HEADERS_C} $(blddir_work)/VersionInfo.h


### PR DESCRIPTION
When the library is built in a _Yocto_ environment, make is called with the _-j_ option to parallelize the build.
In this case, the _VersionInfo.h_ creation with _sed_ can be launched at the same time than the _mkdir_ target and sometimes _sed_ is executed before the actual directory creation.

Here is the error log:

```shell
$ sed -e "s/@CLIENT_VERSION@/1.2.1/g" -e "s/@BUILD_TIMESTAMP@/Thu Aug  2 10:21:03 UTC 2018/g" src/VersionInfo.h.in > build/VersionInfo.h
cannot create build/VersionInfo.h: Directory nonexistent
```

The idea of this commit is to ensure that the directory is created before calling _sed_ by adding a call to _mkdir_ in the _VersionInfo.h_'s Makefile recipe.