### PR TITLE
Large Payloads over WSS either disconnects or fails PUBACK #721  Signed-off-by: Daryl Fortney <daryl.fortney@keysight.com>

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -453,8 +453,8 @@ void MQTTAsync_sleep(long milliseconds)
 // http://ee.lbl.gov/papers/sync_94.pdf
 int MQTTAsync_randomJitter(int currentIntervalBase, int minInterval, int maxInterval)
 {
-	int max_sleep = min(maxInterval, currentIntervalBase) * 1.2; // (e.g. 72 if base > 60)
-	int min_sleep = max(minInterval, currentIntervalBase) / 1.2; // (e.g. 48 if base > 60)
+	int max_sleep = (int) (min(maxInterval, currentIntervalBase) * 1.2); // (e.g. 72 if base > 60)
+	int min_sleep = (int) (max(minInterval, currentIntervalBase) / 1.2); // (e.g. 48 if base > 60)
 
 	if (min_sleep >= max_sleep) // shouldn't happen, but just incase
 	{

--- a/src/SocketBuffer.c
+++ b/src/SocketBuffer.c
@@ -164,13 +164,12 @@ char* SocketBuffer_getQueuedData(int socket, size_t bytes, size_t* actual_len)
 	if (ListFindItem(queues, &socket, socketcompare))
 	{  /* if there is queued data for this socket, add any data read to it */
 		queue = (socket_queue*)(queues->current->content);
-		*actual_len = queue->datalen;
 	}
 	else
 	{
-		*actual_len = 0;
 		queue = def_queue;
 	}
+    *actual_len = queue->datalen;
 	if (bytes > queue->buflen)
 	{
 		if (queue->datalen > 0)


### PR DESCRIPTION
Fixes issue #724 by allowing failed receipt of the first 2 bytes of a websocket frame to be flagged as TCPSOCKET_INTERRUPTED instead of as SOCKET_ERROR.  This is valid as OpenSSL docs explicitly allow for the socket to be renegotiated between peers between frames during which time the SSL_read() call is expected to return SSL_ERROR_WANT_READ.  This change allows the client to maintain it's connection through this renegotiation process and retry frame receipts after this interruption.  I have also included a few very small fixes for build warnings within VS2017. 


