### PR TITLE
Use find package for openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
 sudo: required
 language: c
-compiler:
-- gcc
-- clang
-os:
-- linux
-- osx
-matrix:
-  exclude:
-  - compiler: gcc
-    os: osx
-  - compiler: clang
-    os: linux
+jobs:
+  include:
+    - os: linux
+      compiler: gcc
+      env: OPENSSL_ROOT_DIR=
+    - os: osx
+      compiler: clang
+      env: OPENSSL_ROOT_DIR=/usr/local/opt/openssl
 before_install:
 #- if [ "$DEPLOY" = "true" ]; then ./travis-setup-deploy.sh; fi
 - "./travis-install.sh"

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Variable | Default Value | Description
 PAHO_BUILD_SHARED | TRUE | Build a shared version of the libraries
 PAHO_BUILD_STATIC | FALSE | Build a static version of the libraries
 PAHO_WITH_SSL | FALSE | Flag that defines whether to build ssl-enabled binaries too. 
-OPENSSL_SEARCH_PATH | "" (system default) | Directory containing your OpenSSL installation (i.e. `/usr/local` when headers are in `/usr/local/include` and libraries are in `/usr/local/lib`)
+OPENSSL_ROOT_DIR | "" (system default) | Directory containing your OpenSSL installation (i.e. `/usr/local` when headers are in `/usr/local/include` and libraries are in `/usr/local/lib`)
 PAHO_BUILD_DOCUMENTATION | FALSE | Create and install the HTML based API documentation (requires Doxygen)
 PAHO_BUILD_SAMPLES | FALSE | Build sample programs
 MQTT_TEST_BROKER | tcp://localhost:1883 | MQTT connection URL for a broker to use during test execution

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,10 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       PAHO_WINDOWS_BUILD_BIT: x86
+      OPENSSL_ROOT_DIR: "C:/OpenSSL-Win32"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       PAHO_WINDOWS_BUILD_BIT: x64
+      OPENSSL_ROOT_DIR: "C:/OpenSSL-Win64"
     
 configuration: Debug
 install:
@@ -32,7 +34,7 @@ build_script:
 
     if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2013" call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" %PAHO_WINDOWS_BUILD_BIT%
 
-    cmake -G "NMake Makefiles" -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=TRUE ..
+    cmake -G "NMake Makefiles" -DPAHO_WITH_SSL=TRUE -DOPENSSL_ROOT_DIR=%OPENSSL_ROOT_DIR% -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=TRUE ..
 
     nmake
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,48 +141,13 @@ INSTALL(FILES MQTTAsync.h MQTTClient.h MQTTClientPersistence.h MQTTProperties.h 
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 IF (PAHO_WITH_SSL)
-    SET(OPENSSL_SEARCH_PATH "" CACHE PATH "Directory containing OpenSSL libraries and includes")
-
-    IF (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-        IF(OPENSSL_SEARCH_PATH STREQUAL "")
-            SET(OPENSSL_SEARCH_PATH "/usr/local/opt/openssl")
-        ENDIF ()
-    ENDIF (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-
-    IF (WIN32)
-        IF(OPENSSL_SEARCH_PATH STREQUAL "")
-            SET(OPENSSL_SEARCH_PATH "C:/OpenSSL-Win64")
-            SET(OPENSSL_SEARCH_LIB_PATH "${OPENSSL_SEARCH_PATH}/lib64")
-            IF (DEFINED ENV{PAHO_WINDOWS_BUILD_BIT})
-                IF ($ENV{PAHO_WINDOWS_BUILD_BIT} STREQUAL "x86")
-                    SET(OPENSSL_SEARCH_PATH "C:/OpenSSL-Win32")
-                    SET(OPENSSL_SEARCH_LIB_PATH "${OPENSSL_SEARCH_PATH}/lib32")
-                ENDIF ()
-            ENDIF ()
-        ENDIF ()
-    ELSE()
-        SET(OPENSSL_SEARCH_LIB_PATH "${OPENSSL_SEARCH_PATH}/lib64")
-    ENDIF ()
-
-    FIND_PATH(OPENSSL_INCLUDE_DIR openssl/ssl.h
-        HINTS ${OPENSSL_SEARCH_PATH}/include)
-    FIND_LIBRARY(OPENSSL_LIB NAMES ssl libssl ssleay32
-        HINTS ${OPENSSL_SEARCH_PATH}/lib ${OPENSSL_SEARCH_LIB_PATH})
-    FIND_LIBRARY(OPENSSLCRYPTO_LIB NAMES crypto libcrypto libeay32
-        HINTS ${OPENSSL_SEARCH_PATH}/lib ${OPENSSL_SEARCH_LIB_PATH})
-
-    MESSAGE(STATUS "OpenSSL hints: ${OPENSSL_SEARCH_PATH}")
-    MESSAGE(STATUS "OpenSSL headers found at ${OPENSSL_INCLUDE_DIR}")
-    MESSAGE(STATUS "OpenSSL library found at ${OPENSSL_LIB}")
-    MESSAGE(STATUS "OpenSSL Crypto library found at ${OPENSSLCRYPTO_LIB}")
-
-    INCLUDE_DIRECTORIES(
-        ${OPENSSL_INCLUDE_DIR}
-    )
+    SET(OPENSSL_ROOT_DIR "" CACHE PATH "Directory containing OpenSSL libraries and includes")
+    find_package(OpenSSL REQUIRED)
 
     ## common compilation for libpaho-mqtt3cs and libpaho-mqtt3as
     ## Note: SSL libraries must be recompiled due ifdefs
     ADD_LIBRARY(common_ssl_obj OBJECT ${common_src})
+    TARGET_INCLUDE_DIRECTORIES(common_ssl_obj PUBLIC ${OPENSSL_INCLUDE_DIR})
     SET_PROPERTY(TARGET common_ssl_obj PROPERTY	POSITION_INDEPENDENT_CODE ON)
     SET_PROPERTY(TARGET common_ssl_obj PROPERTY COMPILE_DEFINITIONS "OPENSSL=1;MQTT_EXPORTS=1")
 
@@ -190,8 +155,6 @@ IF (PAHO_WITH_SSL)
         ADD_LIBRARY(paho-mqtt3cs SHARED $<TARGET_OBJECTS:common_ssl_obj> MQTTClient.c SSLSocket.c)
         ADD_LIBRARY(paho-mqtt3as SHARED $<TARGET_OBJECTS:common_ssl_obj> MQTTAsync.c SSLSocket.c)
     
-        TARGET_LINK_LIBRARIES(paho-mqtt3cs ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB} ${LIBS_SYSTEM})
-        TARGET_LINK_LIBRARIES(paho-mqtt3as ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB} ${LIBS_SYSTEM})
         SET_TARGET_PROPERTIES(
             paho-mqtt3cs paho-mqtt3as PROPERTIES
             VERSION ${CLIENT_VERSION}
@@ -205,6 +168,9 @@ IF (PAHO_WITH_SSL)
                     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                 PRIVATE
                     ${CMAKE_BINARY_DIR})
+            TARGET_LINK_LIBRARIES(${TARGET}
+                PUBLIC
+                    OpenSSL::SSL OpenSSL::Crypto ${LIBS_SYSTEM})
         ENDFOREACH()
         INSTALL(TARGETS paho-mqtt3cs paho-mqtt3as
             EXPORT eclipse-paho-mqtt-cTargets
@@ -217,8 +183,6 @@ IF (PAHO_WITH_SSL)
         ADD_LIBRARY(paho-mqtt3cs-static STATIC $<TARGET_OBJECTS:common_ssl_obj> MQTTClient.c SSLSocket.c)
         ADD_LIBRARY(paho-mqtt3as-static STATIC $<TARGET_OBJECTS:common_ssl_obj> MQTTAsync.c SSLSocket.c)
 
-        TARGET_LINK_LIBRARIES(paho-mqtt3cs-static ${OPENSSL_LIBRARIES} ${LIBS_SYSTEM})
-        TARGET_LINK_LIBRARIES(paho-mqtt3as-static ${OPENSSL_LIBRARIES} ${LIBS_SYSTEM})
         SET_TARGET_PROPERTIES(
             paho-mqtt3cs-static paho-mqtt3as-static PROPERTIES
             VERSION ${CLIENT_VERSION}
@@ -247,6 +211,9 @@ IF (PAHO_WITH_SSL)
                     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                 PRIVATE
                     ${CMAKE_BINARY_DIR})
+            TARGET_LINK_LIBRARIES(${TARGET}
+                PUBLIC
+                    OpenSSL::SSL OpenSSL::Crypto ${LIBS_SYSTEM})
         ENDFOREACH()
     ENDIF()
 ENDIF()
@@ -269,7 +236,7 @@ ADD_EXECUTABLE( Base64Test EXCLUDE_FROM_ALL Base64.c Base64.h )
 TARGET_COMPILE_DEFINITIONS( Base64Test PUBLIC "-DBASE64_TEST" )
 IF (PAHO_WITH_SSL)
 	ADD_EXECUTABLE( Base64TestOpenSSL EXCLUDE_FROM_ALL Base64.c Base64.h )
-	TARGET_LINK_LIBRARIES( Base64TestOpenSSL ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB} )
+	TARGET_LINK_LIBRARIES( Base64TestOpenSSL OpenSSL::SSL OpenSSL::Crypto)
 	TARGET_COMPILE_DEFINITIONS( Base64TestOpenSSL PUBLIC "-DBASE64_TEST -DOPENSSL=1" )
 ENDIF (PAHO_WITH_SSL)
 
@@ -278,6 +245,6 @@ ADD_EXECUTABLE( Sha1Test EXCLUDE_FROM_ALL SHA1.c SHA1.h )
 TARGET_COMPILE_DEFINITIONS( Sha1Test PUBLIC "-DSHA1_TEST" )
 IF (PAHO_WITH_SSL)
 	ADD_EXECUTABLE( Sha1TestOpenSSL EXCLUDE_FROM_ALL SHA1.c SHA1.h )
-	TARGET_LINK_LIBRARIES( Sha1TestOpenSSL ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB} )
+	TARGET_LINK_LIBRARIES( Sha1TestOpenSSL OpenSSL::SSL OpenSSL::Crypto)
 	TARGET_COMPILE_DEFINITIONS( Sha1TestOpenSSL PUBLIC "-DSHA1_TEST -DOPENSSL=1" )
 ENDIF (PAHO_WITH_SSL)

--- a/src/samples/CMakeLists.txt
+++ b/src/samples/CMakeLists.txt
@@ -73,10 +73,10 @@ ADD_EXECUTABLE(paho_c_sub_static paho_c_sub.c pubsub_opts.c)
 ADD_EXECUTABLE(paho_cs_pub_static paho_cs_pub.c pubsub_opts.c)
 ADD_EXECUTABLE(paho_cs_sub_static paho_cs_sub.c pubsub_opts.c)
 
-TARGET_LINK_LIBRARIES(paho_c_pub_static paho-mqtt3as-static ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB})
-TARGET_LINK_LIBRARIES(paho_c_sub_static paho-mqtt3as-static ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB})
-TARGET_LINK_LIBRARIES(paho_cs_pub_static paho-mqtt3cs-static ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB})
-TARGET_LINK_LIBRARIES(paho_cs_sub_static paho-mqtt3cs-static ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB})
+TARGET_LINK_LIBRARIES(paho_c_pub_static paho-mqtt3as-static)
+TARGET_LINK_LIBRARIES(paho_c_sub_static paho-mqtt3as-static)
+TARGET_LINK_LIBRARIES(paho_cs_pub_static paho-mqtt3cs-static)
+TARGET_LINK_LIBRARIES(paho_cs_sub_static paho-mqtt3cs-static)
 
 ENDIF()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,37 +7,6 @@ SET(MQTT_SSL_HOSTNAME "localhost" CACHE STRING "Hostname of a test SSL MQTT brok
 SET(CERTDIR ${CMAKE_SOURCE_DIR}/test/ssl)
 
 
-IF (PAHO_WITH_SSL)
-	SET(OPENSSL_SEARCH_PATH "" CACHE PATH "Directory containing OpenSSL libraries and includes")
-
-	IF (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-		IF(OPENSSL_SEARCH_PATH STREQUAL "")
-			SET(OPENSSL_SEARCH_PATH "/usr/local/opt/openssl")
-		ENDIF ()	
-	ENDIF (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-
-	IF (WIN32)
-		IF(OPENSSL_SEARCH_PATH STREQUAL "")
-			SET(OPENSSL_SEARCH_PATH "C:/OpenSSL-Win64")
-			IF (DEFINED ENV{PAHO_WINDOWS_BUILD_BIT})
-				IF ($ENV{PAHO_WINDOWS_BUILD_BIT} STREQUAL "x86")
-					SET(OPENSSL_SEARCH_PATH "C:/OpenSSL-Win32")
-				ENDIF ()
-			ENDIF ()
-		ENDIF ()
-	ENDIF ()
-
-	FIND_PATH(OPENSSL_INCLUDE_DIR openssl/ssl.h
-		HINTS ${OPENSSL_SEARCH_PATH}/include)
-
-	MESSAGE(STATUS "OpenSSL hints: ${OPENSSL_SEARCH_PATH}")
-	MESSAGE(STATUS "OpenSSL headers found at ${OPENSSL_INCLUDE_DIR}")
-
-	INCLUDE_DIRECTORIES(
-		${OPENSSL_INCLUDE_DIR}
-	)
-ENDIF ()
-
 IF (WIN32)
 	SET(LIBS_SYSTEM ws2_32)
 ELSEIF (UNIX)
@@ -357,7 +326,7 @@ IF (PAHO_WITH_SSL)
 		)
 		TARGET_LINK_LIBRARIES(
 			test3-static
-			paho-mqtt3cs-static  ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB}
+			paho-mqtt3cs-static
 		)
 		
 		ADD_TEST(
@@ -777,7 +746,7 @@ IF (PAHO_WITH_SSL)
 		
 		TARGET_LINK_LIBRARIES(
 			test5-static
-			paho-mqtt3as-static ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB}
+			paho-mqtt3as-static
 		)
 		
 		ADD_TEST(

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -5,9 +5,9 @@ set -e
 rm -rf build.paho
 mkdir build.paho
 cd build.paho
-echo "travis build dir $TRAVIS_BUILD_DIR pwd $PWD"
-cmake -DCMAKE_BUILD_TYPE=Debug -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=TRUE ..
-make
+echo "travis build dir $TRAVIS_BUILD_DIR pwd $PWD with OpenSSL root $OPENSSL_ROOT_DIR"
+cmake -DCMAKE_BUILD_TYPE=Debug -DPAHO_WITH_SSL=TRUE -DOPENSSL_ROOT_DIR=$OPENSSL_ROOT_DIR -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=TRUE ..
+cmake --build .
 python3 ../test/mqttsas.py &
 ctest -VV --timeout 600
 cpack --verbose

--- a/travis-env-vars
+++ b/travis-env-vars
@@ -1,2 +1,0 @@
-export TRAVIS_OS_NAME=linux
-export TRAVIS_BUILD_DIR=$PWD

--- a/travis-macos-vars
+++ b/travis-macos-vars
@@ -1,2 +1,0 @@
-export TRAVIS_OS_NAME=osx
-export TRAVIS_BUILD_DIR=$PWD


### PR DESCRIPTION
With the targets provided by find_package, we can simply add the required libraries as PUBLIC and depending targets will simply know everything they need.

I changed OPENSSL_SEARCH_PATH to OPENSSL_ROOT_DIR, because this is the default from FindOpenSSL

This is meant as part of #799 