### PR TITLE
Flexible yet secure SSL/TLS version

### DIFF
--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -889,6 +889,9 @@ typedef struct
 #define MQTT_SSL_VERSION_TLS_1_0 1
 #define MQTT_SSL_VERSION_TLS_1_1 2
 #define MQTT_SSL_VERSION_TLS_1_2 3
+#define MQTT_SSL_VERSION_TLS_1_0_OR_HIGHER 4
+#define MQTT_SSL_VERSION_TLS_1_1_OR_HIGHER 5
+#define MQTT_SSL_VERSION_TLS_1_2_OR_HIGHER 6
 
 /**
 * MQTTAsync_sslProperties defines the settings to establish an SSL/TLS connection using the

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -634,6 +634,9 @@ typedef struct
 #define MQTT_SSL_VERSION_TLS_1_0 1
 #define MQTT_SSL_VERSION_TLS_1_1 2
 #define MQTT_SSL_VERSION_TLS_1_2 3
+#define MQTT_SSL_VERSION_TLS_1_0_OR_HIGHER 4
+#define MQTT_SSL_VERSION_TLS_1_1_OR_HIGHER 5
+#define MQTT_SSL_VERSION_TLS_1_2_OR_HIGHER 6
 
 /**
 * MQTTClient_sslProperties defines the settings to establish an SSL/TLS connection using the

--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -536,15 +536,33 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts)
 		case MQTT_SSL_VERSION_TLS_1_0:
 			net->ctx = SSL_CTX_new(TLSv1_client_method());
 			break;
+		case MQTT_SSL_VERSION_TLS_1_0_OR_HIGHER:
+			net->ctx = SSL_CTX_new(SSLv23_client_method());
+			SSL_CTX_set_options(net->ctx, SSL_OP_NO_SSLv2);
+			SSL_CTX_set_options(net->ctx, SSL_OP_NO_SSLv3);
+			break;
 #endif
 #if defined(SSL_OP_NO_TLSv1_1) && !defined(OPENSSL_NO_TLS1)
 		case MQTT_SSL_VERSION_TLS_1_1:
 			net->ctx = SSL_CTX_new(TLSv1_1_client_method());
 			break;
+		case MQTT_SSL_VERSION_TLS_1_1_OR_HIGHER:
+			net->ctx = SSL_CTX_new(SSLv23_client_method());
+			SSL_CTX_set_options(net->ctx, SSL_OP_NO_SSLv2);
+			SSL_CTX_set_options(net->ctx, SSL_OP_NO_SSLv3);
+			SSL_CTX_set_options(net->ctx, SSL_OP_NO_TLSv1);
+			break;
 #endif
 #if defined(SSL_OP_NO_TLSv1_2) && !defined(OPENSSL_NO_TLS1)
 		case MQTT_SSL_VERSION_TLS_1_2:
 			net->ctx = SSL_CTX_new(TLSv1_2_client_method());
+			break;
+		case MQTT_SSL_VERSION_TLS_1_2_OR_HIGHER:
+			net->ctx = SSL_CTX_new(SSLv23_client_method());
+			SSL_CTX_set_options(net->ctx, SSL_OP_NO_SSLv2);
+			SSL_CTX_set_options(net->ctx, SSL_OP_NO_SSLv3);
+			SSL_CTX_set_options(net->ctx, SSL_OP_NO_TLSv1);
+			SSL_CTX_set_options(net->ctx, SSL_OP_NO_TLSv1_1);
 			break;
 #endif
 		default:


### PR DESCRIPTION
Add SSL/TLS version options MQTT_SSL_VERSION_TLS_1_0_OR_HIGHER, MQTT_SSL_VERSION_TLS_1_1_OR_HIGHER and MQTT_SSL_VERSION_TLS_1_2_OR_HIGHER, which can be used to disable outdated versions, but will include future versions
See #545