### PR TITLE
Fix websocket frame buffer appending

### DIFF
--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -654,7 +654,7 @@ char *WebSocket_getRawSocketData(
 		frame_buffer = NULL;
 	}
 	// append data to the buffer
-	else if (rv != NULL)
+	else if (rv != NULL && *actual_len != 0U)
 	{
 		// no buffer allocated
 		if (!frame_buffer)


### PR DESCRIPTION
Without that check there is a possibility to call malloc/realloc with 0 size. The behavior depends on c standard (or library implementation), but most likely:
- malloc will return some pointer (but shall not be dereferenced),
- realloc will free memory (and return NULL),

which shall not happen.

In the scenario when two consecutive calls to `SSLSocket_getdata` are interrupted by the SSL (with `SSL_ERROR_WANT_READ/WRITE`, no data received) and `frame_buffer == NULL`, the following will happen:
- `frame_buffer` will be allocated with `malloc(0)` and it will have valid pointer address (index, len and data_len = 0),
- in the next iteration of the cycle, resize buffer happens and `realloc(0)` is called - `frame_buffer` is `NULL` at that point and is later returned from the`WebSocket_getRawSocketData`.

At the end of the day user experience disconnect.