### PR TITLE
update MQTTAsync callback functions documentation

### DIFF
--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -325,6 +325,9 @@ typedef struct
  * called by the client library when a new message that matches a client
  * subscription has been received from the server. This function is executed on
  * a separate thread to the one on which the client application is running.
+ *
+ * <b>Note:</b> Neither MQTTAsync_create() nor MQTTAsync_destroy() should be
+ * called within this callback.
  * @param context A pointer to the <i>context</i> value originally passed to
  * MQTTAsync_setCallbacks(), which contains any application-specific context.
  * @param topicName The topic associated with the received message.
@@ -355,6 +358,9 @@ typedef int MQTTAsync_messageArrived(void* context, char* topicName, int topicLe
  * handshaking and acknowledgements for the requested quality of service (see
  * MQTTAsync_message.qos) have been completed. This function is executed on a
  * separate thread to the one on which the client application is running.
+ *
+ * <b>Note:</b> Neither MQTTAsync_create() nor MQTTAsync_destroy() should be
+ * called within this callback.
  * @param context A pointer to the <i>context</i> value originally passed to
  * MQTTAsync_setCallbacks(), which contains any application-specific context.
  * @param token The ::MQTTAsync_token associated with
@@ -375,6 +381,9 @@ typedef void MQTTAsync_deliveryComplete(void* context, MQTTAsync_token token);
  * appropriate action, such as trying to reconnect or reporting the problem.
  * This function is executed on a separate thread to the one on which the
  * client application is running.
+ *
+ * <b>Note:</b> Neither MQTTAsync_create() nor MQTTAsync_destroy() should be
+ * called within this callback.
  * @param context A pointer to the <i>context</i> value originally passed to
  * MQTTAsync_setCallbacks(), which contains any application-specific context.
  * @param cause The reason for the disconnection.
@@ -390,6 +399,9 @@ typedef void MQTTAsync_connectionLost(void* context, char* cause);
  * callback can be used.  It is intended for use when automatic reconnect
  * is enabled, so that when a reconnection attempt succeeds in the background,
  * the application is notified and can take any required actions.
+ *
+ * <b>Note:</b> Neither MQTTAsync_create() nor MQTTAsync_destroy() should be
+ * called within this callback.
  * @param context A pointer to the <i>context</i> value originally passed to
  * MQTTAsync_setCallbacks(), which contains any application-specific context.
  * @param cause The reason for the disconnection.
@@ -400,6 +412,9 @@ typedef void MQTTAsync_connected(void* context, char* cause);
 /**
  * This is a callback function, which will be called when the client
  * library receives a disconnect packet.
+ *
+ * <b>Note:</b> Neither MQTTAsync_create() nor MQTTAsync_destroy() should be
+ * called within this callback.
  * @param context A pointer to the <i>context</i> value originally passed to
  * MQTTAsync_setCallbacks(), which contains any application-specific context.
  * @param properties the properties in the disconnect packet.
@@ -413,6 +428,9 @@ typedef void MQTTAsync_disconnected(void* context, MQTTProperties* properties,
  * Sets the MQTTAsync_disconnected() callback function for a client.
  * @param handle A valid client handle from a successful call to
  * MQTTAsync_create().
+ *
+ * <b>Note:</b> Neither MQTTAsync_create() nor MQTTAsync_destroy() should be
+ * called within this callback.
  * @param context A pointer to any application-specific context. The
  * the <i>context</i> pointer is passed to each of the callback functions to
  * provide access to the context information in the callback.
@@ -536,6 +554,9 @@ typedef struct
  * notification of the successful completion of an API call. The function is
  * registered with the client library by passing it as an argument in
  * ::MQTTAsync_responseOptions.
+ *
+ * <b>Note:</b> Neither MQTTAsync_create() nor MQTTAsync_destroy() should be
+ * called within this callback.
  * @param context A pointer to the <i>context</i> value originally passed to
  * ::MQTTAsync_responseOptions, which contains any application-specific context.
  * @param response Any success data associated with the API completion.
@@ -549,6 +570,9 @@ typedef void MQTTAsync_onSuccess(void* context, MQTTAsync_successData* response)
  * notification of the successful completion of an API call. The function is
  * registered with the client library by passing it as an argument in
  * ::MQTTAsync_responseOptions.
+ *
+ * <b>Note:</b> Neither MQTTAsync_create() nor MQTTAsync_destroy() should be
+ * called within this callback.
  * @param context A pointer to the <i>context</i> value originally passed to
  * ::MQTTAsync_responseOptions, which contains any application-specific context.
  * @param response Any success data associated with the API completion.
@@ -561,6 +585,9 @@ typedef void MQTTAsync_onSuccess5(void* context, MQTTAsync_successData5* respons
  * notification of the unsuccessful completion of an API call. The function is
  * registered with the client library by passing it as an argument in
  * ::MQTTAsync_responseOptions.
+ *
+ * <b>Note:</b> Neither MQTTAsync_create() nor MQTTAsync_destroy() should be
+ * called within this callback.
  * @param context A pointer to the <i>context</i> value originally passed to
  * ::MQTTAsync_responseOptions, which contains any application-specific context.
  * @param response Failure data associated with the API completion.
@@ -573,6 +600,9 @@ typedef void MQTTAsync_onFailure(void* context,  MQTTAsync_failureData* response
  * notification of the unsuccessful completion of an API call. The function is
  * registered with the client library by passing it as an argument in
  * ::MQTTAsync_responseOptions.
+ *
+ * <b>Note:</b> Neither MQTTAsync_create() nor MQTTAsync_destroy() should be
+ * called within this callback.
  * @param context A pointer to the <i>context</i> value originally passed to
  * ::MQTTAsync_responseOptions, which contains any application-specific context.
  * @param response Failure data associated with the API completion.


### PR DESCRIPTION
It is unclear in MQTTAsync documentation that users must not call
MQTTAsync_destroy or MQTTAsync_create functions from any of the
callback threads. This mistake is easy to make and cause deadlock
within libpaho [1].

Add a note on callback functions Doxygen comments to warn users.

[1] https://github.com/eclipse/paho.mqtt.c/issues/578