### PR TITLE
Fixed library names errors while compiling static samples

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -249,17 +249,17 @@ IF (PAHO_WITH_SSL)
     	SET_PROPERTY(TARGET common_ssl_obj_static PROPERTY POSITION_INDEPENDENT_CODE ON)
     	SET_PROPERTY(TARGET common_ssl_obj_static PROPERTY COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_STATIC=1")
     
-        ADD_LIBRARY(paho-mqtt3cs-static STATIC $<TARGET_OBJECTS:common_ssl_obj_static> MQTTClient.c SSLSocket.c)
-        ADD_LIBRARY(paho-mqtt3as-static STATIC $<TARGET_OBJECTS:common_ssl_obj_static> MQTTAsync.c SSLSocket.c)
+        ADD_LIBRARY(paho-mqtt3c-static STATIC $<TARGET_OBJECTS:common_ssl_obj_static> MQTTClient.c SSLSocket.c)
+        ADD_LIBRARY(paho-mqtt3a-static STATIC $<TARGET_OBJECTS:common_ssl_obj_static> MQTTAsync.c SSLSocket.c)
 
         SET_TARGET_PROPERTIES(
-            paho-mqtt3cs-static paho-mqtt3as-static PROPERTIES
+            paho-mqtt3cs-static paho-mqtt3a-static PROPERTIES
             VERSION ${CLIENT_VERSION}
             SOVERSION ${PAHO_VERSION_MAJOR}
             COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_STATIC=1")
         IF (NOT WIN32)
-            SET_TARGET_PROPERTIES(paho-mqtt3cs-static PROPERTIES OUTPUT_NAME paho-mqtt3cs)
-            SET_TARGET_PROPERTIES(paho-mqtt3as-static PROPERTIES OUTPUT_NAME paho-mqtt3as)
+            SET_TARGET_PROPERTIES(paho-mqtt3c-static PROPERTIES OUTPUT_NAME paho-mqtt3cs)
+            SET_TARGET_PROPERTIES(paho-mqtt3a-static PROPERTIES OUTPUT_NAME paho-mqtt3as)
         ENDIF()
 
 	    IF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
@@ -272,24 +272,24 @@ IF (PAHO_WITH_SSL)
 
 		IF (NOT WIN32)
 		    SET_TARGET_PROPERTIES(
-	            paho-mqtt3cs-static PROPERTIES
+	            paho-mqtt3c-static PROPERTIES
 	            LINK_FLAGS "-Wl,-init,${MQTTCLIENT_ENTRY_POINT}")
 	        SET_TARGET_PROPERTIES(
-	            paho-mqtt3as-static PROPERTIES
+	            paho-mqtt3a-static PROPERTIES
 	            LINK_FLAGS "-Wl,-init,${MQTTASYNC_ENTRY_POINT}")
 	    ENDIF()
 
         IF (NOT PAHO_BUILD_SHARED)
-            INSTALL(TARGETS paho-mqtt3cs-static paho-mqtt3as-static
+            INSTALL(TARGETS paho-mqtt3c-static paho-mqtt3a-static
                 EXPORT eclipse-paho-mqtt-cTargets
                 ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
                 LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
                 RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR})
         ELSE()
-            INSTALL(TARGETS paho-mqtt3cs-static paho-mqtt3as-static
+            INSTALL(TARGETS paho-mqtt3cs-static paho-mqtt3a-static
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
         ENDIF()
-        FOREACH(TARGET paho-mqtt3cs-static paho-mqtt3as-static)
+        FOREACH(TARGET paho-mqtt3cs-static paho-mqtt3a-static)
             TARGET_INCLUDE_DIRECTORIES(${TARGET}
                 PUBLIC
                     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,10 +99,11 @@ ENDIF()
 IF (PAHO_BUILD_SHARED)
     ADD_LIBRARY(paho-mqtt3c SHARED $<TARGET_OBJECTS:common_obj> MQTTClient.c)
     ADD_LIBRARY(paho-mqtt3a SHARED $<TARGET_OBJECTS:common_obj> MQTTAsync.c)
+    message(STATUS "[debug] LIBS_SYSTEM: ${LIBS_SYSTEM}")
     
-    TARGET_LINK_LIBRARIES(paho-mqtt3c ${LIBS_SYSTEM})
-    TARGET_LINK_LIBRARIES(paho-mqtt3a ${LIBS_SYSTEM})
-    TARGET_LINK_LIBRARIES(MQTTVersion paho-mqtt3a paho-mqtt3c ${LIBS_SYSTEM})
+    TARGET_LINK_LIBRARIES(paho-mqtt3c PUBLIC ${LIBS_SYSTEM})
+    TARGET_LINK_LIBRARIES(paho-mqtt3a PUBLIC ${LIBS_SYSTEM})
+    TARGET_LINK_LIBRARIES(MQTTVersion PUBLIC paho-mqtt3a paho-mqtt3c ${LIBS_SYSTEM})
     
     SET_TARGET_PROPERTIES(
         paho-mqtt3c paho-mqtt3a PROPERTIES
@@ -149,8 +150,8 @@ IF (PAHO_BUILD_STATIC)
     ADD_LIBRARY(paho-mqtt3c-static STATIC $<TARGET_OBJECTS:common_obj_static> MQTTClient.c)
     ADD_LIBRARY(paho-mqtt3a-static STATIC $<TARGET_OBJECTS:common_obj_static> MQTTAsync.c)
 
-    TARGET_LINK_LIBRARIES(paho-mqtt3c-static ${LIBS_SYSTEM})
-    TARGET_LINK_LIBRARIES(paho-mqtt3a-static ${LIBS_SYSTEM})
+    TARGET_LINK_LIBRARIES(paho-mqtt3c-static PUBLIC ${LIBS_SYSTEM})
+    TARGET_LINK_LIBRARIES(paho-mqtt3a-static PUBLIC ${LIBS_SYSTEM})
     IF (NOT WIN32)
         SET_TARGET_PROPERTIES(paho-mqtt3c-static PROPERTIES OUTPUT_NAME paho-mqtt3c)
         SET_TARGET_PROPERTIES(paho-mqtt3a-static PROPERTIES OUTPUT_NAME paho-mqtt3a)
@@ -247,19 +248,22 @@ IF (PAHO_WITH_SSL)
     	ADD_LIBRARY(common_ssl_obj_static OBJECT ${common_src})
     	TARGET_INCLUDE_DIRECTORIES(common_ssl_obj_static PUBLIC ${OPENSSL_INCLUDE_DIR})
     	SET_PROPERTY(TARGET common_ssl_obj_static PROPERTY POSITION_INDEPENDENT_CODE ON)
-    	SET_PROPERTY(TARGET common_ssl_obj_static PROPERTY COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_STATIC=1")
+        SET_PROPERTY(TARGET common_ssl_obj_static PROPERTY COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_STATIC=1")
+        
+        # this block is under PAHO_WITH_SSL
+        ADD_LIBRARY(paho-mqtt3cs-static STATIC $<TARGET_OBJECTS:common_ssl_obj_static> MQTTClient.c SSLSocket.c)
+        ADD_LIBRARY(paho-mqtt3as-static STATIC $<TARGET_OBJECTS:common_ssl_obj_static> MQTTAsync.c SSLSocket.c)
     
-        ADD_LIBRARY(paho-mqtt3c-static STATIC $<TARGET_OBJECTS:common_ssl_obj_static> MQTTClient.c SSLSocket.c)
-        ADD_LIBRARY(paho-mqtt3a-static STATIC $<TARGET_OBJECTS:common_ssl_obj_static> MQTTAsync.c SSLSocket.c)
+        
 
         SET_TARGET_PROPERTIES(
-            paho-mqtt3cs-static paho-mqtt3a-static PROPERTIES
+            paho-mqtt3cs-static paho-mqtt3as-static PROPERTIES
             VERSION ${CLIENT_VERSION}
             SOVERSION ${PAHO_VERSION_MAJOR}
             COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_STATIC=1")
         IF (NOT WIN32)
-            SET_TARGET_PROPERTIES(paho-mqtt3c-static PROPERTIES OUTPUT_NAME paho-mqtt3cs)
-            SET_TARGET_PROPERTIES(paho-mqtt3a-static PROPERTIES OUTPUT_NAME paho-mqtt3as)
+            SET_TARGET_PROPERTIES(paho-mqtt3cs-static PROPERTIES OUTPUT_NAME paho-mqtt3cs)
+            SET_TARGET_PROPERTIES(paho-mqtt3as-static PROPERTIES OUTPUT_NAME paho-mqtt3as)
         ENDIF()
 
 	    IF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
@@ -272,24 +276,24 @@ IF (PAHO_WITH_SSL)
 
 		IF (NOT WIN32)
 		    SET_TARGET_PROPERTIES(
-	            paho-mqtt3c-static PROPERTIES
+	            paho-mqtt3cs-static PROPERTIES
 	            LINK_FLAGS "-Wl,-init,${MQTTCLIENT_ENTRY_POINT}")
 	        SET_TARGET_PROPERTIES(
-	            paho-mqtt3a-static PROPERTIES
+	            paho-mqtt3as-static PROPERTIES
 	            LINK_FLAGS "-Wl,-init,${MQTTASYNC_ENTRY_POINT}")
 	    ENDIF()
 
         IF (NOT PAHO_BUILD_SHARED)
-            INSTALL(TARGETS paho-mqtt3c-static paho-mqtt3a-static
+            INSTALL(TARGETS paho-mqtt3cs-static paho-mqtt3as-static
                 EXPORT eclipse-paho-mqtt-cTargets
                 ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
                 LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
                 RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR})
         ELSE()
-            INSTALL(TARGETS paho-mqtt3cs-static paho-mqtt3a-static
+            INSTALL(TARGETS paho-mqtt3cs-static paho-mqtt3as-static
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
         ENDIF()
-        FOREACH(TARGET paho-mqtt3cs-static paho-mqtt3a-static)
+        FOREACH(TARGET paho-mqtt3cs-static paho-mqtt3as-static)
             TARGET_INCLUDE_DIRECTORIES(${TARGET}
                 PUBLIC
                     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/src/samples/CMakeLists.txt
+++ b/src/samples/CMakeLists.txt
@@ -83,10 +83,10 @@ ADD_EXECUTABLE(paho_cs_sub_static paho_cs_sub.c pubsub_opts.c)
 
 
 
-TARGET_LINK_LIBRARIES(paho_c_pub_static paho-mqtt3as-static)
-TARGET_LINK_LIBRARIES(paho_c_sub_static paho-mqtt3as-static)
-TARGET_LINK_LIBRARIES(paho_cs_pub_static paho-mqtt3cs-static)
-TARGET_LINK_LIBRARIES(paho_cs_sub_static paho-mqtt3cs-static)
+TARGET_LINK_LIBRARIES(paho_c_pub_static paho-mqtt3a-static)
+TARGET_LINK_LIBRARIES(paho_c_sub_static paho-mqtt3a-static)
+TARGET_LINK_LIBRARIES(paho_cs_pub_static paho-mqtt3c-static)
+TARGET_LINK_LIBRARIES(paho_cs_sub_static paho-mqtt3c-static)
 
 ENDIF()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -326,7 +326,7 @@ IF (PAHO_WITH_SSL)
 		)
 		TARGET_LINK_LIBRARIES(
 			test3-static
-			paho-mqtt3cs-static
+			paho-mqtt3c-static
 		)
 		
 		ADD_TEST(
@@ -770,7 +770,7 @@ IF (PAHO_WITH_SSL)
 		
 		TARGET_LINK_LIBRARIES(
 			test5-static
-			paho-mqtt3as-static
+			paho-mqtt3a-static
 		)
 		
 		ADD_TEST(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -326,7 +326,7 @@ IF (PAHO_WITH_SSL)
 		)
 		TARGET_LINK_LIBRARIES(
 			test3-static
-			paho-mqtt3c-static
+			paho-mqtt3cs-static
 		)
 		
 		ADD_TEST(
@@ -770,7 +770,7 @@ IF (PAHO_WITH_SSL)
 		
 		TARGET_LINK_LIBRARIES(
 			test5-static
-			paho-mqtt3a-static
+			paho-mqtt3as-static
 		)
 		
 		ADD_TEST(


### PR DESCRIPTION
The library names used in the sample directory were paho-mqtt3as-static and paho-mqtt3cs-static. The actual names of the generated libraries are paho-mqtt3a-static and paho-mqtt3c-static. This pull changes the respective CMakeLists.txt files to make the samples compile successfully.

Tested on Ubuntu 18.04 amd64 with and without shared libraries being generated


Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


