### PR TITLE
handle ssl errors when processing buffered data

### DIFF
--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -2478,17 +2478,19 @@ static MQTTPacket* MQTTClient_cycle(int* sock, ELAPSED_TIME_TYPE timeout, int* r
 		tp.tv_usec = (long)((timeout % 1000) * 1000); /* this field is microseconds! */
 	}
 
+	int rc1 = 0;
 #if defined(OPENSSL)
 	if ((*sock = SSLSocket_getPendingRead()) == -1)
 	{
-		/* 0 from getReadySocket indicates no work to do, -1 == error, but can happen normally */
+		/* 0 from getReadySocket indicates no work to do, rc -1 == error */
 #endif
-		*sock = Socket_getReadySocket(0, &tp, socket_mutex);
+		*sock = Socket_getReadySocket(0, &tp, socket_mutex, rc);
+		*rc = rc1;
 #if defined(OPENSSL)
 	}
 #endif
 	Thread_lock_mutex(mqttclient_mutex);
-	if (*sock > 0)
+	if (*sock > 0 && rc1 == 0)
 	{
 		MQTTClients* m = NULL;
 		if (ListFindItem(handles, sock, clientSockCompare) != NULL)

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -121,7 +121,7 @@ typedef struct
 
 void Socket_outInitialize(void);
 void Socket_outTerminate(void);
-int Socket_getReadySocket(int more_work, struct timeval *tp, mutex_type mutex);
+int Socket_getReadySocket(int more_work, struct timeval *tp, mutex_type mutex, int* rc);
 int Socket_getch(int socket, char* c);
 char *Socket_getdata(int socket, size_t bytes, size_t* actual_len, int* rc);
 int Socket_putdatas(int socket, char* buf0, size_t buf0len, PacketBuffers bufs);


### PR DESCRIPTION
Signed-off-by: Sandro Scherer <sand.scherer@gmail.com>


Correctly handle ssl errors that occur when buffered messages (because of full tcp send buffer) are processed. See #944 


