### PR TITLE
Add disconnect option initializer for mqttv5

### DIFF
--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -1227,8 +1227,11 @@ typedef struct
 	MQTTAsync_onFailure5* onFailure5;
 } MQTTAsync_disconnectOptions;
 
-#define MQTTAsync_disconnectOptions_initializer { {'M', 'Q', 'T', 'D'}, 1, 0, NULL, NULL, NULL, MQTTProperties_initializer, MQTTREASONCODE_SUCCESS }
+#define MQTTAsync_disconnectOptions_initializer { {'M', 'Q', 'T', 'D'}, 0, 0, NULL, NULL, NULL,\
+	MQTTProperties_initializer, MQTTREASONCODE_SUCCESS }
 
+#define MQTTAsync_disconnectOptions_initializer5 { {'M', 'Q', 'T', 'D'}, 1, 0, NULL, NULL, NULL,\
+	MQTTProperties_initializer, MQTTREASONCODE_SUCCESS, NULL, NULL }
 
 /**
   * This function attempts to disconnect the client from the MQTT


### PR DESCRIPTION
New fields where added to the MQTTAsync_disconnectOptions structure for
MQTTv5 support. The macro provided to initialize this macro, does not
included the new fields. Depending on compilation options it may cause a
warning similar to: 'warning: missing initializer for field
‘onSuccess5’".

Add a MQTTAsync_disconnectOptions_initializer5 with the two missing
fields (onSuccelss5 and onFailure5) set to NULL. Update the previous
initializer and set the struct_version to 0 as it should not be used for
MQTTv5 anyway.