### PR TITLE
Store initial errno and use the stored one in Socket_error to avoid it being overriden

### DIFF
--- a/src/Socket.c
+++ b/src/Socket.c
@@ -100,19 +100,19 @@ int Socket_setnonblocking(int sock)
  */
 int Socket_error(char* aString, int sock)
 {
-#if defined(WIN32) || defined(WIN64)
-	int errno;
-#endif
+	int err;
 
 #if defined(WIN32) || defined(WIN64)
-	errno = WSAGetLastError();
+	err = WSAGetLastError();
+#else
+	err = errno;
 #endif
-	if (errno != EINTR && errno != EAGAIN && errno != EINPROGRESS && errno != EWOULDBLOCK)
+	if (err != EINTR && err != EAGAIN && err != EINPROGRESS && err != EWOULDBLOCK)
 	{
-		if (strcmp(aString, "shutdown") != 0 || (errno != ENOTCONN && errno != ECONNRESET))
-			Log(TRACE_MINIMUM, -1, "Socket error %s(%d) in %s for socket %d", strerror(errno), errno, aString, sock);
+		if (strcmp(aString, "shutdown") != 0 || (err != ENOTCONN && err != ECONNRESET))
+			Log(TRACE_MINIMUM, -1, "Socket error %s(%d) in %s for socket %d", strerror(err), err, aString, sock);
 	}
-	return errno;
+	return err;
 }
 
 


### PR DESCRIPTION
Using MINIMUM logging causes the connection to the broker to fail with musl in alpine docker (even with local broker). PROTOCOL level worked fine. "Invalid argument(22)" error was displayed by Socket_error("connect").

Socket_new calls Socket_error("connect", *sock) if connect fails or is in progress.
Socket_error may call Log directly or though StackTrace logging and any function called may override errno.
For example, Log will call strftime at some point which will call strtoul (with musl).
This causes errno to be set to EINVAL overriding the original EINPROGRESS errno. Caller Socket_new closes the socket.

Avoid this by storing the initial errno before usage in Socket_error.


