### PR TITLE
if CApath is set load the PEM files

### DIFF
--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -594,9 +594,9 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts)
 		}
 	}
 
-	if (opts->trustStore)
+	if (opts->trustStore || opts->CApath)
 	{
-		if ((rc = SSL_CTX_load_verify_locations(net->ctx, opts->trustStore, NULL)) != 1)
+		if ((rc = SSL_CTX_load_verify_locations(net->ctx, opts->trustStore, opts->CApath)) != 1)
 		{
 			if (opts->struct_version >= 3)
 				SSLSocket_error("SSL_CTX_load_verify_locations", NULL, net->socket, rc, opts->ssl_error_cb, opts->ssl_error_context);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -456,6 +456,16 @@ ADD_TEST(
 	COMMAND test5 "--test_no" "8" "--hostname" ${MQTT_SSL_HOSTNAME} "--client_key" 	"${CERTDIR}/client.pem" "--server_key"	"${CERTDIR}/test-root-ca.crt"
 )
 
+ADD_TEST(
+	NAME test5-5-server-verify-with-capath
+	COMMAND test5 "--test_no" "9" "--hostname" ${MQTT_SSL_HOSTNAME} "--client_key" 	"${CERTDIR}/client.pem" "--server_key"	"${CERTDIR}/test-root-ca.crt"
+)
+
+ADD_TEST(
+	NAME test5-6-server-verify-with-capath
+	COMMAND test5 "--test_no" "10" "--hostname" ${MQTT_SSL_HOSTNAME} "--client_key" 	"${CERTDIR}/client.pem" "--server_key"	"${CERTDIR}/test-root-ca.crt"
+)
+
 SET_TESTS_PROPERTIES(
 	test5-1-ssl-connection-to-no-SSL-server
 	test5-2a-multual-ssl-auth-certificates-in-place
@@ -465,6 +475,8 @@ SET_TESTS_PROPERTIES(
 	test5-3a-server-auth-server-cert-in-client-store
 	test5-3b-server-auth-client-missing-broker-cert
 	test5-4-accept-invalid-certificates
+	test5-5-server-verify-with-capath
+	test5-6-server-verify-with-capath
 	PROPERTIES TIMEOUT 540
 )
 


### PR DESCRIPTION
i tried to use CApath but enableServerCertAuth always failed

It happens because we never load the certs from the given path.

in 695563fccb5d3add93c46a9562dbdc9f6afa5a57 the loading option is missing

Signed-off-by: Kilian von Pflugk <github@jumoog.io>