### PR TITLE
1. Normalize some code;

### DIFF
--- a/src/Clients.h
+++ b/src/Clients.h
@@ -126,7 +126,8 @@ typedef struct
 	willMessages* will;
 	List* inboundMsgs;
 	List* outboundMsgs;				/**< in flight */
-	List* messageQueue;
+	List* messageQueue; /* List queue for PUBLISH message from server that RecevieThread can't deliver immediately when
+	                       connected flag is 0 or deliver failed or other PUBLISH message waiting in queue. */
 	unsigned int qentry_seqno;
 	void* phandle;  /* the persistence handle */
 	MQTTClient_persistence* persistence; /* a persistence implementation */

--- a/src/Clients.h
+++ b/src/Clients.h
@@ -117,7 +117,7 @@ typedef struct
 	unsigned int connected : 1;		/**< whether it is currently connected */
 	unsigned int good : 1; 			  /**< if we have an error on the socket we turn this off */
 	unsigned int ping_outstanding : 1;
-	signed int connect_state : 4;
+	signed int connect_state : 4;   /**< Connect state only for creating connection process. Caution: System set 'connect_state = NOT_IN_PROCESS; connected = 1' when receiving CONNACK in 'connect_state = WAIT_FOR_CONNACK' state */
 	networkHandles net;
 	int msgID;
 	int keepAliveInterval;

--- a/src/LinkedList.c
+++ b/src/LinkedList.c
@@ -218,10 +218,10 @@ static int ListUnlink(List* aList, void* content, int(*callback)(void*, void*), 
 
 	next = aList->current->next;
 	if (freeContent)
-        {
+	{
 		free(aList->current->content);
-                aList->current->content = NULL;
-        }
+		aList->current->content = NULL;
+	}
 	if (saved == aList->current)
 		saveddeleted = 1;
 	free(aList->current);
@@ -360,10 +360,10 @@ void ListEmpty(List* aList)
 	{
 		ListElement* first = aList->first;
 		if (first->content != NULL)
-                {
+		{
 			free(first->content);
-                        first->content = NULL;
-                }
+			first->content = NULL;
+		}
 		aList->first = first->next;
 		free(first);
 	}

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -1653,7 +1653,7 @@ static int MQTTAsync_processCommand(void)
 					data.token = 0;
 					data.code = MQTTASYNC_OPERATION_INCOMPLETE;
 					data.message = NULL;
-					Log(TRACE_MIN, -1, "Calling connect failure for client %s", command->client->c->clientID);
+					Log(TRACE_MIN, -1, "Calling disconnect failure for client %s", command->client->c->clientID);
 					(*(command->client->connect.onFailure))(command->client->connect.context, &data);
 				}
 				else if (command->client->connect.onFailure5)
@@ -1663,7 +1663,7 @@ static int MQTTAsync_processCommand(void)
 					data.token = 0;
 					data.code = MQTTASYNC_OPERATION_INCOMPLETE;
 					data.message = NULL;
-					Log(TRACE_MIN, -1, "Calling connect failure for client %s", command->client->c->clientID);
+					Log(TRACE_MIN, -1, "Calling disconnect failure for client %s", command->client->c->clientID);
 					(*(command->client->connect.onFailure5))(command->client->connect.context, &data);
 				}
 			}
@@ -3564,7 +3564,7 @@ int MQTTAsync_send(MQTTAsync handle, const char* destinationName, int payloadlen
 		rc = MQTTASYNC_BAD_QOS;
 	else if (qos > 0 && (msgid = MQTTAsync_assignMsgId(m)) == 0)
 		rc = MQTTASYNC_NO_MORE_MSGIDS;
-	else if (m->createOptions && (MQTTAsync_countBufferedMessages(m) >= m->createOptions->maxBufferedMessages))
+	else if (m->createOptions && (m->createOptions->sendWhileDisconnected != 0) && (MQTTAsync_countBufferedMessages(m) >= m->createOptions->maxBufferedMessages))
 		rc = MQTTASYNC_MAX_BUFFERED_MESSAGES;
 	else if (response)
 	{

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -243,8 +243,8 @@ typedef void* MQTTAsync;
  * A value representing an MQTT message. A token is returned to the
  * client application when a message is published. The token can then be used to
  * check that the message was successfully delivered to its destination (see
- * MQTTAsync_publish(),
- * MQTTAsync_publishMessage(),
+ * MQTTAsync_send(),
+ * MQTTAsync_sendMessage(),
  * MQTTAsync_deliveryComplete(), and
  * MQTTAsync_getPendingTokens()).
  */
@@ -252,8 +252,8 @@ typedef int MQTTAsync_token;
 
 /**
  * A structure representing the payload and attributes of an MQTT message. The
- * message topic is not part of this structure (see MQTTAsync_publishMessage(),
- * MQTTAsync_publish(), MQTTAsync_receive(), MQTTAsync_freeMessage()
+ * message topic is not part of this structure (see MQTTAsync_sendMessage(),
+ * MQTTAsync_send(), MQTTAsync_receive(), MQTTAsync_freeMessage()
  * and MQTTAsync_messageArrived()).
  */
 typedef struct
@@ -1378,7 +1378,7 @@ DLLExport int MQTTAsync_send(MQTTAsync handle, const char* destinationName, int 
 
 /**
   * This function attempts to publish a message to a given topic (see also
-  * MQTTAsync_publish()). An ::MQTTAsync_token is issued when
+  * MQTTAsync_send()). An ::MQTTAsync_token is issued when
   * this function returns successfully. If the client application needs to
   * test for successful delivery of messages, a callback should be set
   * (see ::MQTTAsync_onSuccess() and ::MQTTAsync_deliveryComplete()).

--- a/src/MQTTProtocolClient.c
+++ b/src/MQTTProtocolClient.c
@@ -617,7 +617,8 @@ void MQTTProtocol_keepalive(time_t now)
 
 		if (client->ping_outstanding == 1)
 		{
-			if (difftime(now, client->net.lastPing) >= client->keepAliveInterval)
+			if ((difftime(now, client->net.lastPing) >= client->keepAliveInterval) 
+			 && (difftime(now, client->net.lastReceived) >= client->keepAliveInterval))
 			{
 				Log(TRACE_PROTOCOL, -1, "PINGRESP not received in keepalive interval for client %s on socket %d, disconnecting", client->clientID, client->net.socket);
 				MQTTProtocol_closeSession(client, 1);


### PR DESCRIPTION
2.Add comments for some global variables and structure;
3. Add mutex for routine "MQTTAsync_countBufferedMessages", refer to routine "MQTTAsync_assignMsgId";
fix bug: Detecting its elements when the response pointer is null may cause segment fault in 'MQTTAsync_subscribeMany' routine.
fix bug: Allocate room for MQTTProperties but sometimes would forget to free this room when receive PUBLISH response from server.
fix bug: Forget to set topicLen to 0 when strlen(topicName) = topicLen.
fix bug: In receiveThread, forget to free the node's topic string and msg room when user do not set message arrived callback routine.



Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


