### PR TITLE
Add missing fields in MQTTAsync_disconnectOptions initializer

### DIFF
--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -1300,7 +1300,7 @@ typedef struct
 } MQTTAsync_disconnectOptions;
 
 #define MQTTAsync_disconnectOptions_initializer { {'M', 'Q', 'T', 'D'}, 0, 0, NULL, NULL, NULL,\
-	MQTTProperties_initializer, MQTTREASONCODE_SUCCESS }
+	MQTTProperties_initializer, MQTTREASONCODE_SUCCESS, NULL, NULL }
 
 #define MQTTAsync_disconnectOptions_initializer5 { {'M', 'Q', 'T', 'D'}, 1, 0, NULL, NULL, NULL,\
 	MQTTProperties_initializer, MQTTREASONCODE_SUCCESS, NULL, NULL }


### PR DESCRIPTION
A missing field initializer is given when initializing a MQTTAsync_disconnectOptions with MQTTAsync_disconnectOptions_initializer.

error: missing initializer for field 'onSuccess5' of 'MQTTAsync_disconnectOptions {aka struct <anonymous>}' [-Werror=missing-field-initializers]
|          MQTTAsync_disconnectOptions opts = MQTTAsync_disconnectOptions_initializer;

Make sure that every disconnect initializer has every field
