### PR TITLE
#368 Add underscores to Windows compiler macro checks, _WIN32 and _WIN64

### DIFF
--- a/src/Base64.c
+++ b/src/Base64.c
@@ -16,7 +16,7 @@
 
 #include "Base64.h"
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #pragma comment(lib, "crypt32.lib")
 #include <windows.h>
 #include <wincrypt.h>
@@ -37,7 +37,7 @@ b64_size_t Base64_encode( char *out, b64_size_t out_len, const b64_data_t *in, b
 		ret = (b64_size_t)dw_out_len;
 	return ret;
 }
-#else /* if defined(WIN32) || defined(WIN64) */
+#else /* if defined(_WIN32) || defined(_WIN64) */
 
 #if defined(OPENSSL)
 #include <openssl/bio.h>
@@ -234,7 +234,7 @@ b64_size_t Base64_encode( char *out, b64_size_t out_len, const b64_data_t *in, b
 	return ret;
 }
 #endif /* else if defined(OPENSSL) */
-#endif /* if else defined(WIN32) || defined(WIN64) */
+#endif /* if else defined(_WIN32) || defined(_WIN64) */
 
 b64_size_t Base64_decodeLength( const char *in, b64_size_t in_len )
 {

--- a/src/Clients.h
+++ b/src/Clients.h
@@ -24,7 +24,7 @@
 
 #include <time.h>
 #if defined(OPENSSL)
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #include <winsock2.h>
 #endif
 #include <openssl/ssl.h>

--- a/src/Heap.c
+++ b/src/Heap.c
@@ -46,7 +46,7 @@ char* Broker_recordFFDC(char* symptoms);
 #undef realloc
 #undef free
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 mutex_type heap_mutex;
 #else
 static pthread_mutex_t heap_mutex_store = PTHREAD_MUTEX_INITIALIZER;

--- a/src/Log.c
+++ b/src/Log.c
@@ -38,7 +38,7 @@
 #include <time.h>
 #include <string.h>
 
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 #include <syslog.h>
 #include <sys/stat.h>
 #define GETTIMEOFDAY 1
@@ -52,7 +52,7 @@
 	#include <sys/timeb.h>
 #endif
 
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 /**
  * _unlink mapping for linux
  */
@@ -121,7 +121,7 @@ struct timeb ts, last_ts;
 #endif
 static char msg_buf[512];
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 mutex_type log_mutex;
 #else
 static pthread_mutex_t log_mutex_store = PTHREAD_MUTEX_INITIALIZER;
@@ -133,7 +133,7 @@ int Log_initialize(Log_nameValue* info)
 {
 	int rc = -1;
 	char* envval = NULL;
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 	struct stat buf;
 #endif
 
@@ -183,7 +183,7 @@ int Log_initialize(Log_nameValue* info)
 			info++;
 		}
 	}
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 	if (stat("/proc/version", &buf) != -1)
 	{
 		FILE* vfile;

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -46,7 +46,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 	#include <sys/time.h>
 #endif
 
@@ -108,7 +108,7 @@ enum MQTTAsync_threadStates receiveThread_state = STOPPED;
 static thread_id_type sendThread_id = 0,
 					receiveThread_id = 0;
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 static mutex_type mqttasync_mutex = NULL;
 static mutex_type socket_mutex = NULL;
 static mutex_type mqttcommand_mutex = NULL;
@@ -209,7 +209,7 @@ static int tostop = 0;
 static List* commands = NULL;
 
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #define START_TIME_TYPE DWORD
 START_TIME_TYPE MQTTAsync_start_clock(void)
 {
@@ -237,7 +237,7 @@ START_TIME_TYPE MQTTAsync_start_clock(void)
 }
 #endif
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 void MQTTAsync_init_rand(void)
 {
 	START_TIME_TYPE now = MQTTAsync_start_clock();
@@ -258,7 +258,7 @@ void MQTTAsync_init_rand(void)
 #endif
 
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 long MQTTAsync_elapsed(DWORD milliseconds)
 {
 	return GetTickCount() - milliseconds;
@@ -456,7 +456,7 @@ static MQTTPacket* MQTTAsync_cycle(int* sock, unsigned long timeout, int* rc);
 void MQTTAsync_sleep(long milliseconds)
 {
 	FUNC_ENTRY;
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);
@@ -1098,7 +1098,7 @@ static int MQTTAsync_addCommand(MQTTAsync_queuedCommand* command, int command_si
 #endif
 	}
 	MQTTAsync_unlock_mutex(mqttcommand_mutex);
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 	rc = Thread_signal_cond(send_cond);
 	if (rc != 0)
 		Log(LOG_ERROR, 0, "Error %d from signal cond", rc);
@@ -1907,7 +1907,7 @@ static thread_return_type WINAPI MQTTAsync_sendThread(void* n)
 			if (MQTTAsync_processCommand() == 0)
 				break;  /* no commands were processed, so go into a wait */
 		}
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 		if ((rc = Thread_wait_cond(send_cond, 1)) != 0 && rc != ETIMEDOUT)
 			Log(LOG_ERROR, -1, "Error %d waiting for condition variable", rc);
 #else
@@ -2157,7 +2157,7 @@ static int MQTTAsync_completeConnection(MQTTAsyncs* m, Connack* connack)
 			}
 		}
 		m->pack = NULL;
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 		Thread_signal_cond(send_cond);
 #else
 		Thread_post_sem(send_sem);
@@ -2480,7 +2480,7 @@ static thread_return_type WINAPI MQTTAsync_receiveThread(void* n)
 	receiveThread_state = STOPPED;
 	receiveThread_id = 0;
 	MQTTAsync_unlock_mutex(mqttasync_mutex);
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 	if (sendThread_state != STOPPED)
 		Thread_signal_cond(send_cond);
 #else

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -92,7 +92,7 @@
  extern "C" {
 #endif
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	#if defined(MQTT_EXPORTS)
 	  #define LIBMQTT_API __declspec(dllexport)
 	#else
@@ -1835,7 +1835,7 @@ int main(int argc, char* argv[])
          "on topic %s for client with ClientID: %s\n",
          PAYLOAD, TOPIC, CLIENTID);
 	while (!finished)
-		#if defined(WIN32) || defined(WIN64)
+		#if defined(_WIN32) || defined(_WIN64)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1985,7 +1985,7 @@ int main(int argc, char* argv[])
 	}
 
 	while	(!subscribed)
-		#if defined(WIN32) || defined(WIN64)
+		#if defined(_WIN32) || defined(_WIN64)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -2006,7 +2006,7 @@ int main(int argc, char* argv[])
 		exit(EXIT_FAILURE);
 	}
  	while	(!disc_finished)
-		#if defined(WIN32) || defined(WIN64)
+		#if defined(_WIN32) || defined(_WIN64)
 			Sleep(100);
 		#else
 			usleep(10000L);

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -45,7 +45,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 	#include <sys/time.h>
 #endif
 
@@ -100,7 +100,7 @@ ClientStates* bstate = &ClientState;
 
 MQTTProtocol state;
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 static mutex_type mqttclient_mutex = NULL;
 static mutex_type socket_mutex = NULL;
 static mutex_type subscribe_mutex = NULL;
@@ -247,7 +247,7 @@ struct props_rc_parms
 void MQTTClient_sleep(long milliseconds)
 {
 	FUNC_ENTRY;
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);
@@ -256,7 +256,7 @@ void MQTTClient_sleep(long milliseconds)
 }
 
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #define START_TIME_TYPE DWORD
 START_TIME_TYPE MQTTClient_start_clock(void)
 {
@@ -285,7 +285,7 @@ START_TIME_TYPE MQTTClient_start_clock(void)
 #endif
 
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 long MQTTClient_elapsed(DWORD milliseconds)
 {
 	return GetTickCount() - milliseconds;

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -110,7 +110,7 @@
  extern "C" {
 #endif
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	#if defined(MQTT_EXPORTS)
 		#define LIBMQTT_API __declspec(dllexport)
 	#else

--- a/src/MQTTPersistenceDefault.c
+++ b/src/MQTTPersistenceDefault.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include <errno.h>
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	#include <direct.h>
 	/* Windows doesn't have strtok_r, so remap it to strtok */
 	#define strtok_r( A, B, C ) strtok( A, B )
@@ -135,7 +135,7 @@ int pstmkdir( char *pPathname )
 	int rc = 0;
 
 	FUNC_ENTRY;
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	if ( _mkdir( pPathname ) != 0 )
 	{
 #else
@@ -279,7 +279,7 @@ int pstremove(void* handle, char* key)
 	file = malloc(strlen(clientDir) + strlen(key) + strlen(MESSAGE_FILENAME_EXTENSION) + 2);
 	sprintf(file, "%s/%s%s", clientDir, key, MESSAGE_FILENAME_EXTENSION);
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	if ( _unlink(file) != 0 )
 	{
 #else
@@ -313,7 +313,7 @@ int pstclose(void* handle)
 		goto exit;
 	}
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	if ( _rmdir(clientDir) != 0 )
 	{
 #else
@@ -347,7 +347,7 @@ int pstcontainskey(void *handle, char *key)
 		goto exit;
 	}
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	rc = containskeyWin32(clientDir, key);
 #else
 	rc = containskeyUnix(clientDir, key);
@@ -359,7 +359,7 @@ exit:
 }
 
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 int containskeyWin32(char *dirname, char *key)
 {
 	int notFound = MQTTCLIENT_PERSISTENCE_ERROR;
@@ -457,7 +457,7 @@ int pstclear(void *handle)
 		goto exit;
 	}
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	rc = clearWin32(clientDir);
 #else
 	rc = clearUnix(clientDir);
@@ -469,7 +469,7 @@ exit:
 }
 
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 int clearWin32(char *dirname)
 {
 	int rc = 0;
@@ -557,7 +557,7 @@ int pstkeys(void *handle, char ***keys, int *nkeys)
 		goto exit;
 	}
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	rc = keysWin32(clientDir, keys, nkeys);
 #else
 	rc = keysUnix(clientDir, keys, nkeys);
@@ -569,7 +569,7 @@ exit:
 }
 
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 int keysWin32(char *dirname, char ***keys, int *nkeys)
 {
 	int rc = 0;

--- a/src/MQTTProperties.h
+++ b/src/MQTTProperties.h
@@ -50,7 +50,7 @@ enum MQTTPropertyCodes {
   MQTTPROPERTY_CODE_SHARED_SUBSCRIPTION_AVAILABLE = 42/**< The value is 241 */
 };
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
   #define DLLImport __declspec(dllimport)
   #define DLLExport __declspec(dllexport)
 #else

--- a/src/MQTTReasonCodes.h
+++ b/src/MQTTReasonCodes.h
@@ -66,7 +66,7 @@ enum MQTTReasonCodes {
   MQTTREASONCODE_WILDCARD_SUBSCRIPTIONS_NOT_SUPPORTED = 162
 };
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
   #define DLLImport __declspec(dllimport)
   #define DLLExport __declspec(dllexport)
 #else

--- a/src/MQTTVersion.c
+++ b/src/MQTTVersion.c
@@ -26,7 +26,7 @@
 #include <ctype.h>
 #include "MQTTAsync.h"
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #include <tchar.h>
 #include <io.h>
@@ -137,7 +137,7 @@ int loadandcall(const char* libname)
 {
 	int rc = 0;
 	MQTTAsync_nameValue* (*func_address)(void) = NULL;
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	HMODULE APILibrary = LoadLibraryA(libname);
 	if (APILibrary == NULL)
 		printf("Error loading library %s, error code %d\n", libname, GetLastError());
@@ -201,7 +201,7 @@ int main(int argc, char** argv)
 		{
 #if defined(__CYGWIN__)
 			sprintf(namebuf, "cyg%s-1.dll", libraries[i]);
-#elif defined(WIN32) || defined(WIN64)
+#elif defined(_WIN32) || defined(_WIN64)
 			sprintf(namebuf, "%s.dll", libraries[i]);
 #elif defined(OSX)
 			sprintf(namebuf, "lib%s.1.dylib", libraries[i]);

--- a/src/SHA1.c
+++ b/src/SHA1.c
@@ -17,7 +17,7 @@
 #include "SHA1.h"
 
 #if !defined(OPENSSL)
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #pragma comment(lib, "crypt32.lib")
 
 int SHA1_Init(SHA_CTX *c)
@@ -52,7 +52,7 @@ int SHA1_Final(unsigned char *md, SHA_CTX *c)
 	return rv;
 }
 
-#else /* if defined(WIN32) || defined(WIN64) */
+#else /* if defined(_WIN32) || defined(_WIN64) */
 #if defined(__linux__) || defined(__CYGWIN__)
 #  include <endian.h>
 #elif defined(__APPLE__)
@@ -195,7 +195,7 @@ int SHA1_Update(SHA_CTX *ctx, const void *data, size_t len)
 	return 1;
 }
 
-#endif /* else if defined(WIN32) || defined(WIN64) */
+#endif /* else if defined(_WIN32) || defined(_WIN64) */
 #endif /* elif !defined(OPENSSL) */
 
 #if defined(SHA1_TEST)

--- a/src/SHA1.h
+++ b/src/SHA1.h
@@ -25,7 +25,7 @@
 
 #else /* if defined(OPENSSL) */
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #include <wincrypt.h>
 typedef struct SHA_CTX_S
@@ -33,7 +33,7 @@ typedef struct SHA_CTX_S
 	HCRYPTPROV hProv;
 	HCRYPTHASH hHash;
 } SHA_CTX;
-#else /* if defined(WIN32) || defined(WIN64) */
+#else /* if defined(_WIN32) || defined(_WIN64) */
 
 #include <stdint.h>
 typedef struct SHA_CTX_S {
@@ -45,7 +45,7 @@ typedef struct SHA_CTX_S {
 	unsigned int size;
 	unsigned int total;
 } SHA_CTX;
-#endif /* else if defined(WIN32) || defined(WIN64) */
+#endif /* else if defined(_WIN32) || defined(_WIN64) */
 
 #include <stddef.h>
 

--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -79,7 +79,7 @@ static ssl_mutex_type sslCoreMutex;
 /* Used to store MQTTClient_SSLOptions for TLS-PSK callback */
 static int tls_ex_index_ssl_opts;
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #define iov_len len
 #define iov_base buf
 #endif
@@ -344,7 +344,7 @@ int SSL_create_mutex(ssl_mutex_type* mutex)
 	int rc = 0;
 
 	FUNC_ENTRY;
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	*mutex = CreateMutex(NULL, 0, NULL);
 #else
 	rc = pthread_mutex_init(mutex, NULL);
@@ -358,7 +358,7 @@ int SSL_lock_mutex(ssl_mutex_type* mutex)
 	int rc = -1;
 
 	/* don't add entry/exit trace points, as trace gets lock too, and it might happen quite frequently  */
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	if (WaitForSingleObject(*mutex, INFINITE) != WAIT_FAILED)
 #else
 	if ((rc = pthread_mutex_lock(mutex)) == 0)
@@ -373,7 +373,7 @@ int SSL_unlock_mutex(ssl_mutex_type* mutex)
 	int rc = -1;
 
 	/* don't add entry/exit trace points, as trace gets lock too, and it might happen quite frequently  */
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	if (ReleaseMutex(*mutex) != 0)
 #else
 	if ((rc = pthread_mutex_unlock(mutex)) == 0)
@@ -388,7 +388,7 @@ void SSL_destroy_mutex(ssl_mutex_type* mutex)
 	int rc = 0;
 
 	FUNC_ENTRY;
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	rc = CloseHandle(*mutex);
 #else
 	rc = pthread_mutex_destroy(mutex);
@@ -401,7 +401,7 @@ void SSL_destroy_mutex(ssl_mutex_type* mutex)
 #if (OPENSSL_VERSION_NUMBER >= 0x010000000)
 extern void SSLThread_id(CRYPTO_THREADID *id)
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	CRYPTO_THREADID_set_numeric(id, (unsigned long)GetCurrentThreadId());
 #else
 	CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
@@ -410,7 +410,7 @@ extern void SSLThread_id(CRYPTO_THREADID *id)
 #else
 extern unsigned long SSLThread_id(void)
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	return (unsigned long)GetCurrentThreadId();
 #else
 	return (unsigned long)pthread_self();

--- a/src/SSLSocket.h
+++ b/src/SSLSocket.h
@@ -18,7 +18,7 @@
 #if !defined(SSLSOCKET_H)
 #define SSLSOCKET_H
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	#define ssl_mutex_type HANDLE
 #else
 	#include <pthread.h>

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -55,7 +55,7 @@ int Socket_continueWrites(fd_set* pwset);
 char* Socket_getaddrname(struct sockaddr* sa, int sock);
 int Socket_abortWrite(int socket);
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #define iov_len len
 #define iov_base buf
 #endif
@@ -74,7 +74,7 @@ static fd_set wset;
 int Socket_setnonblocking(int sock)
 {
 	int rc;
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	u_long flag = 1L;
 
 	FUNC_ENTRY;
@@ -102,7 +102,7 @@ int Socket_error(char* aString, int sock)
 {
 	int err;
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	err = WSAGetLastError();
 #else
 	err = errno;
@@ -121,7 +121,7 @@ int Socket_error(char* aString, int sock)
  */
 void Socket_outInitialize(void)
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	WORD    winsockVer = 0x0202;
 	WSADATA wsd;
 
@@ -155,7 +155,7 @@ void Socket_outTerminate(void)
 	ListFree(s.write_pending);
 	ListFree(s.clientsds);
 	SocketBuffer_terminate();
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	WSACleanup();
 #endif
 	FUNC_EXIT;
@@ -425,7 +425,7 @@ int Socket_writev(int socket, iobuf* iovecs, int count, unsigned long* bytes)
 
 	FUNC_ENTRY;
 	*bytes = 0L;
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	rc = WSASend(socket, iovecs, count, (LPDWORD)bytes, 0, NULL, NULL);
 	if (rc == SOCKET_ERROR)
 	{
@@ -585,7 +585,7 @@ int Socket_close_only(int socket)
 	int rc;
 
 	FUNC_ENTRY;
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	if (shutdown(socket, SD_BOTH) == SOCKET_ERROR)
 		Socket_error("shutdown", socket);
 	if ((rc = closesocket(socket)) == SOCKET_ERROR)
@@ -662,7 +662,7 @@ int Socket_new(const char* addr, size_t addr_len, int port, int* sock)
 	struct sockaddr_in6 address6;
 #endif
 	int rc = SOCKET_ERROR;
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	short family;
 #else
 	sa_family_t family = AF_INET;
@@ -999,7 +999,7 @@ char* Socket_getaddrname(struct sockaddr* sa, int sock)
 #define PORTLEN 10
 	static char addr_string[ADDRLEN + PORTLEN];
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	int buflen = ADDRLEN*2;
 	wchar_t buf[ADDRLEN*2];
 	if (WSAAddressToStringW(sa, sizeof(struct sockaddr_in6), NULL, buf, (LPDWORD)&buflen) == SOCKET_ERROR)

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -20,7 +20,7 @@
 
 #include <sys/types.h>
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #include <errno.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>

--- a/src/SocketBuffer.c
+++ b/src/SocketBuffer.c
@@ -34,7 +34,7 @@
 
 #include "Heap.h"
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #define iov_len len
 #define iov_base buf
 #endif

--- a/src/SocketBuffer.h
+++ b/src/SocketBuffer.h
@@ -18,7 +18,7 @@
 #if !defined(SOCKETBUFFER_H)
 #define SOCKETBUFFER_H
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #include <winsock2.h>
 #else
 #include <sys/socket.h>
@@ -28,7 +28,7 @@
 #include <openssl/ssl.h>
 #endif
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	typedef WSABUF iobuf;
 #else
 	typedef struct iovec iobuf;

--- a/src/StackTrace.c
+++ b/src/StackTrace.c
@@ -25,7 +25,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #define snprintf _snprintf
 #endif
 
@@ -64,7 +64,7 @@ static int thread_count = 0;
 static threadEntry threads[MAX_THREADS];
 static threadEntry *my_thread = NULL;
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 mutex_type stack_mutex;
 #else
 static pthread_mutex_t stack_mutex_store = PTHREAD_MUTEX_INITIALIZER;

--- a/src/StackTrace.h
+++ b/src/StackTrace.h
@@ -34,7 +34,7 @@
 #define FUNC_EXIT_MED_RC(x)
 #define FUNC_EXIT_MAX_RC(x)
 #else
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #define inline __inline
 #define FUNC_ENTRY StackTrace_entry(__FUNCTION__, __LINE__, TRACE_MINIMUM)
 #define FUNC_ENTRY_NOLOG StackTrace_entry(__FUNCTION__, __LINE__, -1)

--- a/src/Thread.c
+++ b/src/Thread.c
@@ -38,7 +38,7 @@
 #undef realloc
 #undef free
 
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 #include <errno.h>
 #include <unistd.h>
 #include <sys/time.h>
@@ -59,7 +59,7 @@
  */
 thread_type Thread_start(thread_fn fn, void* parameter)
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	thread_type thread = NULL;
 #else
 	thread_type thread = 0;
@@ -67,7 +67,7 @@ thread_type Thread_start(thread_fn fn, void* parameter)
 #endif
 
 	FUNC_ENTRY;
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	thread = CreateThread(NULL, 0, fn, parameter, 0, NULL);
 #else
 	pthread_attr_init(&attr);
@@ -91,7 +91,7 @@ mutex_type Thread_create_mutex(void)
 	int rc = 0;
 
 	FUNC_ENTRY;
-	#if defined(WIN32) || defined(WIN64)
+	#if defined(_WIN32) || defined(_WIN64)
 		mutex = CreateMutex(NULL, 0, NULL);
 		if (mutex == NULL)
 			rc = GetLastError();
@@ -113,7 +113,7 @@ int Thread_lock_mutex(mutex_type mutex)
 	int rc = -1;
 
 	/* don't add entry/exit trace points as the stack log uses mutexes - recursion beckons */
-	#if defined(WIN32) || defined(WIN64)
+	#if defined(_WIN32) || defined(_WIN64)
 		/* WaitForSingleObject returns WAIT_OBJECT_0 (0), on success */
 		rc = WaitForSingleObject(mutex, INFINITE);
 	#else
@@ -134,7 +134,7 @@ int Thread_unlock_mutex(mutex_type mutex)
 	int rc = -1;
 
 	/* don't add entry/exit trace points as the stack log uses mutexes - recursion beckons */
-	#if defined(WIN32) || defined(WIN64)
+	#if defined(_WIN32) || defined(_WIN64)
 		/* if ReleaseMutex fails, the return value is 0 */
 		if (ReleaseMutex(mutex) == 0)
 			rc = GetLastError();
@@ -157,7 +157,7 @@ void Thread_destroy_mutex(mutex_type mutex)
 	int rc = 0;
 
 	FUNC_ENTRY;
-	#if defined(WIN32) || defined(WIN64)
+	#if defined(_WIN32) || defined(_WIN64)
 		rc = CloseHandle(mutex);
 	#else
 		rc = pthread_mutex_destroy(mutex);
@@ -173,7 +173,7 @@ void Thread_destroy_mutex(mutex_type mutex)
  */
 thread_id_type Thread_getid(void)
 {
-	#if defined(WIN32) || defined(WIN64)
+	#if defined(_WIN32) || defined(_WIN64)
 		return GetCurrentThreadId();
 	#else
 		return pthread_self();
@@ -191,7 +191,7 @@ sem_type Thread_create_sem(void)
 	int rc = 0;
 
 	FUNC_ENTRY;
-	#if defined(WIN32) || defined(WIN64)
+	#if defined(_WIN32) || defined(_WIN64)
 		sem = CreateEvent(
 		        NULL,               /* default security attributes */
 		        FALSE,              /* manual-reset event? */
@@ -230,7 +230,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
  * so I've used trywait in a loop instead. Ian Craggs 23/7/2010
  */
 	int rc = -1;
-#if !defined(WIN32) && !defined(WIN64) && !defined(OSX)
+#if !defined(_WIN32) && !defined(_WIN64) && !defined(OSX)
 #define USE_TRYWAIT
 #if defined(USE_TRYWAIT)
 	int i = 0;
@@ -242,7 +242,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
 #endif
 
 	FUNC_ENTRY;
-	#if defined(WIN32) || defined(WIN64)
+	#if defined(_WIN32) || defined(_WIN64)
 		/* returns 0 (WAIT_OBJECT_0) on success, non-zero (WAIT_TIMEOUT) if timeout occurred */
 		rc = WaitForSingleObject(sem, timeout < 0 ? 0 : timeout);
 		if (rc == WAIT_TIMEOUT)
@@ -288,7 +288,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
  */
 int Thread_check_sem(sem_type sem)
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	/* if the return value is not 0, the semaphore will not have been decremented */
 	return WaitForSingleObject(sem, 0) == WAIT_OBJECT_0;
 #elif defined(OSX)
@@ -312,7 +312,7 @@ int Thread_post_sem(sem_type sem)
 	int rc = 0;
 
 	FUNC_ENTRY;
-	#if defined(WIN32) || defined(WIN64)
+	#if defined(_WIN32) || defined(_WIN64)
 		if (SetEvent(sem) == 0)
 			rc = GetLastError();
 	#elif defined(OSX)
@@ -340,7 +340,7 @@ int Thread_destroy_sem(sem_type sem)
 	int rc = 0;
 
 	FUNC_ENTRY;
-	#if defined(WIN32) || defined(WIN64)
+	#if defined(_WIN32) || defined(_WIN64)
 		rc = CloseHandle(sem);
   #elif defined(OSX)
 	  dispatch_release(sem);
@@ -353,7 +353,7 @@ int Thread_destroy_sem(sem_type sem)
 }
 
 
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 
 /**
  * Create a new condition variable
@@ -443,7 +443,7 @@ int Thread_destroy_cond(cond_type condvar)
 
 #if defined(THREAD_UNIT_TESTS)
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -473,7 +473,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;

--- a/src/Thread.h
+++ b/src/Thread.h
@@ -23,7 +23,7 @@
 
 #include "mutex_type.h" /* Needed for mutex_type */
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	#include <windows.h>
 	#define thread_type HANDLE
 	#define thread_id_type DWORD

--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -21,7 +21,7 @@
 #include <string.h>
 // for timeout process in WebSocket_proxy_connect()
 #include <time.h>
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #else
 #include <unistd.h>
@@ -49,7 +49,7 @@
 #  define be64toh(x) OSSwapBigToHostInt64(x)
 #elif defined(__FreeBSD__) || defined(__NetBSD__)
 #  include <sys/endian.h>
-#elif defined(WIN32) || defined(WIN64)
+#elif defined(_WIN32) || defined(_WIN64)
 #  pragma comment(lib, "rpcrt4.lib")
 #  include <Rpc.h>
 #  define strncasecmp(s1,s2,c) _strnicmp(s1,s2,c)
@@ -87,7 +87,7 @@
 
 #define HTTP_PROTOCOL(x) x ? "https" : "http"
 
-#if !(defined(WIN32) || defined(WIN64))
+#if !(defined(_WIN32) || defined(_WIN64))
 #if defined(LIBUUID)
 #include <uuid/uuid.h>
 #else /* if defined(USE_LIBUUID) */
@@ -137,7 +137,7 @@ void uuid_unparse( uuid_t uu, char *out )
 	*out = '\0';
 }
 #endif /* else if defined(LIBUUID) */
-#endif /* if !(defined(WIN32) || defined(WIN64)) */
+#endif /* if !(defined(_WIN32) || defined(_WIN64)) */
 
 /** raw websocket frame data */
 struct ws_frame
@@ -334,11 +334,11 @@ int WebSocket_connect( networkHandles *net, const char *uri )
 	size_t hostname_len;
 	int port = 80;
 	const char *topic = NULL;
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	UUID uuid;
-#else /* if defined(WIN32) || defined(WIN64) */
+#else /* if defined(_WIN32) || defined(_WIN64) */
 	uuid_t uuid;
-#endif /* else if defined(WIN32) || defined(WIN64) */
+#endif /* else if defined(_WIN32) || defined(_WIN64) */
 
 	FUNC_ENTRY;
 	/* Generate UUID */
@@ -346,14 +346,14 @@ int WebSocket_connect( networkHandles *net, const char *uri )
 		net->websocket_key = malloc(25u);
 	else
 		net->websocket_key = realloc(net->websocket_key, 25u);
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	ZeroMemory( &uuid, sizeof(UUID) );
 	UuidCreate( &uuid );
 	Base64_encode( net->websocket_key, 25u, (const b64_data_t*)&uuid, sizeof(UUID) );
-#else /* if defined(WIN32) || defined(WIN64) */
+#else /* if defined(_WIN32) || defined(_WIN64) */
 	uuid_generate( uuid );
 	Base64_encode( net->websocket_key, 25u, uuid, sizeof(uuid_t) );
-#endif /* else if defined(WIN32) || defined(WIN64) */
+#endif /* else if defined(_WIN32) || defined(_WIN64) */
 
 	hostname_len = MQTTProtocol_addressPort(uri, &port, &topic);
 
@@ -1377,7 +1377,7 @@ int WebSocket_proxy_connect( networkHandles *net, int ssl, const char *hostname)
 				rc = SOCKET_ERROR;
 				break;
 			}
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 			Sleep(250);
 #else
 			usleep(250000);

--- a/src/mutex_type.h
+++ b/src/mutex_type.h
@@ -14,7 +14,7 @@
 #if !defined(_MUTEX_TYPE_H_)
 #define _MUTEX_TYPE_H_
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	#include <windows.h>
 	#define mutex_type HANDLE
 #else

--- a/src/samples/MQTTAsync_publish.c
+++ b/src/samples/MQTTAsync_publish.c
@@ -19,7 +19,7 @@
 #include <string.h>
 #include "MQTTAsync.h"
 
-#if !defined(WIN32)
+#if !defined(_WIN32)
 #include <unistd.h>
 #else
 #include <windows.h>
@@ -144,7 +144,7 @@ int main(int argc, char* argv[])
          "on topic %s for client with ClientID: %s\n",
          PAYLOAD, TOPIC, CLIENTID);
 	while (!finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);

--- a/src/samples/MQTTAsync_subscribe.c
+++ b/src/samples/MQTTAsync_subscribe.c
@@ -19,7 +19,7 @@
 #include <string.h>
 #include "MQTTAsync.h"
 
-#if !defined(WIN32)
+#if !defined(_WIN32)
 #include <unistd.h>
 #else
 #include <windows.h>
@@ -159,7 +159,7 @@ int main(int argc, char* argv[])
 	}
 
 	while	(!subscribed)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -180,7 +180,7 @@ int main(int argc, char* argv[])
 		exit(EXIT_FAILURE);
 	}
  	while	(!disc_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);

--- a/src/samples/paho_c_pub.c
+++ b/src/samples/paho_c_pub.c
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #define sleep Sleep
 #else
@@ -56,7 +56,7 @@ MQTTProperties props = MQTTProperties_initializer;
 
 void mysleep(int ms)
 {
-	#if defined(WIN32)
+	#if defined(_WIN32)
 		Sleep(ms);
 	#else
 		usleep(ms * 1000);
@@ -371,7 +371,7 @@ int main(int argc, char** argv)
 	const char* version = NULL;
 	const char* program_name = "paho_c_pub";
 	MQTTAsync_nameValue* infos = MQTTAsync_getVersionInfo();
-#if !defined(WIN32)
+#if !defined(_WIN32)
     struct sigaction sa;
 #endif
 
@@ -408,7 +408,7 @@ int main(int argc, char** argv)
 		exit(EXIT_FAILURE);
 	}
 
-#if defined(WIN32)
+#if defined(_WIN32)
 	signal(SIGINT, cfinish);
 	signal(SIGTERM, cfinish);
 #else

--- a/src/samples/paho_c_sub.c
+++ b/src/samples/paho_c_sub.c
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #define sleep Sleep
 #else
@@ -46,7 +46,7 @@ int disconnected = 0;
 
 void mysleep(int ms)
 {
-	#if defined(WIN32)
+	#if defined(_WIN32)
 		Sleep(ms);
 	#else
 		usleep(ms * 1000);
@@ -209,7 +209,7 @@ int main(int argc, char** argv)
 	const char* version = NULL;
 	const char* program_name = "paho_c_sub";
 	MQTTAsync_nameValue* infos = MQTTAsync_getVersionInfo();
-#if !defined(WIN32)
+#if !defined(_WIN32)
     struct sigaction sa;
 #endif
 
@@ -257,7 +257,7 @@ int main(int argc, char** argv)
 		exit(EXIT_FAILURE);
 	}
 
-#if defined(WIN32)
+#if defined(_WIN32)
 	signal(SIGINT, cfinish);
 	signal(SIGTERM, cfinish);
 #else

--- a/src/samples/paho_cs_pub.c
+++ b/src/samples/paho_cs_pub.c
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #define sleep Sleep
 #else
 #include <sys/time.h>
@@ -144,7 +144,7 @@ int main(int argc, char** argv)
 	int rc = 0;
 	char* url;
 	const char* version = NULL;
-#if !defined(WIN32)
+#if !defined(_WIN32)
     struct sigaction sa;
 #endif
 	const char* program_name = "paho_cs_pub";
@@ -183,7 +183,7 @@ int main(int argc, char** argv)
 		exit(EXIT_FAILURE);
 	}
 
-#if defined(WIN32)
+#if defined(_WIN32)
 	signal(SIGINT, cfinish);
 	signal(SIGTERM, cfinish);
 #else

--- a/src/samples/paho_cs_sub.c
+++ b/src/samples/paho_cs_sub.c
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #define sleep Sleep
 #else
 #include <sys/time.h>
@@ -141,7 +141,7 @@ int main(int argc, char** argv)
 	int rc = 0;
 	char* url;
 	const char* version = NULL;
-#if !defined(WIN32)
+#if !defined(_WIN32)
     struct sigaction sa;
 #endif
 	const char* program_name = "paho_cs_sub";
@@ -183,7 +183,7 @@ int main(int argc, char** argv)
 		exit(EXIT_FAILURE);
 	}
 
-#if defined(WIN32)
+#if defined(_WIN32)
 	signal(SIGINT, cfinish);
 	signal(SIGTERM, cfinish);
 #else

--- a/test/sync_client_test.c
+++ b/test/sync_client_test.c
@@ -171,7 +171,7 @@ void getopts(int argc, char** argv)
 }
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define msleep Sleep
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -597,11 +597,11 @@ int retained_message_test(void)
 
 int test6_socket_error(char* aString, int sock)
 {
-#if defined(WIN32)
+#if defined(_WIN32)
 	int errno;
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
 	errno = WSAGetLastError();
 #endif
 	if (errno != EINTR && errno != EAGAIN && errno != EINPROGRESS && errno != EWOULDBLOCK)
@@ -616,7 +616,7 @@ int test6_socket_close(int socket)
 {
 	int rc;
 
-#if defined(WIN32)
+#if defined(_WIN32)
 	if (shutdown(socket, SD_BOTH) == SOCKET_ERROR)
 		test6_socket_error("shutdown", socket);
 	if ((rc = closesocket(socket)) == SOCKET_ERROR)

--- a/test/test1.c
+++ b/test/test1.c
@@ -172,7 +172,7 @@ void MyLog(int LOGA_level, char* format, ...)
 }
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -202,7 +202,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;
@@ -476,7 +476,7 @@ void test2_sendAndReceive(MQTTClient* c, int qos, char* test_topic)
 			rc = MQTTClient_publishMessage(c, test_topic, &test2_pubmsg, &dt);
 		assert("Good rc from publish", rc == MQTTCLIENT_SUCCESS, "rc was %d", rc);
 
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(100000L);
@@ -486,7 +486,7 @@ void test2_sendAndReceive(MQTTClient* c, int qos, char* test_topic)
 		while ((test2_arrivedcount < i) && (wait_seconds-- > 0))
 		{
 			MyLog(LOGA_DEBUG, "Arrived %d count %d", test2_arrivedcount, i);
-			#if defined(WIN32)
+			#if defined(_WIN32)
 				Sleep(1000);
 			#else
 				usleep(1000000L);
@@ -505,7 +505,7 @@ void test2_sendAndReceive(MQTTClient* c, int qos, char* test_topic)
 		while ((test2_deliveryCompleted < iterations) && (wait_seconds-- > 0))
 		{
 			MyLog(LOGA_DEBUG, "Delivery Completed %d count %d", test2_deliveryCompleted, i);
-			#if defined(WIN32)
+			#if defined(_WIN32)
 				Sleep(1000);
 			#else
 				usleep(1000000L);
@@ -1006,7 +1006,7 @@ int test6(struct Options options)
 	count = 0;
 	while (++count < 40)
 	{
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(1000L);
 		#else
 			sleep(1);
@@ -1114,7 +1114,7 @@ int test6a(struct Options options)
 	count = 0;
 	while (++count < 40)
 	{
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(1000L);
 		#else
 			sleep(1);

--- a/test/test10.c
+++ b/test/test10.c
@@ -173,7 +173,7 @@ void MyLog(int LOGA_level, char* format, ...)
 
 	strcpy(msg_buf, "");
 	ftime(&ts);
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 	localtime_s(&timeinfo, &ts.time);
 #else
 	localtime_r(&ts.time, &timeinfo);
@@ -191,7 +191,7 @@ void MyLog(int LOGA_level, char* format, ...)
 }
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -221,7 +221,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;
@@ -452,7 +452,7 @@ int test_client_topic_aliases(struct Options options)
 	count = 0;
 	while (test_topic_aliases_globals.disconnected == 0 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -498,7 +498,7 @@ int test_client_topic_aliases(struct Options options)
 	/* should get a response */
 	while (messages_arrived == 0 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -514,7 +514,7 @@ int test_client_topic_aliases(struct Options options)
 	/* should get a response */
 	while (messages_arrived == 0 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -541,7 +541,7 @@ int test_client_topic_aliases(struct Options options)
 	/* should get a response */
 	while (messages_arrived == 0 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -561,7 +561,7 @@ int test_client_topic_aliases(struct Options options)
 	/* should not get a response */
 	while (messages_arrived == 0 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -573,7 +573,7 @@ int test_client_topic_aliases(struct Options options)
 	count = 0;
 	while (test_topic_aliases_globals.disconnected == 0 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -716,7 +716,7 @@ int test_server_topic_aliases(struct Options options)
 	/* should get responses */
 	while (messages_arrived < msg_count && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -858,7 +858,7 @@ int test_subscription_ids(struct Options options)
 	/* should get responses */
 	while (messages_arrived < msg_count && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -985,7 +985,7 @@ int test_flow_control(struct Options options)
 	/* should get responses */
 	while (messages_arrived < receive_maximum + 2 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -1212,7 +1212,7 @@ int test_qos_1_2_errors(struct Options options)
 	count = 0;
 	while (test_qos_1_2_errors_globals.published == 0 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -1234,7 +1234,7 @@ int test_qos_1_2_errors(struct Options options)
 	count = 0;
 	while (test_qos_1_2_errors_globals.published == 0 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -1255,7 +1255,7 @@ int test_qos_1_2_errors(struct Options options)
 	count = 0;
 	while (test_qos_1_2_errors_globals.published == 0 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -1439,7 +1439,7 @@ int test_request_response(struct Options options)
 	/* should get the request */
 	while (test_request_response_globals.messages_arrived < 1 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -1460,7 +1460,7 @@ int test_request_response(struct Options options)
 	/* should get the response */
 	while (test_request_response_globals.messages_arrived < 1 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -1610,7 +1610,7 @@ int test_subscribe_options(struct Options options)
 	/* should get the request */
 	while (test_subscribe_options_globals.messages_arrived < 1 && ++count < 10)
 	{
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(1000);
 #else
 		usleep(1000000L);
@@ -1777,7 +1777,7 @@ int test_shared_subscriptions(struct Options options)
 		/* should get the request */
 		while (test_shared_subscriptions_globals.messages_arrived < i+1 && ++count < 100)
 		{
-#if defined(WIN32)
+#if defined(_WIN32)
 			Sleep(100);
 #else
 			usleep(100000L);

--- a/test/test11.c
+++ b/test/test11.c
@@ -149,7 +149,7 @@ void MyLog(int LOGA_level, char* format, ...)
 #endif
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -179,7 +179,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;
@@ -508,7 +508,7 @@ int test_client_topic_aliases(struct Options options)
 		goto exit;
 
 	while (test_client_topic_aliases_globals.disconnected == 0)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -521,7 +521,7 @@ int test_client_topic_aliases(struct Options options)
 		goto exit;
 
 	while (test_client_topic_aliases_globals.test_finished == 0)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -699,7 +699,7 @@ int test_server_topic_aliases(struct Options options)
 		goto exit;
 
 	while (test_server_topic_aliases_globals.test_finished == 0)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -879,7 +879,7 @@ int test_subscription_ids(struct Options options)
 		goto exit;
 
 	while (test_subscription_ids_globals.test_finished == 0)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1041,7 +1041,7 @@ int test_flow_control(struct Options options)
 		goto exit;
 
 	while (test_flow_control_globals.test_finished == 0)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1215,7 +1215,7 @@ int test_error_reporting(struct Options options)
 		goto exit;
 
 	while (test_error_reporting_globals.test_finished == 0)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1420,7 +1420,7 @@ int test_qos_1_2_errors(struct Options options)
 		goto exit;
 
 	while (test_qos_1_2_errors_globals.test_finished == 0)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1657,7 +1657,7 @@ int test_request_response(struct Options options)
 		goto exit;
 
 	while (test_request_response_globals.test_finished == 0)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1844,7 +1844,7 @@ int test_subscribeOptions(struct Options options)
 		goto exit;
 
 	while (test_subscribeOptions_globals.test_finished == 0)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -2044,14 +2044,14 @@ int test_shared_subscriptions(struct Options options)
 		goto exit;
 
 	while (test_shared_subscriptions_globals.test_finished == 0 && ++count < 1000)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
 		#endif
 
 	/* sleep a bit more to see if any other messages arrive */
-	#if defined(WIN32)
+	#if defined(_WIN32)
 		Sleep(100);
 	#else
 		usleep(10000L);

--- a/test/test15.c
+++ b/test/test15.c
@@ -174,7 +174,7 @@ void MyLog(int LOGA_level, char* format, ...)
 }
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -204,7 +204,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;
@@ -594,7 +594,7 @@ void test2_sendAndReceive(MQTTClient* c, int qos, char* test_topic)
 			response = MQTTClient_publishMessage5(c, test_topic, &test2_pubmsg, &dt);
 		assert("Good rc from publish", response.reasonCode == MQTTCLIENT_SUCCESS, "rc was %d", response.reasonCode);
 
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(100000L);
@@ -604,7 +604,7 @@ void test2_sendAndReceive(MQTTClient* c, int qos, char* test_topic)
 		while ((test2_arrivedcount < i) && (wait_seconds-- > 0))
 		{
 			MyLog(LOGA_DEBUG, "Arrived %d count %d", test2_arrivedcount, i);
-			#if defined(WIN32)
+			#if defined(_WIN32)
 				Sleep(1000);
 			#else
 				usleep(1000000L);
@@ -623,7 +623,7 @@ void test2_sendAndReceive(MQTTClient* c, int qos, char* test_topic)
 		while ((test2_deliveryCompleted < iterations) && (wait_seconds-- > 0))
 		{
 			MyLog(LOGA_DEBUG, "Delivery Completed %d count %d", test2_deliveryCompleted, i);
-			#if defined(WIN32)
+			#if defined(_WIN32)
 				Sleep(1000);
 			#else
 				usleep(1000000L);
@@ -1243,7 +1243,7 @@ int test6(struct Options options)
 	count = 0;
 	while (++count < 40)
 	{
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(1000L);
 		#else
 			sleep(1);
@@ -1359,7 +1359,7 @@ int test6a(struct Options options)
 	count = 0;
 	while (++count < 40)
 	{
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(1000L);
 		#else
 			sleep(1);

--- a/test/test2.c
+++ b/test/test2.c
@@ -163,7 +163,7 @@ void MyLog(int LOGA_level, char* format, ...)
 }
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -193,7 +193,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;
@@ -267,7 +267,7 @@ void myassert(char* filename, int lineno, char* description, int value, char* fo
 }
 
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 mutex_type deliveryCompleted_mutex = NULL;
 #else
 pthread_mutex_t deliveryCompleted_mutex_store = PTHREAD_MUTEX_INITIALIZER;
@@ -368,7 +368,7 @@ thread_return_type WINAPI test1_sendAndReceive(void* n)
 			rc = MQTTClient_publishMessage(c, test_topic, &test1_pubmsg, &dt);
 		assert("Good rc from publish", rc == MQTTCLIENT_SUCCESS, "rc was %d", rc);
 
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(100000L);
@@ -378,7 +378,7 @@ thread_return_type WINAPI test1_sendAndReceive(void* n)
 		while ((test1_arrivedcount_qos[qos] < i) && (wait_seconds-- > 0))
 		{
 			MyLog(LOGA_DEBUG, "Arrived %d count %d", test1_arrivedcount_qos[qos], i);
-			#if defined(WIN32)
+			#if defined(_WIN32)
 				Sleep(1000);
 			#else
 				usleep(1000000L);
@@ -466,7 +466,7 @@ int test1(struct Options options)
 	int wait_seconds = 90;
 	while (((test1_arrivedcount < iterations*3) || (test1_deliveryCompleted < iterations*2)) && (wait_seconds-- > 0))
 	{
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(1000);
 		#else
 			usleep(1000000L);
@@ -560,7 +560,7 @@ void test2_sendAndReceive(MQTTClient* c, int qos, char* test_topic)
 			rc = MQTTClient_publishMessage(c, test_topic, &test2_pubmsg, &dt);
 		assert("Good rc from publish", rc == MQTTCLIENT_SUCCESS, "rc was %d", rc);
 
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(100000L);
@@ -570,7 +570,7 @@ void test2_sendAndReceive(MQTTClient* c, int qos, char* test_topic)
 		while ((test2_arrivedcount < i) && (wait_seconds-- > 0))
 		{
 			MyLog(LOGA_DEBUG, "Arrived %d count %d", test2_arrivedcount, i);
-			#if defined(WIN32)
+			#if defined(_WIN32)
 				Sleep(1000);
 			#else
 				usleep(1000000L);
@@ -589,7 +589,7 @@ void test2_sendAndReceive(MQTTClient* c, int qos, char* test_topic)
 		while ((test2_deliveryCompleted < iterations) && (wait_seconds-- > 0))
 		{
 			MyLog(LOGA_DEBUG, "Delivery Completed %d count %d", test2_deliveryCompleted, i);
-			#if defined(WIN32)
+			#if defined(_WIN32)
 				Sleep(1000);
 			#else
 				usleep(1000000L);
@@ -667,7 +667,7 @@ int main(int argc, char** argv)
  	int (*tests[])() = {NULL, test1};
 	int i;
 
-	#if defined(WIN32) || defined(WIN64)
+	#if defined(_WIN32) || defined(_WIN64)
 	deliveryCompleted_mutex = CreateMutex(NULL, 0, NULL);
 	#endif
 

--- a/test/test3.c
+++ b/test/test3.c
@@ -291,7 +291,7 @@ void MyLog(int LOGA_level, char* format, ...)
 }
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -321,7 +321,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;
@@ -520,7 +520,7 @@ void multiThread_sendAndReceive(MQTTClient* c, int qos, char* test_topic)
 			rc = MQTTClient_publishMessage(c, test_topic, &multiThread_pubmsg, &dt);
 		assert("Good rc from publish", rc == MQTTCLIENT_SUCCESS, "rc was %d", rc);
 
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(100000L);
@@ -530,7 +530,7 @@ void multiThread_sendAndReceive(MQTTClient* c, int qos, char* test_topic)
 		while ((multiThread_arrivedcount < i) && (wait_seconds-- > 0))
 		{
 			MyLog(LOGA_DEBUG, "Arrived %d count %d", multiThread_arrivedcount, i);
-			#if defined(WIN32)
+			#if defined(_WIN32)
 				Sleep(1000);
 			#else
 				usleep(1000000L);
@@ -549,7 +549,7 @@ void multiThread_sendAndReceive(MQTTClient* c, int qos, char* test_topic)
 		while ((multiThread_deliveryCompleted < iterations) && (wait_seconds-- > 0))
 		{
 			MyLog(LOGA_DEBUG, "Delivery Completed %d count %d", multiThread_deliveryCompleted, i);
-			#if defined(WIN32)
+			#if defined(_WIN32)
 				Sleep(1000);
 			#else
 				usleep(1000000L);

--- a/test/test4.c
+++ b/test/test4.c
@@ -148,7 +148,7 @@ void MyLog(int LOGA_level, char* format, ...)
 #endif
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -178,7 +178,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;
@@ -400,7 +400,7 @@ int test1(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -494,7 +494,7 @@ int test2(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -705,7 +705,7 @@ int test3(struct Options options)
 	while (test_finished < num_clients)
 	{
 		MyLog(LOGA_DEBUG, "num_clients %d test_finished %d\n", num_clients, test_finished);
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -894,7 +894,7 @@ int test4(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(1000L);
@@ -977,7 +977,7 @@ int test5(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1073,7 +1073,7 @@ int test6(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1107,7 +1107,7 @@ int test6(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1289,7 +1289,7 @@ int test7(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1306,7 +1306,7 @@ int test7(struct Options options)
 		goto exit;
 
 	while (!test7_subscribed)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1343,7 +1343,7 @@ int test7(struct Options options)
 	MQTTAsync_disconnect(c, &dopts); /* now there should be "orphaned" publications */
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1392,7 +1392,7 @@ int test7(struct Options options)
 		goto exit;
 	}
 
-	#if defined(WIN32)
+	#if defined(_WIN32)
 		Sleep(5000);
 	#else
 		usleep(5000000L);
@@ -1413,7 +1413,7 @@ int test7(struct Options options)
 	MQTTAsync_disconnect(c, &dopts);
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1569,7 +1569,7 @@ int test8(struct Options options)
 		goto exit;
 
 	while (!test8_subscribed)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1597,7 +1597,7 @@ int test8(struct Options options)
 	assert("Good rc from disconnect", rc == MQTTASYNC_SUCCESS, "rc was %d", rc);
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1625,7 +1625,7 @@ int test8(struct Options options)
 		goto exit;
 
 	while (!test8_subscribed)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1653,7 +1653,7 @@ int test8(struct Options options)
 	assert("Good rc from disconnect", rc == MQTTASYNC_SUCCESS, "rc was %d", rc);
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);

--- a/test/test45.c
+++ b/test/test45.c
@@ -134,7 +134,7 @@ void MyLog(int LOGA_level, char* format, ...)
 	  return;
 
 	ftime(&ts);
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 	localtime_s(&timeinfo, &ts.time);
 #else
 	localtime_r(&ts.time, &timeinfo);
@@ -155,7 +155,7 @@ void MyLog(int LOGA_level, char* format, ...)
 
 void MySleep(long milliseconds)
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);
@@ -163,7 +163,7 @@ void MySleep(long milliseconds)
 }
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
 START_TIME_TYPE start_clock(void)
@@ -190,7 +190,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;

--- a/test/test5.c
+++ b/test/test5.c
@@ -256,7 +256,7 @@ void MyLog(int LOGA_level, char* format, ...)
 }
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -285,7 +285,7 @@ START_TIME_TYPE start_clock(void)
 }
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;
@@ -424,7 +424,7 @@ void sendAndReceive(MQTTAsync* c, int qos, char* test_topic)
 					&ropts);
 		assert("Good rc from publish", rc == MQTTASYNC_SUCCESS, "rc was %d", rc);
 
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(100000L);
@@ -435,7 +435,7 @@ void sendAndReceive(MQTTAsync* c, int qos, char* test_topic)
 		{
 			MyLog(LOGA_DEBUG, "Arrived %d count %d", multiThread_arrivedcount,
 					i);
-#if defined(WIN32)
+#if defined(_WIN32)
 			Sleep(1000);
 #else
 			usleep(1000000L);
@@ -456,7 +456,7 @@ void sendAndReceive(MQTTAsync* c, int qos, char* test_topic)
 		{
 			MyLog(LOGA_DEBUG, "Delivery Completed %d count %d",
 					multiThread_deliveryCompleted, i);
-#if defined(WIN32)
+#if defined(_WIN32)
 			Sleep(1000);
 #else
 			usleep(1000000L);
@@ -719,7 +719,7 @@ int test1(struct Options options)
 
 	/* wait for success or failure callback */
 	while (!test1Finished && ++count < 10000)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -825,7 +825,7 @@ int test2a(struct Options options)
 		goto exit;
 
 	while (!tc.subscribed && !tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -835,7 +835,7 @@ int test2a(struct Options options)
 		goto exit;
 
 	while (!tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -932,7 +932,7 @@ int test2b(struct Options options)
 		goto exit;
 
 	while (!test2bFinished && ++count < 10000)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -1030,7 +1030,7 @@ int test2c(struct Options options)
 	}
 
 	while (!test2cFinished && ++count < 10000)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -1139,7 +1139,7 @@ int test2d(struct Options options)
 #define TEST2D_COUNT 1000
 		while (!test2dFinished && ++count < TEST2D_COUNT)
 		{
-#if defined(WIN32)
+#if defined(_WIN32)
 			Sleep(100);
 #else
 			usleep(10000L);
@@ -1237,7 +1237,7 @@ int test3a(struct Options options)
 		goto exit;
 
 	while (!tc.subscribed && !tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -1266,7 +1266,7 @@ int test3a(struct Options options)
 	}
 
 	while (!tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -1360,7 +1360,7 @@ int test3b(struct Options options)
 		goto exit;
 
 	while (!test3bFinished && ++count < 10000)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -1458,7 +1458,7 @@ int test4(struct Options options)
 		goto exit;
 
 	while (!tc.subscribed && !tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -1487,7 +1487,7 @@ int test4(struct Options options)
 	}
 
 	while (!tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -1591,7 +1591,7 @@ int test5a(struct Options options)
 		goto exit;
 
 	while (!tc.subscribed && !tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -1620,7 +1620,7 @@ int test5a(struct Options options)
 	}
 
 	while (!tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -1724,7 +1724,7 @@ int test5b(struct Options options)
 		goto exit;
 
 	while (!tc.subscribed && !tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -1753,7 +1753,7 @@ int test5b(struct Options options)
 	}
 
 	while (!tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -1845,7 +1845,7 @@ int test5c(struct Options options)
 		goto exit;
 
 	while (!test5cFinished && ++count < 10000)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -1951,7 +1951,7 @@ int test6(struct Options options)
 	{
 		MyLog(LOGA_DEBUG, "num_clients %d test_finished %d\n", num_clients,
 				test6finished);
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 
 #else
@@ -2231,7 +2231,7 @@ int test7(struct Options options)
 		goto exit;
 
 	while (!tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(1000L);
@@ -2323,7 +2323,7 @@ int test8(struct Options options)
 		goto exit;
 
 	while (!tc.subscribed && !tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -2333,7 +2333,7 @@ int test8(struct Options options)
 		goto exit;
 
 	while (!tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -2434,7 +2434,7 @@ int test9(struct Options options)
 		goto exit;
 
 	while (!tc.subscribed && !tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -2444,7 +2444,7 @@ int test9(struct Options options)
 		goto exit;
 
 	while (!tc.testFinished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);
@@ -2555,7 +2555,7 @@ int test10(struct Options options)
 		goto exit;
 
 	while (!test10Finished)
-#if defined(WIN32)
+#if defined(_WIN32)
 		Sleep(100);
 #else
 		usleep(10000L);

--- a/test/test6.c
+++ b/test/test6.c
@@ -202,14 +202,14 @@ void MyLog(int log_level, char* format, ...)
 
 void MySleep(long milliseconds)
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);
 #endif
 }
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
 START_TIME_TYPE start_clock(void)
@@ -235,7 +235,7 @@ START_TIME_TYPE start_clock(void)
 }
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;
@@ -962,7 +962,7 @@ int main(int argc, char** argv)
 	static char topic_buf[200];
 	static char clientid[40];
 
-#if !defined(WIN32)
+#if !defined(_WIN32)
 	signal(SIGPIPE, SIG_IGN);
 #endif
 

--- a/test/test8.c
+++ b/test/test8.c
@@ -124,7 +124,7 @@ void MyLog(int LOGA_level, char* format, ...)
 #endif
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -154,7 +154,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;
@@ -372,7 +372,7 @@ int test1(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -462,7 +462,7 @@ int test2(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -671,7 +671,7 @@ int test3(struct Options options)
 	while (test_finished < num_clients)
 	{
 		MyLog(LOGA_DEBUG, "num_clients %d test_finished %d\n", num_clients, test_finished);
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -858,7 +858,7 @@ int test4(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(1000L);
@@ -941,7 +941,7 @@ int test5a(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1003,7 +1003,7 @@ int test5b(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -1065,7 +1065,7 @@ int test5c(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);

--- a/test/test9.c
+++ b/test/test9.c
@@ -129,14 +129,14 @@ void MyLog(int LOGA_level, char* format, ...)
 
 void MySleep(long milliseconds)
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);
 #endif
 }
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
 START_TIME_TYPE start_clock(void)
@@ -162,7 +162,7 @@ START_TIME_TYPE start_clock(void)
 }
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;

--- a/test/test95.c
+++ b/test/test95.c
@@ -130,14 +130,14 @@ void MyLog(int LOGA_level, char* format, ...)
 
 void MySleep(long milliseconds)
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);
 #endif
 }
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
 START_TIME_TYPE start_clock(void)
@@ -163,7 +163,7 @@ START_TIME_TYPE start_clock(void)
 }
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;

--- a/test/test_issue373.c
+++ b/test/test_issue373.c
@@ -133,7 +133,7 @@ void MyLog(int LOGA_level, char* format, ...)
 
 void MySleep(long milliseconds)
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32) || defined(_WIN64)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);

--- a/test/test_mqtt4async.c
+++ b/test/test_mqtt4async.c
@@ -165,7 +165,7 @@ void MyLog(int LOGA_level, char* format, ...)
 }
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -195,7 +195,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;
@@ -440,7 +440,7 @@ int test1(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);
@@ -574,7 +574,7 @@ int test2(struct Options options)
 		goto exit;
 
 	while (!test_finished)
-		#if defined(WIN32)
+		#if defined(_WIN32)
 			Sleep(100);
 		#else
 			usleep(10000L);

--- a/test/test_mqtt4sync.c
+++ b/test/test_mqtt4sync.c
@@ -165,7 +165,7 @@ void MyLog(int LOGA_level, char* format, ...)
 }
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -195,7 +195,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;

--- a/test/test_sync_session_present.c
+++ b/test/test_sync_session_present.c
@@ -216,7 +216,7 @@ void MyLog(int LOGA_level, char* format, ...)
 }
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mqsleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -246,7 +246,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
     return GetTickCount() - start_time;
@@ -321,7 +321,7 @@ void myassert(char* filename, int lineno, char* description, int value, char* fo
 
 void mysleep(int seconds)
 {
-#if defined(WIN32)
+#if defined(_WIN32)
     Sleep(1000L*seconds);
 #else
     sleep(seconds);

--- a/test/thread.c
+++ b/test/thread.c
@@ -112,7 +112,7 @@ void MyLog(int LOGA_level, char* format, ...)
 }
 
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define mysleep(A) Sleep(1000*A)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
@@ -142,7 +142,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;
@@ -312,7 +312,7 @@ int test_sem(struct Options options)
 	return failures;
 }
 
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 thread_return_type cond_secondary(void* n)
 {
 	int rc = 0;
@@ -485,7 +485,7 @@ int main(int argc, char** argv)
  	int (*tests[])() = {NULL,
  		test_mutex,
  		test_sem,
-#if !defined(WIN32) && !defined(WIN64)
+#if !defined(_WIN32) && !defined(_WIN64)
 		test_cond
 #endif
  	}; /* indexed starting from 1 */


### PR DESCRIPTION
Signed-off-by: fpagliughi <fpagliughi@mindspring.com>

This updates the conditional compilation checks for Windows to use the _WIN32 and _WIN64 pre-defined macros (with the leading underscore).