### PR TITLE
Add OpenSSL error handler callback function and context

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -2702,7 +2702,7 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 	}
 	if (options->struct_version != 0 && options->ssl) /* check validity of SSL options structure */
 	{
-		if (strncmp(options->ssl->struct_id, "MQTS", 4) != 0 || options->ssl->struct_version < 0 || options->ssl->struct_version > 2)
+		if (strncmp(options->ssl->struct_id, "MQTS", 4) != 0 || options->ssl->struct_version < 0 || options->ssl->struct_version > 3)
 		{
 			rc = MQTTASYNC_BAD_STRUCTURE;
 			goto exit;

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -2859,6 +2859,11 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 			if (options->ssl->CApath)
 				m->c->sslopts->CApath = MQTTStrdup(options->ssl->CApath);
 		}
+		if (m->c->sslopts->struct_version >= 3)
+		{
+			m->c->sslopts->ssl_error_cb = options->ssl->ssl_error_cb;
+			m->c->sslopts->ssl_error_context = options->ssl->ssl_error_context;
+		}
 	}
 #else
 	if (options->struct_version != 0 && options->ssl)

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -3449,8 +3449,11 @@ static int MQTTAsync_connecting(MQTTAsyncs* m)
 				if (m->c->session != NULL)
 					if ((rc = SSL_set_session(m->c->net.ssl, m->c->session)) != 1)
 						Log(TRACE_MIN, -1, "Failed to set SSL session with stored data, non critical");
-				rc = SSLSocket_connect(m->c->net.ssl, m->c->net.socket,
-						m->serverURI, m->c->sslopts->verify);
+				rc = m->c->sslopts->struct_version >= 3 ?
+					SSLSocket_connect(m->c->net.ssl, m->c->net.socket, m->serverURI,
+						m->c->sslopts->verify, m->c->sslopts->ssl_error_cb, m->c->sslopts->ssl_error_context) :
+					SSLSocket_connect(m->c->net.ssl, m->c->net.socket, m->serverURI,
+						m->c->sslopts->verify, NULL, NULL);
 				if (rc == TCPSOCKET_INTERRUPTED)
 				{
 					rc = MQTTCLIENT_SUCCESS; /* the connect is still in progress */
@@ -3513,8 +3516,12 @@ static int MQTTAsync_connecting(MQTTAsyncs* m)
 #if defined(OPENSSL)
 	else if (m->c->connect_state == SSL_IN_PROGRESS) /* SSL connect sent - wait for completion */
 	{
-		if ((rc = SSLSocket_connect(m->c->net.ssl, m->c->net.socket,
-				m->serverURI, m->c->sslopts->verify)) != 1)
+		rc = m->c->sslopts->struct_version >= 3 ?
+			SSLSocket_connect(m->c->net.ssl, m->c->net.socket, m->serverURI,
+				m->c->sslopts->verify, m->c->sslopts->ssl_error_cb, m->c->sslopts->ssl_error_context) :
+			SSLSocket_connect(m->c->net.ssl, m->c->net.socket, m->serverURI,
+				m->c->sslopts->verify, NULL, NULL);
+		if (rc != 1)
 			goto exit;
 
 		if(!m->c->cleansession && m->c->session == NULL)

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -944,9 +944,21 @@ typedef struct
      * Exists only if struct_version >= 2
 	 */
 	const char* CApath;
+
+    /**
+     * Callback function for OpenSSL error handler ERR_print_errors_cb
+     * Exists only if struct_version >= 3
+     */
+    int (*ssl_error_cb) (const char *str, size_t len, void *u);
+
+    /**
+     * Application-specific contex for OpenSSL error handler ERR_print_errors_cb
+     * Exists only if struct_version >= 3
+     */
+    void* ssl_error_context;
 } MQTTAsync_SSLOptions;
 
-#define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 2, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL }
+#define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 3, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL }
 
 /**
  * MQTTAsync_connectOptions defines several settings that control the way the

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1540,7 +1540,7 @@ MQTTResponse MQTTClient_connect5(MQTTClient handle, MQTTClient_connectOptions* o
 #if defined(OPENSSL)
 	if (options->struct_version != 0 && options->ssl) /* check validity of SSL options structure */
 	{
-		if (strncmp(options->ssl->struct_id, "MQTS", 4) != 0 || options->ssl->struct_version < 0 || options->ssl->struct_version > 2)
+		if (strncmp(options->ssl->struct_id, "MQTS", 4) != 0 || options->ssl->struct_version < 0 || options->ssl->struct_version > 3)
 		{
 			rc.reasonCode = MQTTCLIENT_BAD_STRUCTURE;
 			goto exit;

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1443,6 +1443,11 @@ static MQTTResponse MQTTClient_connectURI(MQTTClient handle, MQTTClient_connectO
 			if (options->ssl->CApath)
 				m->c->sslopts->CApath = MQTTStrdup(options->ssl->CApath);
 		}
+		if (m->c->sslopts->struct_version >= 3)
+		{
+			m->c->sslopts->ssl_error_cb = options->ssl->ssl_error_cb;
+			m->c->sslopts->ssl_error_context = options->ssl->ssl_error_context;
+		}
 	}
 #endif
 

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -882,8 +882,11 @@ static thread_return_type WINAPI MQTTClient_run(void* n)
 #if defined(OPENSSL)
 			else if (m->c->connect_state == SSL_IN_PROGRESS)
 			{
-				rc = SSLSocket_connect(m->c->net.ssl, m->c->net.socket,
-						m->serverURI, m->c->sslopts->verify);
+				rc = m->c->sslopts->struct_version >= 3 ?
+					SSLSocket_connect(m->c->net.ssl, m->c->net.socket, m->serverURI, 
+						m->c->sslopts->verify, m->c->sslopts->ssl_error_cb, m->c->sslopts->ssl_error_context) :
+					SSLSocket_connect(m->c->net.ssl, m->c->net.socket, m->serverURI,
+						m->c->sslopts->verify, NULL, NULL);
 				if (rc == 1 || rc == SSL_FATAL)
 				{
 					if (rc == 1 && (m->c->cleansession == 0 && m->c->cleanstart == 0) && m->c->session == NULL)
@@ -1138,8 +1141,11 @@ static MQTTResponse MQTTClient_connectURIVersion(MQTTClient handle, MQTTClient_c
 				if (m->c->session != NULL)
 					if ((rc = SSL_set_session(m->c->net.ssl, m->c->session)) != 1)
 						Log(TRACE_MIN, -1, "Failed to set SSL session with stored data, non critical");
-				rc = SSLSocket_connect(m->c->net.ssl, m->c->net.socket,
-						m->serverURI, m->c->sslopts->verify);
+				rc = m->c->sslopts->struct_version >= 3 ?
+					SSLSocket_connect(m->c->net.ssl, m->c->net.socket, m->serverURI,
+						m->c->sslopts->verify, m->c->sslopts->ssl_error_cb, m->c->sslopts->ssl_error_context) :
+					SSLSocket_connect(m->c->net.ssl, m->c->net.socket, m->serverURI,
+						m->c->sslopts->verify, NULL, NULL);
 				if (rc == TCPSOCKET_INTERRUPTED)
 					m->c->connect_state = SSL_IN_PROGRESS;  /* the connect is still in progress */
 				else if (rc == SSL_FATAL)
@@ -2380,8 +2386,11 @@ static MQTTPacket* MQTTClient_waitfor(MQTTClient handle, int packet_type, int* r
 #if defined(OPENSSL)
 				else if (m->c->connect_state == SSL_IN_PROGRESS)
 				{
-					*rc = SSLSocket_connect(m->c->net.ssl, sock,
-							m->serverURI, m->c->sslopts->verify);
+					*rc = m->c->sslopts->struct_version >= 3 ?
+						SSLSocket_connect(m->c->net.ssl, sock, m->serverURI,
+							m->c->sslopts->verify, m->c->sslopts->ssl_error_cb, m->c->sslopts->ssl_error_context) :
+						SSLSocket_connect(m->c->net.ssl, sock, m->serverURI,
+							m->c->sslopts->verify, NULL, NULL);
 					if (*rc == SSL_FATAL)
 						break;
 					else if (*rc == 1) /* rc == 1 means SSL connect has finished and succeeded */

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -694,9 +694,21 @@ typedef struct
 	 */
 	const char* CApath;
 
+    /**
+     * Callback function for OpenSSL error handler ERR_print_errors_cb
+     * Exists only if struct_version >= 3
+     */
+    int (*ssl_error_cb) (const char *str, size_t len, void *u);
+
+    /**
+     * Application-specific contex for OpenSSL error handler ERR_print_errors_cb
+     * Exists only if struct_version >= 3
+     */
+    void* ssl_error_context;
+
 } MQTTClient_SSLOptions;
 
-#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 2, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL }
+#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 3, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL }
 
 /**
  * MQTTClient_connectOptions defines several settings that control the way the

--- a/src/MQTTProtocolOut.c
+++ b/src/MQTTProtocolOut.c
@@ -125,8 +125,11 @@ int MQTTProtocol_connect(const char* ip_address, Clients* aClient, int websocket
 		{
 			if (SSLSocket_setSocketForSSL(&aClient->net, aClient->sslopts, ip_address, addr_len) == 1)
 			{
-				rc = SSLSocket_connect(aClient->net.ssl, aClient->net.socket,
-						ip_address, aClient->sslopts->verify);
+				rc = aClient->sslopts->struct_version >= 3 ?
+					SSLSocket_connect(aClient->net.ssl, aClient->net.socket, ip_address,
+						aClient->sslopts->verify, aClient->sslopts->ssl_error_cb, aClient->sslopts->ssl_error_context) :
+					SSLSocket_connect(aClient->net.ssl, aClient->net.socket, ip_address,
+						aClient->sslopts->verify, NULL, NULL);
 				if (rc == TCPSOCKET_INTERRUPTED)
 					aClient->connect_state = SSL_IN_PROGRESS; /* SSL connect called - wait for completion */
 			}

--- a/src/SSLSocket.h
+++ b/src/SSLSocket.h
@@ -44,7 +44,7 @@ char *SSLSocket_getdata(SSL* ssl, int socket, size_t bytes, size_t* actual_len);
 
 int SSLSocket_close(networkHandles* net);
 int SSLSocket_putdatas(SSL* ssl, int socket, char* buf0, size_t buf0len, int count, char** buffers, size_t* buflens, int* frees);
-int SSLSocket_connect(SSL* ssl, int sock, const char* hostname, int verify);
+int SSLSocket_connect(SSL* ssl, int sock, const char* hostname, int verify, int (*cb)(const char *str, size_t len, void *u), void* u);
 
 int SSLSocket_getPendingRead(void);
 int SSLSocket_continueWrite(pending_writes* pw);

--- a/src/samples/paho_c_pub.c
+++ b/src/samples/paho_c_pub.c
@@ -206,6 +206,13 @@ void onPublish(void* context, MQTTAsync_successData* response)
 }
 
 
+static int onSSLError(const char *str, size_t len, void *context)
+{
+	MQTTAsync client = (MQTTAsync)context;
+	return fprintf(stderr, "SSL error: %s\n", str);
+}
+
+
 void myconnect(MQTTAsync client)
 {
 	MQTTAsync_connectOptions conn_opts = MQTTAsync_connectOptions_initializer;
@@ -256,6 +263,8 @@ void myconnect(MQTTAsync client)
 		ssl_opts.privateKey = opts.key;
 		ssl_opts.privateKeyPassword = opts.keypass;
 		ssl_opts.enabledCipherSuites = opts.ciphers;
+		ssl_opts.ssl_error_cb = onSSLError;
+		ssl_opts.ssl_error_context = client;
 		conn_opts.ssl = &ssl_opts;
 	}
 


### PR DESCRIPTION
* Add new members to SSL options structures MQTTClient_SSLOptions / MQTTAsync_SSLOptions to set an application-specific OpenSSL error handler callback function and context
* Increment the structure version and fall back to nullified error handler, i.e., no more OpenSSL messages are printed to stderr
* This removes the error reporting for SSLSocket_getch, SSLSocket_getdata, SSLSocket_putdatas and SSLSocket_continueWrite where the SSL options structure is not trivially available

Close #326