### PR TITLE
use proper type for time functions

### DIFF
--- a/src/MQTTProtocolClient.c
+++ b/src/MQTTProtocolClient.c
@@ -665,14 +665,14 @@ void MQTTProtocol_keepalive(START_TIME_TYPE now)
 
 		if (client->ping_outstanding == 1)
 		{
-			if (MQTTTime_difftime(now, client->net.lastPing) >= (long)(client->keepAliveInterval * 1000))
+			if (MQTTTime_difftime(now, client->net.lastPing) >= (MQTT_TIME_TPYE)(client->keepAliveInterval * 1000))
 			{
 				Log(TRACE_PROTOCOL, -1, "PINGRESP not received in keepalive interval for client %s on socket %d, disconnecting", client->clientID, client->net.socket);
 				MQTTProtocol_closeSession(client, 1);
 			}
 		}
-		else if (MQTTTime_difftime(now, client->net.lastSent) >= (long)(client->keepAliveInterval * 1000) ||
-					MQTTTime_difftime(now, client->net.lastReceived) >= (long)(client->keepAliveInterval * 1000))
+		else if (MQTTTime_difftime(now, client->net.lastSent) >= (MQTT_TIME_TPYE)(client->keepAliveInterval * 1000) ||
+					MQTTTime_difftime(now, client->net.lastReceived) >= (MQTT_TIME_TPYE)(client->keepAliveInterval * 1000))
 		{
 			if (Socket_noPendingWrites(client->net.socket))
 			{
@@ -713,7 +713,7 @@ static void MQTTProtocol_retries(START_TIME_TYPE now, Clients* client, int regar
 		   Socket_noPendingWrites(client->net.socket)) /* there aren't any previous packets still stacked up on the socket */
 	{
 		Messages* m = (Messages*)(outcurrent->content);
-		if (regardless || MQTTTime_difftime(now, m->lastTouch) > (long)(max(client->retryInterval, 10) * 1000))
+		if (regardless || MQTTTime_difftime(now, m->lastTouch) > (MQTT_TIME_TPYE)(max(client->retryInterval, 10) * 1000))
 		{
 			if (m->qos == 1 || (m->qos == 2 && m->nextMessageType == PUBREC))
 			{

--- a/src/MQTTTime.c
+++ b/src/MQTTTime.c
@@ -36,12 +36,12 @@ void MQTTTime_sleep(long milliseconds)
 }
 
 #if defined(_WIN32) || defined(_WIN64)
-START_TIME_TYPE MQTTTime_start_clock(void)
+MQTT_TIME_TPYE MQTTTime_start_clock(void)
 {
 	return GetTickCount();
 }
 #elif defined(AIX)
-START_TIME_TYPE MQTTTime_start_clock(void)
+MQTT_TIME_TPYE MQTTTime_start_clock(void)
 {
 	static struct timespec start;
 	clock_gettime(CLOCK_MONOTONIC, &start);
@@ -66,13 +66,13 @@ START_TIME_TYPE MQTTTime_now(void)
 
 
 #if defined(_WIN32) || defined(_WIN64)
-long MQTTTime_elapsed(DWORD milliseconds)
+MQTT_TIME_TPYE MQTTTime_elapsed(DWORD milliseconds)
 {
 	return GetTickCount() - milliseconds;
 }
 #elif defined(AIX)
 #define assert(a)
-long MQTTTime_elapsed(struct timespec start)
+MQTT_TIME_TPYE MQTTTime_elapsed(struct timespec start)
 {
 	struct timespec now, res;
 
@@ -81,7 +81,7 @@ long MQTTTime_elapsed(struct timespec start)
 	return (res.tv_sec)*1000L + (res.tv_nsec)/1000000L;
 }
 #else
-long MQTTTime_elapsed(struct timeval start)
+MQTT_TIME_TPYE MQTTTime_elapsed(struct timeval start)
 {
 	struct timeval now, res;
 	static struct timespec now_ts;
@@ -100,13 +100,13 @@ long MQTTTime_elapsed(struct timeval start)
  * @param old older time in milliseconds from GetTickCount()
  * @return difference in milliseconds
  */
-long MQTTTime_difftime(DWORD new, DWORD old)
+MQTT_TIME_TPYE MQTTTime_difftime(DWORD new, DWORD old)
 {
 	return new - old;
 }
 #elif defined(AIX)
 #define assert(a)
-long MQTTTime_difftime(struct timespec new, struct timespec old)
+MQTT_TIME_TPYE MQTTTime_difftime(struct timespec new, struct timespec old)
 {
 	struct timespec result;
 
@@ -114,7 +114,7 @@ long MQTTTime_difftime(struct timespec new, struct timespec old)
 	return (result.tv_sec)*1000L + (result.tv_nsec)/1000000L; /* convert to milliseconds */
 }
 #else
-long MQTTTime_difftime(struct timeval new, struct timeval old)
+MQTT_TIME_TPYE MQTTTime_difftime(struct timeval new, struct timeval old)
 {
 	struct timeval result;
 

--- a/src/MQTTTime.h
+++ b/src/MQTTTime.h
@@ -20,20 +20,23 @@
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #define START_TIME_TYPE DWORD
+#define MQTT_TIME_TPYE DWORD
 #define START_TIME_ZERO 0
 #elif defined(AIX)
 #define START_TIME_TYPE struct timespec
+#define MQTT_TIME_TPYE long
 #define START_TIME_ZERO {0, 0}
 #else
 #include <sys/time.h>
 #define START_TIME_TYPE struct timeval
+#define MQTT_TIME_TPYE long
 #define START_TIME_ZERO {0, 0}
 #endif
 
-void MQTTTime_sleep(long milliseconds);
+void MQTTTime_sleep(MQTT_TIME_TPYE milliseconds);
 START_TIME_TYPE MQTTTime_start_clock(void);
 START_TIME_TYPE MQTTTime_now(void);
-long MQTTTime_elapsed(START_TIME_TYPE milliseconds);
-long MQTTTime_difftime(START_TIME_TYPE new, START_TIME_TYPE old);
+MQTT_TIME_TPYE MQTTTime_elapsed(START_TIME_TYPE milliseconds);
+MQTT_TIME_TPYE MQTTTime_difftime(START_TIME_TYPE new, START_TIME_TYPE old);
 
 #endif


### PR DESCRIPTION
long has a different range

tested at system with 44 Days and 12h uptime with Tickcount: **3844828906**

I still perfer a version with no overflow.