### PR TITLE
Fix calling convention for 'InitOnceFunction' for windows with STATIC…

### DIFF
--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -200,7 +200,7 @@ void MQTTClient_cleanup(void)
 static INIT_ONCE g_InitOnce = INIT_ONCE_STATIC_INIT; /* Static initialization */
 
 /* One time initialization function */
-BOOL InitOnceFunction (
+BOOL WINAPI InitOnceFunction (
     PINIT_ONCE InitOnce,        /* Pointer to one-time initialization structure */
     PVOID Parameter,            /* Optional parameter passed by InitOnceExecuteOnce */
     PVOID *lpContext)           /* Receives pointer to event object */

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -200,7 +200,7 @@ void MQTTClient_cleanup(void)
 static INIT_ONCE g_InitOnce = INIT_ONCE_STATIC_INIT; /* Static initialization */
 
 /* One time initialization function */
-BOOL WINAPI InitOnceFunction (
+BOOL CALLBACK InitOnceFunction (
     PINIT_ONCE InitOnce,        /* Pointer to one-time initialization structure */
     PVOID Parameter,            /* Optional parameter passed by InitOnceExecuteOnce */
     PVOID *lpContext)           /* Receives pointer to event object */


### PR DESCRIPTION
Fix calling convention for 'InitOnceFunction' for windows with STATIC build

Signed-off-by: Madhu Kumar <madhu.kumar@nxp.com>
