### PR TITLE
Memory leak corrections

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -860,7 +860,7 @@ static int MQTTAsync_unpersistInflightMessages(Clients* c)
 #endif
 
 /**
- * List callback function for comparing client handles and command types being CONNECT or DISCONNECT 
+ * List callback function for comparing client handles and command types being CONNECT or DISCONNECT
  * @param a first MQTTAsync_queuedCommand pointer
  * @param b second MQTTAsync_queuedCommand pointer
  * @return boolean indicating whether a and b are equal
@@ -880,7 +880,7 @@ static int clientCompareConnectCommand(void* a, void* b)
 		}
 	}
 	return 0;	//Item NOT found in the list
-}								   
+}
 
 
 int MQTTAsync_addCommand(MQTTAsync_queuedCommand* command, int command_size)
@@ -903,7 +903,7 @@ int MQTTAsync_addCommand(MQTTAsync_queuedCommand* command, int command_size)
 		if (head != NULL && head->client == command->client && head->command.type == command->command.type)
 			MQTTAsync_freeCommand(command); /* ignore duplicate connect or disconnect command */
 		else
-		{ 
+		{
 			ListRemoveItem(MQTTAsync_commands, command, clientCompareConnectCommand); /* remove command from the list if already there */
 			ListInsert(MQTTAsync_commands, command, command_size, MQTTAsync_commands->first); /* add to the head of the list */
 		}
@@ -2057,6 +2057,12 @@ static void MQTTAsync_freePack(MQTTPacket* pack)
 		else if (pack->header.bits.type == DISCONNECT)
 		{
 			MQTTPacket_freeAck((Ack*)pack);
+		}
+		else if (pack->header.bits.type == PINGRESP ||
+			     pack->header.bits.type == PINGREQ)
+		{
+			// No free(pack) here as pack comes from MQTTPacket_header_only, which returns a
+			// reference to a static variable.
 		}
 		else
 			free(pack);

--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -3119,7 +3119,7 @@ static MQTTPacket* MQTTAsync_cycle(int* sock, unsigned long timeout, int* rc)
 				}
 			}
 			else if (pack->header.bits.type == PUBREL)
-				*rc = MQTTProtocol_handlePubrels(pack, *sock);
+				*rc = MQTTProtocol_handlePubrels(pack, *sock, 1);
 			else if (pack->header.bits.type == PINGRESP)
 				*rc = MQTTProtocol_handlePingresps(pack, *sock);
 			else

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -2560,7 +2560,7 @@ static MQTTPacket* MQTTClient_cycle(int* sock, ELAPSED_TIME_TYPE timeout, int* r
 				*rc = MQTTProtocol_handlePubrecs(pack, *sock);
 			}
 			else if (pack->header.bits.type == PUBREL)
-				*rc = MQTTProtocol_handlePubrels(pack, *sock);
+				*rc = MQTTProtocol_handlePubrels(pack, *sock, 0);
 			else if (pack->header.bits.type == PINGRESP)
 				*rc = MQTTProtocol_handlePingresps(pack, *sock);
 			else

--- a/src/MQTTProtocolClient.c
+++ b/src/MQTTProtocolClient.c
@@ -521,9 +521,10 @@ int MQTTProtocol_handlePubrecs(void* pack, int sock)
  * Process an incoming pubrel packet for a socket
  * @param pack pointer to the publish packet
  * @param sock the socket on which the packet was received
+ * @param freeTopic If true, the topic name is freed along with the packet
  * @return completion code
  */
-int MQTTProtocol_handlePubrels(void* pack, int sock)
+int MQTTProtocol_handlePubrels(void* pack, int sock, int freeTopic)
 {
 	Pubrel* pubrel = (Pubrel*)pack;
 	Clients* client = NULL;
@@ -585,7 +586,8 @@ int MQTTProtocol_handlePubrels(void* pack, int sock)
 			if (m->publish)
 			{
 				ListRemove(&(state.publications), m->publish);
-				free(m->publish->topic);
+				if (freeTopic)
+					free(m->publish->topic);
 			}
 			ListRemove(client->inboundMsgs, m);
 			++(state.msgs_received);

--- a/src/MQTTProtocolClient.c
+++ b/src/MQTTProtocolClient.c
@@ -585,9 +585,9 @@ int MQTTProtocol_handlePubrels(void* pack, int sock, int freeTopic)
 				MQTTProperties_free(&m->properties);
 			if (m->publish)
 			{
-				ListRemove(&(state.publications), m->publish);
 				if (freeTopic)
 					free(m->publish->topic);
+				ListRemove(&(state.publications), m->publish);
 			}
 			ListRemove(client->inboundMsgs, m);
 			++(state.msgs_received);

--- a/src/MQTTProtocolClient.c
+++ b/src/MQTTProtocolClient.c
@@ -583,7 +583,10 @@ int MQTTProtocol_handlePubrels(void* pack, int sock)
 			if (m->MQTTVersion >= MQTTVERSION_5)
 				MQTTProperties_free(&m->properties);
 			if (m->publish)
+			{
 				ListRemove(&(state.publications), m->publish);
+				free(m->publish->topic);
+			}
 			ListRemove(client->inboundMsgs, m);
 			++(state.msgs_received);
 		}

--- a/src/MQTTProtocolClient.h
+++ b/src/MQTTProtocolClient.h
@@ -42,7 +42,7 @@ void Protocol_processPublication(Publish* publish, Clients* client, int allocate
 int MQTTProtocol_handlePublishes(void* pack, int sock);
 int MQTTProtocol_handlePubacks(void* pack, int sock);
 int MQTTProtocol_handlePubrecs(void* pack, int sock);
-int MQTTProtocol_handlePubrels(void* pack, int sock);
+int MQTTProtocol_handlePubrels(void* pack, int sock, int freeTopic);
 int MQTTProtocol_handlePubcomps(void* pack, int sock);
 
 void MQTTProtocol_closeSession(Clients* c, int sendwill);

--- a/src/MQTTProtocolOut.c
+++ b/src/MQTTProtocolOut.c
@@ -361,7 +361,8 @@ int MQTTProtocol_handlePingresps(void* pack, int sock)
 	client = (Clients*)(ListFindItem(bstate->clients, &sock, clientSocketCompare)->content);
 	Log(LOG_PROTOCOL, 21, NULL, sock, client->clientID);
 	client->ping_outstanding = 0;
-	free(pack);
+	// No free(pack) here as pack comes from MQTTPacket_header_only, which returns a
+	// reference to a static variable.
 	FUNC_EXIT_RC(rc);
 	return rc;
 }

--- a/src/MQTTProtocolOut.c
+++ b/src/MQTTProtocolOut.c
@@ -361,6 +361,7 @@ int MQTTProtocol_handlePingresps(void* pack, int sock)
 	client = (Clients*)(ListFindItem(bstate->clients, &sock, clientSocketCompare)->content);
 	Log(LOG_PROTOCOL, 21, NULL, sock, client->clientID);
 	client->ping_outstanding = 0;
+	free(pack);
 	FUNC_EXIT_RC(rc);
 	return rc;
 }


### PR DESCRIPTION
Here are some fixes for some memory leaks that I found while using the Async library.

**A couple of them were active leaks of the topic name.** Others were places where an owning pointer goes out of scope without freeing or transferring ownership to another pointer. These are potential leaks that I corrected, though I never saw them actively leaking.
