### PR TITLE
Update WebSocket.c for cross-compiling to Windows from GNU/Linux

### DIFF
--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -56,7 +56,7 @@
 #  include <sys/endian.h>
 #elif defined(_WIN32) || defined(_WIN64)
 #  pragma comment(lib, "rpcrt4.lib")
-#  include <Rpc.h>
+#  include <rpc.h>
 #  define strncasecmp(s1,s2,c) _strnicmp(s1,s2,c)
 #  define htonll(x) _byteswap_uint64(x)
 #  define ntohll(x) _byteswap_uint64(x)


### PR DESCRIPTION
Compatibility for cross-compiling to Windows in GNU/Linux with MinGW 32.

Signed-off-by: Asier González Blanco cppapprentice@gmail.com