### PR TITLE
Linking under Windows (MinGW 5.3.0)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ SET(common_src
     )
 
 IF (WIN32)
-    SET(LIBS_SYSTEM ws2_32)
+    SET(LIBS_SYSTEM ws2_32 crypt32 RpcRT4)
 ELSEIF (UNIX)
     IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
         SET(LIBS_SYSTEM c dl pthread)


### PR DESCRIPTION
Need of link crypt32 and RpcRT4 for referencing 'CryptStringToBinary' and 'UUidCreate' in a mingw toolchain environment. 

src/CMakeFiles/common_obj.dir/Base64.c.obj:Base64.c:(.text+0x44): undefined reference to `_imp__CryptStringToBinaryA@28'
src/CMakeFiles/common_obj.dir/Base64.c.obj:Base64.c:(.text+0x94): undefined reference to `_imp__CryptBinaryToStringA@20'
src/CMakeFiles/common_obj.dir/WebSocket.c.obj:WebSocket.c:(.text+0xe1): undefined reference to `_imp__UuidCreate@4'