### PR TITLE
Removed hard-coded 1 as truth in updateConnectOptions callback return

### DIFF
--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -470,6 +470,12 @@ typedef struct
 
 #define MQTTAsync_connectData_initializer {{'M', 'Q', 'C', 'D'}, 0, NULL, {0, NULL}}
 
+/**
+ * This is a callback function which will allow the client application to update the 
+ * connection data.
+ * @param data The conneciton data which can be modified by the application.
+ * @return Return a non-zero value to update the connect data, zero to keep the same data.
+ */
 typedef int MQTTAsync_updateConnectOptions(void* context, MQTTAsync_connectData* data);
 
 /**

--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -1687,7 +1687,7 @@ static void MQTTAsync_checkTimeouts(void)
 					Log(TRACE_MIN, -1, "Calling updateConnectOptions for client %s", m->c->clientID);
 					callback_rc = (*(m->updateConnectOptions))(m->updateConnectOptions_context, &connectData);
 
-					if (callback_rc == 1)
+					if (callback_rc)
 					{
 						if (connectData.username != m->c->username)
 						{


### PR DESCRIPTION
What is true? (part 2)

This removes the hard-coded _1_ as the _true_ value for the return from `updateConnectOptions` user callback, reverting to the more general not-zero is true C convention. 
See #728.

It also documents the callback.