### PR TITLE
MQTT on WS fixes

### DIFF
--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -620,6 +620,28 @@ exit:
 	return rc;
 }
 
+size_t WebSocket_framePos()
+{
+	if ( in_frames && in_frames->first )
+	{
+		struct ws_frame *frame = in_frames->first->content;
+		return frame->pos;
+	}
+	else
+	{
+		return 0;
+	}
+}
+
+void WebSocket_framePosSeekTo(size_t pos)
+{
+	if ( in_frames && in_frames->first )
+	{
+		struct ws_frame *frame = in_frames->first->content;
+		frame->pos = pos;
+	}
+}
+
 /**
  * @brief receives data from a socket.
  * It should receive all data from the socket that is immediately available.

--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -169,8 +169,7 @@ static void WebSocket_rewindData( void );
 static void WebSocket_pong(
 	networkHandles *net, char *app_data, size_t app_data_len);
 
-static int WebSocket_receiveFrame(networkHandles *net,
-	size_t bytes, size_t *actual_len );
+static int WebSocket_receiveFrame(networkHandles *net, size_t *actual_len);
 
 
 /**
@@ -590,7 +589,7 @@ int WebSocket_getch(networkHandles *net, char* c)
 		if ( !frame  || frame->len == frame->pos )
 		{
 			size_t actual_len = 0u;
-			rc =  WebSocket_receiveFrame( net, 1u, &actual_len );
+			rc =  WebSocket_receiveFrame( net, &actual_len );
 			if ( rc != TCPSOCKET_COMPLETE )
 				goto exit;
 
@@ -692,7 +691,7 @@ char *WebSocket_getdata(networkHandles *net, size_t bytes, size_t* actual_len)
 		if ( !frame )
 		{
 			const int rc =
-				WebSocket_receiveFrame( net, bytes, actual_len );
+				WebSocket_receiveFrame( net, actual_len );
 
 			if ( rc == TCPSOCKET_COMPLETE && in_frames && in_frames->first)
 				frame = in_frames->first->content;
@@ -705,7 +704,7 @@ char *WebSocket_getdata(networkHandles *net, size_t bytes, size_t* actual_len)
 
 
 			while (*actual_len < bytes) {
-				const int rc = WebSocket_receiveFrame(net, bytes, actual_len);
+				const int rc = WebSocket_receiveFrame(net, actual_len);
 
 				if (rc != TCPSOCKET_COMPLETE) {
 					goto exit;
@@ -969,14 +968,13 @@ int WebSocket_putdatas(networkHandles* net, char** buf0, size_t* buf0len,
  * SocketBuffer mechanism.
  *
  * @param[in]      net                 network connection
- * @param[in]      bytes               amount of data to receive
  * @param[out]     actual_len          amount of data actually read
  *
  * @retval TCPSOCKET_COMPLETE          packet received
  * @retval TCPSOCKET_INTERRUPTED       incomplete packet received
  * @retval SOCKET_ERROR                an error was encountered
  */
-int WebSocket_receiveFrame(networkHandles *net, size_t bytes, size_t *actual_len)
+int WebSocket_receiveFrame(networkHandles *net, size_t *actual_len)
 {
 	struct ws_frame *res = NULL;
 	int rc = TCPSOCKET_COMPLETE;

--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -59,6 +59,8 @@ int WebSocket_connect(networkHandles *net, const char *uri);
 /* obtain data from network socket */
 int WebSocket_getch(networkHandles *net, char* c);
 char *WebSocket_getdata(networkHandles *net, size_t bytes, size_t* actual_len);
+size_t WebSocket_framePos();
+void WebSocket_framePosSeekTo(size_t);
 
 /* send data out, in websocket format only if required */
 int WebSocket_putdatas(networkHandles* net, char** buf0, size_t* buf0len,


### PR DESCRIPTION
Because of problems detected during using Paho when MQTT server was sending massive amount of data by WS (Web Socket) fames, I made some research for reasons for that.
There are some description on provided new commits, but generally, I may say, that problem was caused by cutting frames and packing few MQTT frames into WS frame by sending serwer. This is correct from the server side and it may happen on specific server settings. Client side (Paho) in some cases not collecting correctly received data as MQTT frames. This fixes solve this problems.