### PR TITLE
#1035 Increased persistence key buffer size

### DIFF
--- a/src/MQTTPersistence.c
+++ b/src/MQTTPersistence.c
@@ -267,7 +267,7 @@ int MQTTPersistence_restorePackets(Clients *c)
 					{
 						Publish* publish = (Publish*)pack;
 						Messages* msg = NULL;
-						const size_t keysize = MESSAGE_FILENAME_LENGTH + 1;
+						const size_t keysize = PERSISTENCE_MAX_KEY_LENGTH + 1;
 						char *key = malloc(keysize);
 						int chars = 0;
 
@@ -306,7 +306,7 @@ int MQTTPersistence_restorePackets(Clients *c)
 					{
 						/* orphaned PUBRELs ? */
 						Pubrel* pubrel = (Pubrel*)pack;
-						const size_t keysize = MESSAGE_FILENAME_LENGTH + 1;
+						const size_t keysize = PERSISTENCE_MAX_KEY_LENGTH + 1;
 						char *key = malloc(keysize);
 						int chars = 0;
 
@@ -446,7 +446,7 @@ int MQTTPersistence_putPacket(int socket, char* buf0, size_t buf0len, int count,
 	client = (Clients*)(ListFindItem(bstate->clients, &socket, clientSocketCompare)->content);
 	if (client->persistence != NULL)
 	{
-		const size_t keysize = MESSAGE_FILENAME_LENGTH + 1;
+		const size_t keysize = PERSISTENCE_MAX_KEY_LENGTH + 1;
 		if ((key = malloc(keysize)) == NULL)
 		{
 			rc = PAHO_MEMORY_ERROR;
@@ -537,7 +537,7 @@ int MQTTPersistence_remove(Clients* c, char *type, int qos, int msgId)
 	FUNC_ENTRY;
 	if (c->persistence != NULL)
 	{
-		const size_t keysize = MESSAGE_FILENAME_LENGTH + 1;
+		const size_t keysize = PERSISTENCE_MAX_KEY_LENGTH + 1;
 		char *key = malloc(keysize);
 		int chars = 0;
 

--- a/src/MQTTPersistence.h
+++ b/src/MQTTPersistence.h
@@ -50,9 +50,9 @@
 /** Stem of the key for an MQTT V5 incoming message queue */
 #define PERSISTENCE_V5_QUEUE_KEY "q5-"
 /** Maximum length of a stem for a persistence key */
-#define PERSISTENCE_MAX_STEM_LENGTH 3
+#define PERSISTENCE_MAX_STEM_LENGTH 4
 /** Maximum allowed length of a persistence key */
-#define PERSISTENCE_MAX_KEY_LENGTH 9
+#define PERSISTENCE_MAX_KEY_LENGTH 10
 /** Maximum size of an integer sequence number appended to a persistence key */
 #define PERSISTENCE_SEQNO_LIMIT 1000000 /*10^(PERSISTENCE_MAX_KEY_LENGTH - PERSISTENCE_MAX_STEM_LENGTH)*/
 

--- a/src/MQTTPersistenceDefault.c
+++ b/src/MQTTPersistenceDefault.c
@@ -923,7 +923,7 @@ int main (int argc, char *argv[])
 	/* put */
 	for(msgId=0;msgId<NMSGS;msgId++)
 	{
-		key = malloc(MESSAGE_FILENAME_LENGTH + 1);
+		key = malloc(PERSISTENCE_MAX_KEY_LENGTH + 1);
 		sprintf(key, "%s%d", stem, msgId);
 		rc = pstput(handle, key, nbufs, bufs, buflens);
 		printf("%s Adding message %s\n", RC, key);
@@ -942,7 +942,7 @@ int main (int argc, char *argv[])
 	/* containskey */
 	for(i=0;i<NDEL;i++)
 	{
-		key = malloc(MESSAGE_FILENAME_LENGTH + 1);
+		key = malloc(PERSISTENCE_MAX_KEY_LENGTH + 1);
 		sprintf(key, "%s%d", stem, nm[i]);
 		rc = pstcontainskey(handle, key);
 		printf("%s Message %s is persisted ?\n", RC, key);
@@ -952,7 +952,7 @@ int main (int argc, char *argv[])
 	/* get && remove*/
 	for(i=0;i<NDEL;i++)
 	{
-		key = malloc(MESSAGE_FILENAME_LENGTH + 1);
+		key = malloc(PERSISTENCE_MAX_KEY_LENGTH + 1);
 		sprintf(key, "%s%d", stem, nm[i]);
 		rc = pstget(handle, key, &buffer, &buflen);
 		buff = malloc(buflen+1);
@@ -969,7 +969,7 @@ int main (int argc, char *argv[])
 	/* containskey */
 	for(i=0;i<NDEL;i++)
 	{
-		key = malloc(MESSAGE_FILENAME_LENGTH + 1);
+		key = malloc(PERSISTENCE_MAX_KEY_LENGTH + 1);
 		sprintf(key, "%s%d", stem, nm[i]);
 		rc = pstcontainskey(handle, key);
 		printf("%s Message %s is persisted ?\n", RC, key);

--- a/src/MQTTPersistenceDefault.h
+++ b/src/MQTTPersistenceDefault.h
@@ -17,8 +17,6 @@
 #if !defined(MQTTPERSISTENCEDEFAULT_H)
 #define MQTTPERSISTENCEDEFAULT_H
 
-/** 8.3 filesystem */
-#define MESSAGE_FILENAME_LENGTH 8    
 /** Extension of the filename */
 #define MESSAGE_FILENAME_EXTENSION ".msg"
 


### PR DESCRIPTION
Signed-off-by: fpagliughi <fpagliughi@mindspring.com>


Fix for Issue #1035. Increases the persistence key buffer size by one to account for longer stem, and replaced use of `MESSAGE_FILENAME_LENGTH` with `PERSISTENCE_MAX_KEY_LENGTH` when sizing a buffer to hold a key.