### PR TITLE
Fix compilation with VS2010

### DIFF
--- a/src/Log.c
+++ b/src/Log.c
@@ -3,11 +3,11 @@
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
- * and Eclipse Distribution License v1.0 which accompany this distribution. 
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
- * The Eclipse Public License is available at 
+ * The Eclipse Public License is available at
  *    http://www.eclipse.org/legal/epl-v10.html
- * and the Eclipse Distribution License is available at 
+ * and the Eclipse Distribution License is available at
  *   http://www.eclipse.org/org/documents/edl-v10.php.
  *
  * Contributors:
@@ -20,7 +20,7 @@
  * @file
  * \brief Logging and tracing module
  *
- * 
+ *
  */
 
 #include "Log.h"
@@ -133,6 +133,9 @@ int Log_initialize(Log_nameValue* info)
 {
 	int rc = -1;
 	char* envval = NULL;
+#if !defined(WIN32) && !defined(WIN64)
+	struct stat buf;
+#endif
 
 	if ((trace_queue = malloc(sizeof(traceEntry) * trace_settings.max_trace_entries)) == NULL)
 		return rc;
@@ -181,15 +184,14 @@ int Log_initialize(Log_nameValue* info)
 		}
 	}
 #if !defined(WIN32) && !defined(WIN64)
-	struct stat buf;
 	if (stat("/proc/version", &buf) != -1)
 	{
 		FILE* vfile;
-		
+
 		if ((vfile = fopen("/proc/version", "r")) != NULL)
 		{
 			int len;
-			
+
 			strcpy(msg_buf, "/proc/version: ");
 			len = strlen(msg_buf);
 			if (fgets(&msg_buf[len], sizeof(msg_buf) - len, vfile))
@@ -199,7 +201,7 @@ int Log_initialize(Log_nameValue* info)
 	}
 #endif
 	Log_output(TRACE_MINIMUM, "=========================================================");
-		
+
 	return rc;
 }
 
@@ -339,9 +341,9 @@ static void Log_output(enum LOG_LEVELS log_level, const char *msg)
 		fprintf(trace_destination, "%s\n", msg);
 
 		if (trace_destination != stdout && ++lines_written >= max_lines_per_file)
-		{	
+		{
 
-			fclose(trace_destination);		
+			fclose(trace_destination);
 			_unlink(trace_destination_backup_name); /* remove any old backup trace file */
 			rename(trace_destination_name, trace_destination_backup_name); /* rename recently closed to backup */
 			trace_destination = fopen(trace_destination_name, "w"); /* open new trace file */
@@ -352,7 +354,7 @@ static void Log_output(enum LOG_LEVELS log_level, const char *msg)
 		else
 			fflush(trace_destination);
 	}
-		
+
 	if (trace_callback)
 		(*trace_callback)(log_level, msg);
 }
@@ -363,10 +365,10 @@ static void Log_posttrace(enum LOG_LEVELS log_level, traceEntry* cur_entry)
 	if (((trace_output_level == -1) ? log_level >= trace_settings.trace_level : log_level >= trace_output_level))
 	{
 		char* msg = NULL;
-		
+
 		if (trace_destination || trace_callback)
 			msg = &Log_formatTraceEntry(cur_entry)[7];
-		
+
 		Log_output(log_level, msg);
 	}
 }
@@ -409,7 +411,7 @@ void Log(enum LOG_LEVELS log_level, int msgno, const char *format, ...)
 		va_list args;
 
 		/* we're using a static character buffer, so we need to make sure only one thread uses it at a time */
-		Thread_lock_mutex(log_mutex); 
+		Thread_lock_mutex(log_mutex);
 		if (format == NULL && (temp = Messages_get(msgno, log_level)) != NULL)
 			format = temp;
 
@@ -418,7 +420,7 @@ void Log(enum LOG_LEVELS log_level, int msgno, const char *format, ...)
 
 		Log_trace(log_level, msg_buf);
 		va_end(args);
-		Thread_unlock_mutex(log_mutex); 
+		Thread_unlock_mutex(log_mutex);
 	}
 }
 

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1499,11 +1499,12 @@ MQTTResponse MQTTClient_connectAll(MQTTClient handle, MQTTClient_connectOptions*
 int MQTTClient_connect(MQTTClient handle, MQTTClient_connectOptions* options)
 {
 	MQTTClients* m = handle;
+        MQTTResponse response;
 
 	if (m->c->MQTTVersion >= MQTTVERSION_5)
 		return MQTTCLIENT_WRONG_MQTT_VERSION;
 
-	MQTTResponse response = MQTTClient_connectAll(handle, options, NULL, NULL);
+	response = MQTTClient_connectAll(handle, options, NULL, NULL);
 
 	return response.reasonCode;
 }

--- a/src/MQTTPersistence.c
+++ b/src/MQTTPersistence.c
@@ -199,6 +199,7 @@ int MQTTPersistence_restore(Clients *c)
 			{
 				int data_MQTTVersion = MQTTVERSION_3_1_1;
 				char* cur_key = msgkeys[i];
+                                MQTTPacket* pack = NULL;
 
 				if (	strncmp(cur_key, PERSISTENCE_V5_PUBLISH_RECEIVED,
 							strlen(PERSISTENCE_V5_PUBLISH_RECEIVED)) == 0)
@@ -225,7 +226,7 @@ int MQTTPersistence_restore(Clients *c)
 					goto exit;
 				}
 
-				MQTTPacket* pack = MQTTPersistence_restorePacket(data_MQTTVersion, buffer, buflen);
+				pack = MQTTPersistence_restorePacket(data_MQTTVersion, buffer, buflen);
 				if ( pack != NULL )
 				{
 					if (strncmp(cur_key, PERSISTENCE_PUBLISH_RECEIVED,

--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -101,8 +101,8 @@ void uuid_generate( uuid_t out )
 #endif /* defined (OPENSSL) */
 	{
 		/* very insecure, but generates a random uuid */
-		srand(time(NULL));
 		int i;
+		srand(time(NULL));
 		for ( i = 0; i < 16; ++i )
 			out[i] = (unsigned char)(rand() % UCHAR_MAX);
 		out[6] = (out[6] & 0x0f) | 0x40;

--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -314,6 +314,11 @@ int WebSocket_connect( networkHandles *net, const char *uri )
 	size_t hostname_len;
 	int port = 80;
 	const char *topic = NULL;
+#if defined(WIN32) || defined(WIN64)
+	UUID uuid;
+#else /* if defined(WIN32) || defined(WIN64) */
+	uuid_t uuid;
+#endif /* else if defined(WIN32) || defined(WIN64) */
 
 	FUNC_ENTRY;
 	/* Generate UUID */
@@ -322,12 +327,10 @@ int WebSocket_connect( networkHandles *net, const char *uri )
 	else
 		net->websocket_key = realloc(net->websocket_key, 25u);
 #if defined(WIN32) || defined(WIN64)
-	UUID uuid;
 	ZeroMemory( &uuid, sizeof(UUID) );
 	UuidCreate( &uuid );
 	Base64_encode( net->websocket_key, 25u, (const b64_data_t*)&uuid, sizeof(UUID) );
 #else /* if defined(WIN32) || defined(WIN64) */
-	uuid_t uuid;
 	uuid_generate( uuid );
 	Base64_encode( net->websocket_key, 25u, uuid, sizeof(uuid_t) );
 #endif /* else if defined(WIN32) || defined(WIN64) */


### PR DESCRIPTION
Until VS2013, all variables should be defined at the beggining of a block. This patch solves the issue.

Signed-off-by: Adrian Moran <amoran@ikerlan.es>