### PR TITLE
Properly uninitialize OpenSSL - segfault after calling ERR_free_strings()

### DIFF
--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -502,9 +502,9 @@ void SSLSocket_terminate(void)
 
 	if (handle_openssl_init)
 	{
-		EVP_cleanup();
-		ERR_free_strings();
 		CRYPTO_set_locking_callback(NULL);
+		ERR_free_strings();
+		EVP_cleanup();
 		if (sslLocks)
 		{
 			int i = 0;


### PR DESCRIPTION
It looks that OpenSSL was not uninitialized properly and the wrong order of deinit is causing random segfaults. 
It seems like a similar problem was found on the PHP. 
See link for the PHP bug: [https://bugs.php.net/bug.php?id=72140](https://bugs.php.net/bug.php?id=72140)
The solution for PHP is [here](http://git.php.net/?p=php-src.git;a=blobdiff;f=ext/openssl/openssl.c;h=79f666acc5a6421eff70764446f5038e8c660907;hp=88e396c630976329e9931d1e37de1c2bb832ddd8;hb=05033c9ebd015baf825581e5725a594da277d560;hpb=6d3fa654b702c8762aa80ab795080f5c4464d677).
The correct shutdown procedure was found there [stackoverflow](https://stackoverflow.com/questions/29845527/how-to-properly-uninitialize-openssl/29927669#29927669)

Signed-off-by: Igor Šverma <igor@nibejpi.com>


