### PR TITLE
Fix MQTTClient_createOptions_initializer - add missing struct field

### DIFF
--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -540,7 +540,7 @@ typedef struct
 	int MQTTVersion;
 } MQTTClient_createOptions;
 
-#define MQTTClient_createOptions_initializer { {'M', 'Q', 'C', 'O'}, MQTTVERSION_DEFAULT }
+#define MQTTClient_createOptions_initializer { {'M', 'Q', 'C', 'O'}, 0, MQTTVERSION_DEFAULT }
 
 /**
  * A version of :MQTTClient_create() with additional options.


### PR DESCRIPTION
The commit 7cc0e3fa385910a5e1f0bb176f128de51a05a5b9 introduced
- MQTTClient_createWithOptions function
- MQTTClient_createOptions structure
- MQTTClient_createOptions_initializer
The MQTTClient_createOptions struct has 3 fields, but only two were initialized
in the MQTTClient_createOptions_initializer.
It was just fortunate that MQTTVERSION_DEFAULT is defined as 0 and implicitly
initialized MQTTVersion field has value of 0 too.

Signed-off-by: Maksym Ruchko <mruchko@advantech-bb.com>
