### PR TITLE
Remove unneeded variable declaration.

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -2138,7 +2138,7 @@ static thread_return_type WINAPI MQTTAsync_receiveThread(void* n)
 				{
 					Connack* connack = (Connack*)pack;
 					int sessionPresent = connack->flags.bits.sessionPresent;
-          
+
 					rc = MQTTAsync_completeConnection(m, connack);
 					if (rc == MQTTASYNC_SUCCESS)
 					{
@@ -2441,7 +2441,7 @@ int MQTTAsync_setCallbacks(MQTTAsync handle, void* context,
 	return rc;
 }
 
-int MQTTAsync_setConnectionLostCallback(MQTTAsync handle, void* context, 
+int MQTTAsync_setConnectionLostCallback(MQTTAsync handle, void* context,
 										MQTTAsync_connectionLost* cl)
 {
 	int rc = MQTTASYNC_SUCCESS;
@@ -2464,7 +2464,7 @@ int MQTTAsync_setConnectionLostCallback(MQTTAsync handle, void* context,
 }
 
 
-int MQTTAsync_setMessageArrivedCallback(MQTTAsync handle, void* context, 
+int MQTTAsync_setMessageArrivedCallback(MQTTAsync handle, void* context,
 										MQTTAsync_messageArrived* ma)
 {
 	int rc = MQTTASYNC_SUCCESS;
@@ -2486,7 +2486,7 @@ int MQTTAsync_setMessageArrivedCallback(MQTTAsync handle, void* context,
 	return rc;
 }
 
-int MQTTAsync_setDeliveryCompleteCallback(MQTTAsync handle, void* context, 
+int MQTTAsync_setDeliveryCompleteCallback(MQTTAsync handle, void* context,
 										  MQTTAsync_deliveryComplete* dc)
 {
 	int rc = MQTTASYNC_SUCCESS;
@@ -3281,9 +3281,8 @@ exit:
 int MQTTAsync_subscribe(MQTTAsync handle, const char* topic, int qos, MQTTAsync_responseOptions* response)
 {
 	int rc = 0;
-	char *const topics[] = {(char*)topic};
 	FUNC_ENTRY;
-	rc = MQTTAsync_subscribeMany(handle, 1, topics, &qos, response);
+	rc = MQTTAsync_subscribeMany(handle, 1, (char * const *)(&topic), &qos, response);
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
@@ -3362,9 +3361,8 @@ exit:
 int MQTTAsync_unsubscribe(MQTTAsync handle, const char* topic, MQTTAsync_responseOptions* response)
 {
 	int rc = 0;
-	char *const topics[] = {(char*)topic};
 	FUNC_ENTRY;
-	rc = MQTTAsync_unsubscribeMany(handle, 1, topics, response);
+	rc = MQTTAsync_unsubscribeMany(handle, 1, (char * const *)(&topic), response);
 	FUNC_EXIT_RC(rc);
 	return rc;
 }

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -883,7 +883,7 @@ static thread_return_type WINAPI MQTTClient_run(void* n)
 			else if (m->c->connect_state == SSL_IN_PROGRESS)
 			{
 				rc = m->c->sslopts->struct_version >= 3 ?
-					SSLSocket_connect(m->c->net.ssl, m->c->net.socket, m->serverURI, 
+					SSLSocket_connect(m->c->net.ssl, m->c->net.socket, m->serverURI,
 						m->c->sslopts->verify, m->c->sslopts->ssl_error_cb, m->c->sslopts->ssl_error_context) :
 					SSLSocket_connect(m->c->net.ssl, m->c->net.socket, m->serverURI,
 						m->c->sslopts->verify, NULL, NULL);
@@ -1922,10 +1922,9 @@ MQTTResponse MQTTClient_subscribe5(MQTTClient handle, const char* topic, int qos
 		MQTTSubscribe_options* opts, MQTTProperties* props)
 {
 	MQTTResponse rc;
-	char *const topics[] = {(char*)topic};
 
 	FUNC_ENTRY;
-	rc = MQTTClient_subscribeMany5(handle, 1, topics, &qos, opts, props);
+	rc = MQTTClient_subscribeMany5(handle, 1, (char * const *)(&topic), &qos, opts, props);
 	if (qos == MQTT_BAD_SUBSCRIBE) /* addition for MQTT 3.1.1 - error code from subscribe */
 		rc.reasonCode = MQTT_BAD_SUBSCRIBE;
 	FUNC_EXIT_RC(rc.reasonCode);
@@ -2054,9 +2053,8 @@ int MQTTClient_unsubscribeMany(MQTTClient handle, int count, char* const* topic)
 MQTTResponse MQTTClient_unsubscribe5(MQTTClient handle, const char* topic, MQTTProperties* props)
 {
 	MQTTResponse rc;
-	char *const topics[] = {(char*)topic};
 
-	rc = MQTTClient_unsubscribeMany5(handle, 1, topics, props);
+	rc = MQTTClient_unsubscribeMany5(handle, 1, (char * const *)(&topic), props);
 	return rc;
 }
 


### PR DESCRIPTION
IMHO, it's clearest with the direct casting. Moreover, it avoid warnings/errors with certain compilers.

Signed-off-by: Adrian Moran <amoran@ikerlan.es>