### PR TITLE
Adding support for custom HTTP headers when using WebSocket.

### DIFF
--- a/src/Clients.h
+++ b/src/Clients.h
@@ -85,6 +85,7 @@ typedef struct
 #endif
 	int websocket; /**< socket has been upgraded to use web sockets */
 	char *websocket_key;
+	const MQTTClient_nameValue* httpHeaders;
 } networkHandles;
 
 

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -2742,7 +2742,7 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 		goto exit;
 	}
 
-	if (strncmp(options->struct_id, "MQTC", 4) != 0 || options->struct_version < 0 || options->struct_version > 6)
+	if (strncmp(options->struct_id, "MQTC", 4) != 0 || options->struct_version < 0 || options->struct_version > 7)
 	{
 		rc = MQTTASYNC_BAD_STRUCTURE;
 		goto exit;
@@ -2847,6 +2847,10 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 		m->automaticReconnect = options->automaticReconnect;
 		m->minRetryInterval = options->minRetryInterval;
 		m->maxRetryInterval = options->maxRetryInterval;
+	}
+	if (options->struct_version >= 7)
+	{
+		m->c->net.httpHeaders = (const MQTTClient_nameValue *) options->httpHeaders;
 	}
 
 	if (m->c->will)

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -972,6 +972,12 @@ typedef struct
 
 #define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 3, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL }
 
+typedef struct
+{
+	const char* name;
+	const char* value;
+} MQTTAsync_nameValue;
+
 /**
  * MQTTAsync_connectOptions defines several settings that control the way the
  * client connects to an MQTT server.  Default values are set in
@@ -988,6 +994,7 @@ typedef struct
     * 3 signifies no automatic reconnect options
     * 4 signifies no binary password option (just string)
     * 5 signifies no MQTTV5 properties
+    * 6 signifies no HTTP headers option
 	  */
 	int struct_version;
 	/** The "keep alive" interval, measured in seconds, defines the maximum time
@@ -1119,6 +1126,10 @@ typedef struct
 		int len;            /**< binary password length */
 		const void* data;  /**< binary password data */
 	} binarypwd;
+	/**
+	 * httpHeaders
+	 */
+	const MQTTAsync_nameValue* httpHeaders;
 	/*
 	 * MQTT V5 clean start flag.  Only clears state at the beginning of the session.
 	 */
@@ -1146,11 +1157,11 @@ typedef struct
 } MQTTAsync_connectOptions;
 
 
-#define MQTTAsync_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 6, 60, 1, 65535, NULL, NULL, NULL, 30, 0,\
-NULL, NULL, NULL, NULL, 0, NULL, MQTTVERSION_DEFAULT, 0, 1, 60, {0, NULL}, 0, NULL, NULL, NULL, NULL}
+#define MQTTAsync_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 7, 60, 1, 65535, NULL, NULL, NULL, 30, 0,\
+NULL, NULL, NULL, NULL, 0, NULL, MQTTVERSION_DEFAULT, 0, 1, 60, {0, NULL}, NULL, 0, NULL, NULL, NULL, NULL}
 
-#define MQTTAsync_connectOptions_initializer5 { {'M', 'Q', 'T', 'C'}, 6, 60, 0, 65535, NULL, NULL, NULL, 30, 0,\
-NULL, NULL, NULL, NULL, 0, NULL, MQTTVERSION_5, 0, 1, 60, {0, NULL}, 1, NULL, NULL, NULL, NULL}
+#define MQTTAsync_connectOptions_initializer5 { {'M', 'Q', 'T', 'C'}, 7, 60, 0, 65535, NULL, NULL, NULL, 30, 0,\
+NULL, NULL, NULL, NULL, 0, NULL, MQTTVERSION_5, 0, 1, 60, {0, NULL}, NULL, 1, NULL, NULL, NULL, NULL}
 
 
 /**
@@ -1481,13 +1492,6 @@ typedef void MQTTAsync_traceCallback(enum MQTTASYNC_TRACE_LEVELS level, char* me
   * @param callback a pointer to the function which will handle the trace information
   */
 DLLExport void MQTTAsync_setTraceCallback(MQTTAsync_traceCallback* callback);
-
-
-typedef struct
-{
-	const char* name;
-	const char* value;
-} MQTTAsync_nameValue;
 
 /**
   * This function returns version information about the library.

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1360,6 +1360,11 @@ static MQTTResponse MQTTClient_connectURI(MQTTClient handle, MQTTClient_connectO
 			m->c->maxInflightMessages = options->maxInflightMessages;
 	}
 
+	if (options->struct_version >= 7)
+	{
+		m->c->net.httpHeaders = options->httpHeaders;
+	}
+
 	if (m->c->will)
 	{
 		free(m->c->will->payload);
@@ -1542,7 +1547,7 @@ MQTTResponse MQTTClient_connectAll(MQTTClient handle, MQTTClient_connectOptions*
 		goto exit;
 	}
 
-	if (strncmp(options->struct_id, "MQTC", 4) != 0 || options->struct_version < 0 || options->struct_version > 6)
+	if (strncmp(options->struct_id, "MQTC", 4) != 0 || options->struct_version < 0 || options->struct_version > 7)
 	{
 		rc.reasonCode = MQTTCLIENT_BAD_STRUCTURE;
 		goto exit;

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -719,6 +719,26 @@ typedef struct
 #define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 3, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL }
 
 /**
+  * MQTTClient_libraryInfo is used to store details relating to the currently used
+  * library such as the version in use, the time it was built and relevant openSSL
+  * options.
+  * There is one static instance of this struct in MQTTClient.c
+  */
+
+typedef struct
+{
+	const char* name;
+	const char* value;
+} MQTTClient_nameValue;
+
+/**
+  * This function returns version information about the library.
+  * no trace information will be returned.
+  * @return an array of strings describing the library.  The last entry is a NULL pointer.
+  */
+DLLExport MQTTClient_nameValue* MQTTClient_getVersionInfo(void);
+
+/**
  * MQTTClient_connectOptions defines several settings that control the way the
  * client connects to an MQTT server.
  *
@@ -743,6 +763,7 @@ typedef struct
 	 * 3 signifies no returned values
 	 * 4 signifies no binary password option
 	 * 5 signifies no maxInflightMessages and cleanstart
+	 * 6 signifies no HTTP headers option
 	 */
 	int struct_version;
 	/** The "keep alive" interval, measured in seconds, defines the maximum time
@@ -863,6 +884,10 @@ typedef struct
 		const void* data;  /**< binary password data */
 	} binarypwd;
 	/**
+	 * httpHeaders
+	 */
+	const MQTTClient_nameValue* httpHeaders;
+	/**
 	 * The maximum number of messages in flight
 	 */
 	int maxInflightMessages;
@@ -872,29 +897,9 @@ typedef struct
 	int cleanstart;
 } MQTTClient_connectOptions;
 
-#define MQTTClient_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 6, 60, 1, 1, NULL, NULL, NULL, 30, 0, NULL, 0, NULL, MQTTVERSION_DEFAULT, {NULL, 0, 0}, {0, NULL}, -1, 0}
+#define MQTTClient_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 7, 60, 1, 1, NULL, NULL, NULL, 30, 0, NULL, 0, NULL, MQTTVERSION_DEFAULT, {NULL, 0, 0}, {0, NULL}, NULL, -1, 0}
 
-#define MQTTClient_connectOptions_initializer5 { {'M', 'Q', 'T', 'C'}, 6, 60, 0, 1, NULL, NULL, NULL, 30, 0, NULL, 0, NULL, MQTTVERSION_5, {NULL, 0, 0}, {0, NULL}, -1, 1}
-
-/**
-  * MQTTClient_libraryInfo is used to store details relating to the currently used
-  * library such as the version in use, the time it was built and relevant openSSL
-  * options.
-  * There is one static instance of this struct in MQTTClient.c
-  */
-
-typedef struct
-{
-	const char* name;
-	const char* value;
-} MQTTClient_nameValue;
-
-/**
-  * This function returns version information about the library.
-  * no trace information will be returned.
-  * @return an array of strings describing the library.  The last entry is a NULL pointer.
-  */
-DLLExport MQTTClient_nameValue* MQTTClient_getVersionInfo(void);
+#define MQTTClient_connectOptions_initializer5 { {'M', 'Q', 'T', 'C'}, 7, 60, 0, 1, NULL, NULL, NULL, 30, 0, NULL, 0, NULL, MQTTVERSION_5, {NULL, 0, 0}, {0, NULL}, NULL, -1, 1}
 
 /**
   * This function attempts to connect a previously-created client (see


### PR DESCRIPTION
Signed-off-by: Yifan Gu <gyf304@gmail.com>

Custom / additional HTTP headers are sometimes needed for MQTT services behind a reverse proxy, usually for authentication, but can also be used to carry additional metadata that sometimes need to be provided to the server.

For example, for the AWS IoT WebSocket MQTT broker, when using custom authorizers, need specific headers set before establishing a WebSocket connection.

See https://docs.aws.amazon.com/iot/latest/developerguide/custom-auth.html

The current implementation of WebSocket does not allow adding custom / additional headers. This patch adds that feature.
