### PR TITLE
Fix VS2010 macro redefinition warnings

### DIFF
--- a/src/Socket.h
+++ b/src/Socket.h
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 
 #if defined(WIN32) || defined(WIN64)
+#include <errno.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #define MAXHOSTNAMELEN 256


### PR DESCRIPTION
```
ClCompile:
  SSLSocket.c
C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\errno.h(43): warning C4005: 'EINTR': macro redefinition
          C:\Projects\paho.mqtt.c\src\Socket.h(31): see previous definition of 'EINTR'
C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\errno.h(50): warning C4005: 'EAGAIN': macro redefinition
          C:\Projects\paho.mqtt.c\src\Socket.h(29): see previous definition of 'EAGAIN'
C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\errno.h(100): warning C4005: 'ECONNRESET': macro redefinition
          C:\Projects\paho.mqtt.c\src\Socket.h(39): see previous definition of 'ECONNRESET'
C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\errno.h(104): warning C4005: 'EINPROGRESS': macro redefinition
          C:\Projects\paho.mqtt.c\src\Socket.h(33): see previous definition of 'EINPROGRESS'
C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\errno.h(118): warning C4005: 'ENOTCONN': macro redefinition
          C:\Projects\paho.mqtt.c\src\Socket.h(37): see previous definition of 'ENOTCONN'
C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\errno.h(130): warning C4005: 'ETIMEDOUT': macro redefinition
          C:\Projects\paho.mqtt.c\src\Thread.h(35): see previous definition of 'ETIMEDOUT'
C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\errno.h(132): warning C4005: 'EWOULDBLOCK': macro redefinition
          C:\Projects\paho.mqtt.c\src\Socket.h(35): see previous definition of 'EWOULDBLOCK'
```

Reason is that VS2010 (implicitly) includes errno.h by inclusion of openssl/err.h, hence after inclusion of Socket.h. Whereas, VS2015 (implicitly) includes errno.h by inclusion of SocketBuffer.h, hence before Socket.h.

Hint: Compilation with `/showIncludes` reveals the inclusion hierarchy.