### PR TITLE
Fix issue 857.

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -2961,8 +2961,12 @@ void Protocol_processPublication(Publish* publish, Clients* client, int allocate
 			MQTTPersistence_persistQueueEntry(client, (MQTTPersistence_qEntry*)qe);
 #endif
 	}
+	else
+	{
+		if (allocatePayload) { free(mm->payload); }
+		free(mm);
+	}
 exit:
-	publish->topic = NULL;
 	FUNC_EXIT;
 }
 


### PR DESCRIPTION
This fix solves issue #857.  Memory leaks are removes when HIGH_PERFORMANCE is used and memory does not increases with each received message until program crash when HIGH_PERFORMANCE is not used.