### PR TITLE
if rc== SOCKET_ERROR , Can't call MQTTAsync_closeOnly

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -1555,8 +1555,11 @@ static void nextOrClose(MQTTAsyncs* m, int rc, char* message)
 {
 	int was_connected = m->c->connected;
 	FUNC_ENTRY;
-
-	if (MQTTAsync_checkConn(&m->connect, m)  && rc!= SOCKET_ERROR)
+ 	if (rc == SOCKET_ERROR && m->c->net.socket>0)
+	{
+		m->c->net.socket = SOCKET_ERROR;
+	}
+	if (MQTTAsync_checkConn(&m->connect, m) )
 	{
 		MQTTAsync_queuedCommand* conn;
 

--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -1556,7 +1556,7 @@ static void nextOrClose(MQTTAsyncs* m, int rc, char* message)
 	int was_connected = m->c->connected;
 	FUNC_ENTRY;
 
-	if (MQTTAsync_checkConn(&m->connect, m))
+	if (MQTTAsync_checkConn(&m->connect, m)  && rc!= SOCKET_ERROR)
 	{
 		MQTTAsync_queuedCommand* conn;
 


### PR DESCRIPTION
 if rc== SOCKET_ERROR  , Can't  call MQTTAsync_closeOnly

