### PR TITLE
Patch for mingw compile

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ SET(common_src
     )
 
 IF (WIN32)
-    SET(LIBS_SYSTEM ws2_32)
+    SET(LIBS_SYSTEM ws2_32 crypt32 RpcRT4)
 ELSEIF (UNIX)
     IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
         SET(LIBS_SYSTEM c dl pthread)

--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -48,10 +48,15 @@
 #  if BYTE_ORDER == LITTLE_ENDIAN
 #    define htobe16(x)   htons(x)
 #    define htobe32(x)   htonl(x)
-#    define htobe64(x)   htonll(x)
+#    if defined(WIN32)
+#      define htobe64(x)   ((1==htonl(1)) ? (x) : ((uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
+#      define be64toh(x)   ((1==ntohl(1)) ? (x) : ((uint64_t)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
+#    else
+#      define htobe64(x)   htonll(x)
+#      define be64toh(x)   ntohll(x)
+#    endif
 #    define be16toh(x)   ntohs(x)
 #    define be32toh(x)   ntohl(x)
-#    define be64toh(x)   ntohll(x)
 #  elif BTYE_ORDER == BIG_ENDIAN
 #    define htobe16(x)   (x)
 #    define htobe32(x)   (x)


### PR DESCRIPTION
Ok next try with a valid ECA id ;)

with this additions it's fine to compile with mingw under a win32 system 
