### PR TITLE
#680 Async creation accepts struct_version 1 and handles versions

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -508,7 +508,8 @@ int MQTTAsync_createWithOptions(MQTTAsync* handle, const char* serverURI, const 
 		}
 	}
 
-	if (options && (strncmp(options->struct_id, "MQCO", 4) != 0 || options->struct_version != 0))
+	if (options && (strncmp(options->struct_id, "MQCO", 4) != 0 ||
+					options->struct_version < 0 || options->struct_version > 1))
 	{
 		rc = MQTTASYNC_BAD_STRUCTURE;
 		goto exit;
@@ -571,7 +572,8 @@ int MQTTAsync_createWithOptions(MQTTAsync* handle, const char* serverURI, const 
 	{
 		m->createOptions = malloc(sizeof(MQTTAsync_createOptions));
 		memcpy(m->createOptions, options, sizeof(MQTTAsync_createOptions));
-		m->c->MQTTVersion = options->MQTTVersion;
+		if (options->struct_version > 0)
+			m->c->MQTTVersion = options->MQTTVersion;
 	}
 
 #if !defined(NO_PERSISTENCE)

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -838,7 +838,9 @@ typedef struct
 	int MQTTVersion;
 } MQTTAsync_createOptions;
 
-#define MQTTAsync_createOptions_initializer { {'M', 'Q', 'C', 'O'}, 0, 0, 100, MQTTVERSION_DEFAULT }
+#define MQTTAsync_createOptions_initializer  { {'M', 'Q', 'C', 'O'}, 1, 0, 100, MQTTVERSION_DEFAULT }
+
+#define MQTTAsync_createOptions_initializer5 { {'M', 'Q', 'C', 'O'}, 1, 0, 100, MQTTVERSION_5 }
 
 
 DLLExport int MQTTAsync_createWithOptions(MQTTAsync* handle, const char* serverURI, const char* clientId,


### PR DESCRIPTION
This should fix #680 to handle the new version of the MQTTAsync_createOptions struct (ver 1) for MQTT v5.