### PR TITLE
Allow trace level to be set to LOG_ERROR

### DIFF
--- a/src/Log.c
+++ b/src/Log.c
@@ -66,7 +66,11 @@
 
 trace_settings_type trace_settings =
 {
+#if defined(HIGH_PERFORMANCE)
+	LOG_ERROR,
+#else
 	TRACE_MINIMUM,
+#endif
 	400,
 	INVALID_LEVEL
 };

--- a/src/Log.c
+++ b/src/Log.c
@@ -229,6 +229,9 @@ void Log_setTraceLevel(enum LOG_LEVELS level)
 {
 	if (level < LOG_ERROR) /* the lowest we can go is LOG_ERROR */
 		trace_settings.trace_level = level;
+	else
+		trace_settings.trace_level = LOG_ERROR;
+
 	trace_output_level = level;
 }
 
@@ -577,5 +580,3 @@ exit:
 	return rc;
 }
 #endif
-
-


### PR DESCRIPTION
Signed-off-by: Tobias Dubois <tobias.dubois@gmail.com>


Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


