### PR TITLE
Only free the persistence context when using the default file persistence

### DIFF
--- a/src/MQTTPersistence.c
+++ b/src/MQTTPersistence.c
@@ -144,10 +144,11 @@ int MQTTPersistence_close(Clients *c)
 	{
 		rc = c->persistence->pclose(c->phandle);
 
-		if (c->persistence->context)
-			free(c->persistence->context);
-		if (c->persistence->popen == pstopen)
+		if (c->persistence->popen == pstopen) {
+			if (c->persistence->context)
+				free(c->persistence->context);
 			free(c->persistence);
+		}
 
 		c->phandle = NULL;
 		c->persistence = NULL;


### PR DESCRIPTION
Signed-off-by: fpagliughi <fpagliughi@mindspring.com>

Fix for Issue #1001 

The library will only free the persistence context when using the default file persistence. This restores the original library behavior for user-defined persistence while maintaining the fix for #809 
