### PR TITLE
String Null Checks in UFT-8 validate functions

### DIFF
--- a/src/utf-8.c
+++ b/src/utf-8.c
@@ -80,6 +80,9 @@ static const char* UTF8_char_validate(int len, const char* data)
 	int i, j;
 	const char *rc = NULL;
 
+	if (data == NULL)
+		goto exit;	/* don't have data, can't continue */
+
 	/* first work out how many bytes this char is encoded in */
 	if ((data[0] & 128) == 0)
 		charlen = 1;
@@ -129,7 +132,7 @@ int UTF8_validate(int len, const char* data)
 	int rc = 0;
 
 	FUNC_ENTRY;
-	if (len == 0)
+	if (len == 0 || data == NULL)
 	{
 		rc = 1;
 		goto exit;
@@ -155,7 +158,10 @@ int UTF8_validateString(const char* string)
 	int rc = 0;
 
 	FUNC_ENTRY;
-	rc = UTF8_validate((int)strlen(string), string);
+	if (string != NULL)
+	{
+		rc = UTF8_validate((int)strlen(string), string);
+	}
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
@@ -220,6 +226,11 @@ int main (int argc, char *argv[])
 		printf("Failed\n");
 	else
 		printf("Passed\n");
+
+    //Don't crash on null data
+	UTF8_validateString(NULL);
+	UTF8_validate(1, NULL);
+	UTF8_char_validate(1, NULL);
 
 	return 0;
 } /* End of main function*/


### PR DESCRIPTION
This provides NULL checks for the validate functions. I discovered this while using paho and switching our internal system queuing system sending. Instead of crashing the whole app the passed string is null, it just returns error and the app can handle it.

