### PR TITLE
#681 The Eclipse MQTT sandbox server moved to new address

### DIFF
--- a/src/samples/MQTTAsync_publish.c
+++ b/src/samples/MQTTAsync_publish.c
@@ -29,7 +29,7 @@
 #include <OsWrapper.h>
 #endif
 
-#define ADDRESS     "tcp://iot.eclipse.org:1883"
+#define ADDRESS     "tcp://mqtt.eclipse.org:1883"
 #define CLIENTID    "ExampleClientPub"
 #define TOPIC       "MQTT Examples"
 #define PAYLOAD     "Hello World!"

--- a/test/test1.c
+++ b/test/test1.c
@@ -56,7 +56,7 @@ struct Options
 	int iterations;
 } options =
 {
-	"tcp://iot.eclipse.org:1883",
+	"tcp://mqtt.eclipse.org:1883",
 	NULL,
 	"tcp://localhost:1883",
 	0,

--- a/test/test4.c
+++ b/test/test4.c
@@ -54,7 +54,7 @@ struct Options
 	int iterations;
 } options =
 {
-	"iot.eclipse.org:1883",
+	"mqtt.eclipse.org:1883",
 	0,
 	-1,
 	10000,

--- a/test/test9.c
+++ b/test/test9.c
@@ -56,7 +56,7 @@ struct Options
 	int test_no;
 } options =
 {
-	"iot.eclipse.org:1883",
+	"mqtt.eclipse.org:1883",
 	"localhost:1883",
 	0,
 	0,

--- a/test/test95.c
+++ b/test/test95.c
@@ -57,7 +57,7 @@ struct Options
 	int test_no;
 } options =
 {
-	"iot.eclipse.org:1883",
+	"mqtt.eclipse.org:1883",
 	"localhost:1883",
 	0,
 	0,

--- a/test/test_sync_session_present.c
+++ b/test/test_sync_session_present.c
@@ -60,7 +60,7 @@ struct Options
     int reconnect_period;
 } options =
 {
-    "tcp://iot.eclipse.org:1883",
+    "tcp://mqtt.eclipse.org:1883",
     NULL,
     "tcp://localhost:1883",
     "cli/test",


### PR DESCRIPTION
This should fix Issue #681. The Eclipse MQTT sandbox server moved to new address, 'mqtt.eclipse.org'.

This updates the address for test and sample apps.