### PR TITLE
Fix build under Windows

### DIFF
--- a/src/Thread.h
+++ b/src/Thread.h
@@ -24,6 +24,9 @@
 #include "mutex_type.h" /* Needed for mutex_type */
 
 #if defined(WIN32) || defined(WIN64)
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif
 	#include <windows.h>
 	#define thread_type HANDLE
 	#define thread_id_type DWORD


### PR DESCRIPTION
Without that define, windows.h will drag a lot of other headers,
including <winsock.h> which is incompatible with <winsock2.h>
used by Paho.

(PS: This seem to only actually trigger when you build with OPENSSL,
as then Stacktrace.c will include winsock2.h and Thread.h at the
same time. Even building without SSL, its never a good idea to have
two headers of different library versions included anywhere in the
project)


Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


