### PR TITLE
Clear OpenSSL errors before calling an OpenSSL TLS I/O operation

### DIFF
--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -743,6 +743,7 @@ int SSLSocket_connect(SSL* ssl, int sock, const char* hostname, int verify, int 
 
 	FUNC_ENTRY;
 
+	ERR_clear_error();
 	rc = SSL_connect(ssl);
 	if (rc != 1)
 	{
@@ -818,6 +819,7 @@ int SSLSocket_getch(SSL* ssl, int socket, char* c)
 	if ((rc = SocketBuffer_getQueuedChar(socket, c)) != SOCKETBUFFER_INTERRUPTED)
 		goto exit;
 
+	ERR_clear_error();
 	if ((rc = SSL_read(ssl, c, (size_t)1)) < 0)
 	{
 		int err = SSLSocket_error("SSL_read - getch", ssl, socket, rc, NULL, NULL);
@@ -863,6 +865,7 @@ char *SSLSocket_getdata(SSL* ssl, int socket, size_t bytes, size_t* actual_len)
 
 	buf = SocketBuffer_getQueuedData(socket, bytes, actual_len);
 
+	ERR_clear_error();
 	if ((rc = SSL_read(ssl, buf + (*actual_len), (int)(bytes - (*actual_len)))) < 0)
 	{
 		rc = SSLSocket_error("SSL_read - getdata", ssl, socket, rc, NULL, NULL);
@@ -922,6 +925,7 @@ int SSLSocket_close(networkHandles* net)
 
 	if (net->ssl)
 	{
+		ERR_clear_error();
 		rc = SSL_shutdown(net->ssl);
 		SSL_free(net->ssl);
 		net->ssl = NULL;
@@ -964,6 +968,7 @@ int SSLSocket_putdatas(SSL* ssl, int socket, char* buf0, size_t buf0len, int cou
 	}
 
 	SSL_lock_mutex(&sslCoreMutex);
+	ERR_clear_error();
 	if ((rc = SSL_write(ssl, iovec.iov_base, iovec.iov_len)) == iovec.iov_len)
 		rc = TCPSOCKET_COMPLETE;
 	else
@@ -1052,6 +1057,7 @@ int SSLSocket_continueWrite(pending_writes* pw)
 	int rc = 0;
 
 	FUNC_ENTRY;
+	ERR_clear_error();
 	if ((rc = SSL_write(pw->ssl, pw->iovecs[0].iov_base, pw->iovecs[0].iov_len)) == pw->iovecs[0].iov_len)
 	{
 		/* topic and payload buffers are freed elsewhere, when all references to them have been removed */


### PR DESCRIPTION
**Issue:**
For some reasons OpenSSL may return an error when an I/O operation is called.
SSL_get_error is then called to get the reason of the error.
An SSL_ERROR_SSL (1) is returned which triggers a disconnect. This seem to happen, sometimes, under bad network conditions such as cellular networks.
The application would reconnect succesfully with CONNECT+CONNACK but further messages would fail with the same SSL error.
This whole process would repeat indefinitely with continuous disconnection and reconnection (see logs at the end).

**Cause:**

It seems to be because SSL_get_error requires the error queue to be empty before a TLS I/O operation is performed (see https://www.openssl.org/docs/man1.1.1/man3/SSL_get_error.html)

**Fix:**

Use ERR_clear_error before each call to OpenSSL TLS I/O to clear the error queue.

**Notes:**
I also checked libwebsockets (a project we use), mosquitto and libcurl. libcurl and mosquitto clear the error queue before OpenSSL I/O calls. libwebsockets didn't use to do it but a fix was put in place last year (https://libwebsockets.org/pipermail/libwebsockets/2019-July/008033.html and https://github.com/warmcat/libwebsockets/commit/89fd3d822e7cd57190e662b17aa508fc34a4ee77).
It seems that it is quite easy to overlook this OpenSSL API detail but it can have quite some impact.

**Logs:**

20200604 133348.670 (1911096336)  (1)> MQTTAsync_processCommand:1398
20200604 133348.670 (1911096336)   (2)> MQTTProtocol_startPublish:156
20200604 133348.670 (1911096336)    (3)> MQTTProtocol_createMessage:186
20200604 133348.670 (1911096336)     (4)> MQTTProtocol_storePublication:224
20200604 133348.673 (1911096336)     (4)< MQTTProtocol_storePublication:245
20200604 133348.673 (1911096336)    (3)< MQTTProtocol_createMessage:209
20200604 133348.673 (1911096336)    (3)> MQTTProtocol_startPublishCommon:133
20200604 133348.673 (1911096336)     (4)> MQTTPacket_send_publish:800
20200604 133348.673 (1911096336)      (5)> MQTTPacket_sends:239
20200604 133348.673 (1911096336)       (6)> MQTTPacket_encode:281
20200604 133348.673 (1911096336)       (6)< MQTTPacket_encode:291 (2)
20200604 133348.673 (1911096336)       (6)> MQTTPersistence_put:405
20200604 133348.673 (1911096336)       (6)< MQTTPersistence_put:456 (0)
20200604 133348.673 (1911096336)       (6)> WebSocket_putdatas:782
20200604 133348.673 (1911096336)        (7)> SSLSocket_putdatas:936
20200604 133348.673 sent 0 256 buflen 5
20200604 133348.673 (1911096336)         (8)> SSLSocket_error:100
20200604 133348.673 SSLSocket error (1) in SSL_write for socket 9 rc -1 errno 2 No such file or directory
20200604 133348.673 (1911096336)         (8)< SSLSocket_error:120 (-3)
20200604 133348.673 (1911096336)        (7)< SSLSocket_putdatas:990 (-1)
20200604 133348.673 (1911096336)       (6)< WebSocket_putdatas:814 (-1)
20200604 133348.673 (1911096336)      (5)< MQTTPacket_sends:266 (-1)
20200604 133348.673 9 3a4c0898cb83330e -> PUBLISH msgid: 8 qos: 1 retained: 0 (-1) payload: [{"propertyId":"rzQp
20200604 133348.673 (1911096336)     (4)< MQTTPacket_send_publish:844 (-1)
20200604 133348.676 (1911096336)    (3)< MQTTProtocol_startPublishCommon:137 (-1)
20200604 133348.676 (1911096336)   (2)< MQTTProtocol_startPublish:169 (-1)
20200604 133348.676 (1911096336)   (2)> MQTTAsync_disconnect1:3130
20200604 133348.676 (1911096336)    (3)> MQTTAsync_addCommand:1050
20200604 133348.676 (1911096336)     (4)> Thread_signal_cond:395
20200604 133348.676 (1911096336)     (4)< Thread_signal_cond:400 (0)
20200604 133348.676 (1911096336)    (3)< MQTTAsync_addCommand:1084 (0)
20200604 133348.676 (1911096336)   (2)< MQTTAsync_disconnect1:3167 (0)
20200604 133348.676 Calling command failure for client 3a4c0898cb83330e
20200604 133348.676 (1911096336)   (2)> MQTTProperties_free:366
20200604 133348.676 (1911096336)   (2)< MQTTProperties_free:389
20200604 133348.676 (1911096336)  (1)< MQTTAsync_processCommand:1734 (1)
20200604 133348.676 (1911096336)  (1)> MQTTAsync_processCommand:1398
20200604 133348.676 (1911096336)   (2)> MQTTAsync_checkDisconnect:1154
20200604 133348.676 (1911096336)    (3)> MQTTAsync_closeSession:2661
20200604 133348.676 (1911096336)     (4)> MQTTAsync_closeOnly:2633
20200604 133348.676 (1911096336)      (5)> MQTTProtocol_checkPendingWrites:1208
20200604 133348.676 (1911096336)      (5)< MQTTProtocol_checkPendingWrites:1225
20200604 133348.676 (1911096336)      (5)> MQTTPacket_send_disconnect:488
20200604 133348.676 (1911096336)       (6)> MQTTPacket_send:187
20200604 133348.678 (1911096336)        (7)> MQTTPacket_encode:281
20200604 133348.678 (1911096336)        (7)< MQTTPacket_encode:291 (1)
20200604 133348.678 (1911096336)        (7)> WebSocket_putdatas:782
20200604 133348.678 (1911096336)         (8)> SSLSocket_putdatas:936
20200604 133348.678 (1911096336)          (9)> SSLSocket_error:100
20200604 133348.678 SSLSocket error (1) in SSL_write for socket 9 rc -1 errno 2 No such file or directory


