### PR TITLE
use GetTickCount64 instead of GetTickCount

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -92,7 +92,7 @@ void MQTTAsync_global_init(MQTTAsync_init_options* inits)
 void MQTTAsync_init_rand(void)
 {
 	START_TIME_TYPE now = MQTTTime_start_clock();
-	srand(now);
+	srand((UINT)now);
 }
 #elif defined(AIX)
 void MQTTAsync_init_rand(void)
@@ -4320,7 +4320,11 @@ int MQTTAsync_waitForCompletion(MQTTAsync handle, MQTTAsync_token dt, unsigned l
 {
 	int rc = MQTTASYNC_FAILURE;
 	START_TIME_TYPE start = MQTTTime_start_clock();
+#if defined(_WIN32) || defined(_WIN64)
+	ULONGLONG elapsed = 0L;
+#else
 	unsigned long elapsed = 0L;
+#endif
 	MQTTAsyncs* m = handle;
 
 	FUNC_ENTRY;

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -124,6 +124,12 @@
 #include "MQTTClientPersistence.h"
 #endif
 
+#if defined(_WIN32) || defined(_WIN64)
+#define TIME_OUT_TYPE ULONGLONG
+#else
+#define TIME_OUT_TYPE unsigned long 
+#endif
+
 /**
  * Return code: No error. Indicates successful completion of an MQTT client
  * operation.

--- a/src/MQTTTime.c
+++ b/src/MQTTTime.c
@@ -38,7 +38,7 @@ void MQTTTime_sleep(long milliseconds)
 #if defined(_WIN32) || defined(_WIN64)
 START_TIME_TYPE MQTTTime_start_clock(void)
 {
-	return GetTickCount();
+	return GetTickCount64();
 }
 #elif defined(AIX)
 START_TIME_TYPE MQTTTime_start_clock(void)
@@ -66,9 +66,9 @@ START_TIME_TYPE MQTTTime_now(void)
 
 
 #if defined(_WIN32) || defined(_WIN64)
-long MQTTTime_elapsed(DWORD milliseconds)
+ULONGLONG MQTTTime_elapsed(ULONGLONG milliseconds)
 {
-	return GetTickCount() - milliseconds;
+	return GetTickCount64() - milliseconds;
 }
 #elif defined(AIX)
 #define assert(a)
@@ -96,11 +96,11 @@ long MQTTTime_elapsed(struct timeval start)
 
 #if defined(_WIN32) || defined(_WIN64)
 /*
- * @param new most recent time in milliseconds from GetTickCount()
- * @param old older time in milliseconds from GetTickCount()
+ * @param new most recent time in milliseconds from GetTickCount64()
+ * @param old older time in milliseconds from GetTickCount64()
  * @return difference in milliseconds
  */
-long MQTTTime_difftime(DWORD new, DWORD old)
+ULONGLONG MQTTTime_difftime(ULONGLONG new, ULONGLONG old)
 {
 	return new - old;
 }

--- a/src/MQTTTime.h
+++ b/src/MQTTTime.h
@@ -19,7 +19,7 @@
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
-#define START_TIME_TYPE DWORD
+#define START_TIME_TYPE ULONGLONG
 #define START_TIME_ZERO 0
 #elif defined(AIX)
 #define START_TIME_TYPE struct timespec
@@ -33,7 +33,12 @@
 void MQTTTime_sleep(long milliseconds);
 START_TIME_TYPE MQTTTime_start_clock(void);
 START_TIME_TYPE MQTTTime_now(void);
+#if defined(_WIN32) || defined(_WIN64)
+ULONGLONG MQTTTime_elapsed(START_TIME_TYPE milliseconds);
+ULONGLONG MQTTTime_difftime(START_TIME_TYPE new, START_TIME_TYPE old);
+#else
 long MQTTTime_elapsed(START_TIME_TYPE milliseconds);
 long MQTTTime_difftime(START_TIME_TYPE new, START_TIME_TYPE old);
+#endif
 
 #endif


### PR DESCRIPTION
GetTickCount overflows roughly every 49 days.
Code that does not take that into account can loop indefinitely.  
GetTickCount64 operates on 64 bit values and does not have that problem.

fix for #927 