### PR TITLE
Disconnect never occurs if QoS 2 messages are still in progress

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -2120,7 +2120,6 @@ static int MQTTAsync_processCommand(void)
 		{
 			if (command->client->c->connect_state != NOT_IN_PROGRESS)
 			{
-				command->client->c->connect_state = DISCONNECTING;
 				if (command->client->connect.onFailure)
 				{
 					MQTTAsync_failureData data;
@@ -2148,6 +2147,7 @@ static int MQTTAsync_processCommand(void)
 					command->client->connect.onSuccess5 = NULL;
 				}
 			}
+			command->client->c->connect_state = DISCONNECTING;
 			MQTTAsync_checkDisconnect(command->client, &command->command);
 		}
 	}


### PR DESCRIPTION
Attached a trace file that shows the problem:
Immediately before disconnecting, the application sends a message with QoS 2.
The application is still able to send messages after multiple disconnect calls, and the disconnect callbacks are never invoked.
The connect_state is not getting set to DISCONNECTING, so the MQTTAsync_checkTimeouts call does not result in a call to MQTTAsync_checkDisconnect.

[mqtt-disconnect-log.txt](https://github.com/eclipse/paho.mqtt.c/files/5431636/mqtt-disconnect-log.txt)