### PR TITLE
add missing alpn support to async

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -3497,6 +3497,11 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 			m->c->sslopts->ssl_psk_context = options->ssl->ssl_psk_context;
 			m->c->sslopts->disableDefaultTrustStore = options->ssl->disableDefaultTrustStore;
 		}
+		if (m->c->sslopts->struct_version >= 5)
+		{
+			m->c->sslopts->protos = options->ssl->protos;
+			m->c->sslopts->protos_len = options->ssl->protos_len;
+		}
 	}
 #else
 	if (options->struct_version != 0 && options->ssl)

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -1093,9 +1093,21 @@ typedef struct
 	 */
 	int disableDefaultTrustStore;
 
+	/**
+	 * The protocol-lists must be in wire-format, which is defined as a vector of non-empty, 8-bit length-prefixed, byte strings.
+	 * The length-prefix byte is not included in the length. Each string is limited to 255 bytes. A byte-string length of 0 is invalid.
+	 * A truncated byte-string is invalid.
+	 * Check documentation for SSL_CTX_set_alpn_protos
+	 */
+	const unsigned char *protos;
+
+	/**
+	 * The length of the vector protos vector
+	 */
+	unsigned int protos_len;
 } MQTTAsync_SSLOptions;
 
-#define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 4, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0}
+#define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 5, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0 }
 
 /** Utility structure where name/value pairs are needed */
 typedef struct


### PR DESCRIPTION
in 9e9cba2ea2f8a515a9102e94961dc6e4808bb7e3 only the synchronous client got the new feature.

It should work for async as well. But i found an Android bug: https://android.googlesource.com/platform/external/conscrypt/+/f8a9b546d57c4731805e73e1e96ff2fb3e77d6e0%5E!/ 

```
Calling SSL_CTX_set_alpn_protos appears to be detrimental to thread
safety since the implementation of it resets the values. It's not
idempotent to call it multiple times like SSL_CTX_enable_npn.
```