### PR TITLE
Declare variable at the beginning of the block.

### DIFF
--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -913,6 +913,7 @@ int WebSocket_receiveFrame(networkHandles *net, size_t bytes, size_t *actual_len
 {
 	struct ws_frame *res = NULL;
 	int rc = TCPSOCKET_COMPLETE;
+	int opcode = 0;
 
 	FUNC_ENTRY;
 	if ( !in_frames )
@@ -924,7 +925,7 @@ int WebSocket_receiveFrame(networkHandles *net, size_t bytes, size_t *actual_len
 
 	//while( !res )
 	//{
-		int opcode = WebSocket_OP_BINARY;
+		opcode = WebSocket_OP_BINARY;
 		do
 		{
 			/* obtain all frames in the sequence */


### PR DESCRIPTION
Minimal fix for old C standard.

