### PR TITLE
Fix sanitizer errors due to calling memcpy with NULL pointer.

### DIFF
--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -956,8 +956,11 @@ int SSLSocket_putdatas(SSL* ssl, int socket, char* buf0, size_t buf0len, int cou
 	ptr += buf0len;
 	for (i = 0; i < count; i++)
 	{
-		memcpy(ptr, buffers[i], buflens[i]);
-		ptr += buflens[i];
+		if (buffers[i] != NULL && buflens[i] > 0)
+		{
+			memcpy(ptr, buffers[i], buflens[i]);
+			ptr += buflens[i];
+		}
 	}
 
 	SSL_lock_mutex(&sslCoreMutex);


### PR DESCRIPTION
For disconnect message (at least), `SSLSocket_putdatas` function is called with count greater than 0, but `buffers[i]` is set to `NULL`. This entails calling `memcpy` with `NULL` as original buffer, which is detected as a runtime error by some runtime sanitizers:

`SSLSocket.c:1235:3: runtime error: null pointer passed as argument 2, which is declared to never be null`

Warning, line numbers may not match, since I am using modified `SSLSocket.c` with mbedTLS support (see #826).
