### PR TITLE
Correct constness on multi-subscription functions

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -957,7 +957,7 @@ exit:
 }
 
 
-int MQTTAsync_subscribeMany(MQTTAsync handle, int count, char* const* topic, int* qos, MQTTAsync_responseOptions* response)
+int MQTTAsync_subscribeMany(MQTTAsync handle, int count, const char* const* topic, const int* qos, MQTTAsync_responseOptions* response)
 {
 	MQTTAsyncs* m = handle;
 	int i = 0;
@@ -1078,13 +1078,13 @@ int MQTTAsync_subscribe(MQTTAsync handle, const char* topic, int qos, MQTTAsync_
 {
 	int rc = 0;
 	FUNC_ENTRY;
-	rc = MQTTAsync_subscribeMany(handle, 1, (char * const *)(&topic), &qos, response);
+	rc = MQTTAsync_subscribeMany(handle, 1, &topic, &qos, response);
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
 
 
-int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, char* const* topic, MQTTAsync_responseOptions* response)
+int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, const char* const* topic, MQTTAsync_responseOptions* response)
 {
 	MQTTAsyncs* m = handle;
 	int i = 0;
@@ -1166,7 +1166,7 @@ int MQTTAsync_unsubscribe(MQTTAsync handle, const char* topic, MQTTAsync_respons
 {
 	int rc = 0;
 	FUNC_ENTRY;
-	rc = MQTTAsync_unsubscribeMany(handle, 1, (char * const *)(&topic), response);
+	rc = MQTTAsync_unsubscribeMany(handle, 1, &topic, response);
 	FUNC_EXIT_RC(rc);
 	return rc;
 }

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -957,7 +957,7 @@ exit:
 }
 
 
-int MQTTAsync_subscribeMany(MQTTAsync handle, int count, const char* const* topic, const int* qos, MQTTAsync_responseOptions* response)
+int MQTTAsync_subscribeMany(MQTTAsync handle, int count, char* const* topic, const int* qos, MQTTAsync_responseOptions* response)
 {
 	MQTTAsyncs* m = handle;
 	int i = 0;
@@ -1078,13 +1078,13 @@ int MQTTAsync_subscribe(MQTTAsync handle, const char* topic, int qos, MQTTAsync_
 {
 	int rc = 0;
 	FUNC_ENTRY;
-	rc = MQTTAsync_subscribeMany(handle, 1, &topic, &qos, response);
+	rc = MQTTAsync_subscribeMany(handle, 1, (char * const *)(&topic), &qos, response);
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
 
 
-int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, const char* const* topic, MQTTAsync_responseOptions* response)
+int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, char* const* topic, MQTTAsync_responseOptions* response)
 {
 	MQTTAsyncs* m = handle;
 	int i = 0;
@@ -1166,7 +1166,7 @@ int MQTTAsync_unsubscribe(MQTTAsync handle, const char* topic, MQTTAsync_respons
 {
 	int rc = 0;
 	FUNC_ENTRY;
-	rc = MQTTAsync_unsubscribeMany(handle, 1, &topic, response);
+	rc = MQTTAsync_unsubscribeMany(handle, 1, (char * const *)(&topic), response);
 	FUNC_EXIT_RC(rc);
 	return rc;
 }

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -1499,7 +1499,7 @@ LIBMQTT_API int MQTTAsync_subscribe(MQTTAsync handle, const char* topic, int qos
   * An error code is returned if there was a problem registering the
   * subscriptions.
   */
-LIBMQTT_API int MQTTAsync_subscribeMany(MQTTAsync handle, int count, const char* const* topic, const int* qos, MQTTAsync_responseOptions* response);
+LIBMQTT_API int MQTTAsync_subscribeMany(MQTTAsync handle, int count, char* const* topic, const int* qos, MQTTAsync_responseOptions* response);
 
 /**
   * This function attempts to remove an existing subscription made by the
@@ -1527,7 +1527,7 @@ LIBMQTT_API int MQTTAsync_unsubscribe(MQTTAsync handle, const char* topic, MQTTA
   * @return ::MQTTASYNC_SUCCESS if the subscriptions are removed.
   * An error code is returned if there was a problem removing the subscriptions.
   */
-LIBMQTT_API int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, const char* const* topic, MQTTAsync_responseOptions* response);
+LIBMQTT_API int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, char* const* topic, MQTTAsync_responseOptions* response);
 
 
 /**

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -1499,7 +1499,7 @@ LIBMQTT_API int MQTTAsync_subscribe(MQTTAsync handle, const char* topic, int qos
   * An error code is returned if there was a problem registering the
   * subscriptions.
   */
-LIBMQTT_API int MQTTAsync_subscribeMany(MQTTAsync handle, int count, char* const* topic, int* qos, MQTTAsync_responseOptions* response);
+LIBMQTT_API int MQTTAsync_subscribeMany(MQTTAsync handle, int count, const char* const* topic, const int* qos, MQTTAsync_responseOptions* response);
 
 /**
   * This function attempts to remove an existing subscription made by the
@@ -1527,7 +1527,7 @@ LIBMQTT_API int MQTTAsync_unsubscribe(MQTTAsync handle, const char* topic, MQTTA
   * @return ::MQTTASYNC_SUCCESS if the subscriptions are removed.
   * An error code is returned if there was a problem removing the subscriptions.
   */
-LIBMQTT_API int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, char* const* topic, MQTTAsync_responseOptions* response);
+LIBMQTT_API int MQTTAsync_unsubscribeMany(MQTTAsync handle, int count, const char* const* topic, MQTTAsync_responseOptions* response);
 
 
 /**


### PR DESCRIPTION
I recognize that this is a change to the API.

However, as the MQTTAsync_subscribeMany and MQTTAsync_unsubscribeMany functions do not actually change what these parameters are passing, it is correct to mark them as const, which allows for _much_ more flexibility on the part of the caller.

Even though this is a change of function signature, **the increase in constness should apply transparently for existing users**. I verified the following forms on Visual Studio and GCC compilers.

```
char* topic1[] = "topic1";
char* topic2[] = "topic2";
char* myTopics[] = {topic1, topic2};

int myQos[] = {0, 0};

MQTTAsync_subscribeMany(handle, 2, myTopics, myQos, respOpts);    // No problem
```

Even if the user was casting to make the old API work...
```
const char* myTopics[] =
{
   "topic1",
   "topic2"
};

int myQos[] = {0, 0};

MQTTAsync_subscribeMany(handle, 2, (char* const*)myTopics, myQos, respOpts);    // Nasty existing cast, but still no problem
```

Or, another...
```
const char* myTopics[] =
{
   "topic1",
   "topic2"
};

int myQos[] = {0, 0};

MQTTAsync_subscribeMany(handle, 2, (char**)myTopics, myQos, respOpts);    // Nasty existing cast, but still no problem
```

The following calling forms are now acceptable, whereas they weren't before.
```
const char topic1[] = "topic1";
char* topic2[] = "topic2";
const char* myTopics[] = {topic1, topic2};

const int myQos[] = {0, 0};

MQTTAsync_subscribeMany(handle, 2, myTopics, myQos, respOpts);    // Now, no problem
```

Also...

```
const char* myTopics[] =
{
   "topic1",
   "topic2"
};

int myQos[] = {0, 0};

MQTTAsync_subscribeMany(handle, 2, myTopics, myQos, respOpts);    // Now, no problem
```
