### PR TITLE
Added missing verification for SSL server's IP address

### DIFF
--- a/src/samples/paho_c_pub.c
+++ b/src/samples/paho_c_pub.c
@@ -267,6 +267,8 @@ void myconnect(MQTTAsync client)
 	{
 		if (opts.insecure)
 			ssl_opts.verify = 0;
+		else
+			ssl_opts.verify = 1;
 		ssl_opts.CApath = opts.capath;
 		ssl_opts.keyStore = opts.cert;
 		ssl_opts.trustStore = opts.cafile;

--- a/src/samples/paho_c_sub.c
+++ b/src/samples/paho_c_sub.c
@@ -304,6 +304,8 @@ int main(int argc, char** argv)
 	{
 		if (opts.insecure)
 			ssl_opts.verify = 0;
+		else
+			ssl_opts.verify = 1;
 		ssl_opts.CApath = opts.capath;
 		ssl_opts.keyStore = opts.cert;
 		ssl_opts.trustStore = opts.cafile;

--- a/src/samples/paho_cs_pub.c
+++ b/src/samples/paho_cs_pub.c
@@ -86,6 +86,8 @@ int myconnect(MQTTClient* client)
 	{
 		if (opts.insecure)
 			ssl_opts.verify = 0;
+		else
+			ssl_opts.verify = 1;
 		ssl_opts.CApath = opts.capath;
 		ssl_opts.keyStore = opts.cert;
 		ssl_opts.trustStore = opts.cafile;

--- a/src/samples/paho_cs_sub.c
+++ b/src/samples/paho_cs_sub.c
@@ -83,6 +83,8 @@ int myconnect(MQTTClient* client)
 	{
 		if (opts.insecure)
 			ssl_opts.verify = 0;
+		else
+			ssl_opts.verify = 1;
 		ssl_opts.CApath = opts.capath;
 		ssl_opts.keyStore = opts.cert;
 		ssl_opts.trustStore = opts.cafile;


### PR DESCRIPTION
The PAHO SSL code was checking only DNS names from certificate's Subject Alternative Name.
Thus if the "verify" was properly set to 1 in the MQTTClient_SSLOptions and connection was made
to the IP address (not the DNS name), the SSL verification was failing regardless the server
had valid cert.
Samples incorrectly assumed default value for verify as 1, so never set it to 1, only reset to 0.
Thus samples were always operating as if --insecure flag was specified.
This is fixed in this commit as well.

Signed-off-by: Maksym Ruchko <mruchko@advantech-bb.com>


Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


