### PR TITLE
Synchronise coverity scan branches on a weekly basis.

### DIFF
--- a/.github/workflows/covsync.yml
+++ b/.github/workflows/covsync.yml
@@ -1,0 +1,17 @@
+name: "Synchronise Coverity Scan branches on a weekly basis"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "7 3 * * 0"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: |
+          git checkout -b coverity-develop origin/develop
+          git push origin coverity-develop


### PR DESCRIPTION
This uses github actions to synchronise `coverity-develop` to point at
`develop`, and so triggers a Coverity Scan build on a weekly basis, if
that branch has moved.

It is also possible to trigger this manually, by going to
https://github.com/eclipse/paho.mqtt.c/actions , selecting the
Synchronise Coverity Scan branches workflow, clicking `Run workflow`,
then `Run workflow`.

Signed-off-by: Roger A. Light <roger@atchoo.org>
