### PR TITLE
Minor params names fix: new -> t_new, old -> t_old

### DIFF
--- a/src/MQTTTime.c
+++ b/src/MQTTTime.c
@@ -71,36 +71,36 @@ START_TIME_TYPE MQTTTime_now(void)
 
 #if defined(_WIN32) || defined(_WIN64)
 /*
- * @param new most recent time in milliseconds from GetTickCount()
- * @param old older time in milliseconds from GetTickCount()
+ * @param t_new most recent time in milliseconds from GetTickCount()
+ * @param t_old older time in milliseconds from GetTickCount()
  * @return difference in milliseconds
  */
-DIFF_TIME_TYPE MQTTTime_difftime(START_TIME_TYPE new, START_TIME_TYPE old)
+DIFF_TIME_TYPE MQTTTime_difftime(START_TIME_TYPE t_new, START_TIME_TYPE t_old)
 {
 #if WINVER >= _WIN32_WINNT_VISTA
-	return (DIFF_TIME_TYPE )(new - old);
+	return (DIFF_TIME_TYPE)(t_new - t_old);
 #else
-	if (old < new)       /* check for wrap around condition in GetTickCount */
-		return (DIFF_TIME_TYPE)(new - old);
+	if (t_old < t_new)       /* check for wrap around condition in GetTickCount */
+		return (DIFF_TIME_TYPE)(t_new - t_old);
 	else
-	    return (DIFF_TIME_TYPE)((0xFFFFFFFFL - old) + 1 + new);
+	    return (DIFF_TIME_TYPE)((0xFFFFFFFFL - t_old) + 1 + t_new);
 #endif
 }
 #elif defined(AIX)
 #define assert(a)
-DIFF_TIME_TYPE MQTTTime_difftime(START_TIME_TYPE new, START_TIME_TYPE old)
+DIFF_TIME_TYPE MQTTTime_difftime(START_TIME_TYPE t_new, START_TIME_TYPE t_old)
 {
 	struct timespec result;
 
-	ntimersub(new, old, result);
+	ntimersub(t_new, t_old, result);
 	return (DIFF_TIME_TYPE)((result.tv_sec)*1000L + (result.tv_nsec)/1000000L); /* convert to milliseconds */
 }
 #else
-DIFF_TIME_TYPE MQTTTime_difftime(START_TIME_TYPE new, START_TIME_TYPE old)
+DIFF_TIME_TYPE MQTTTime_difftime(START_TIME_TYPE t_new, START_TIME_TYPE t_old)
 {
 	struct timeval result;
 
-	timersub(&new, &old, &result);
+	timersub(&t_new, &t_old, &result);
 	return (DIFF_TIME_TYPE)(((DIFF_TIME_TYPE)result.tv_sec)*1000 + ((DIFF_TIME_TYPE)result.tv_usec)/1000); /* convert to milliseconds */
 }
 #endif

--- a/src/MQTTTime.h
+++ b/src/MQTTTime.h
@@ -44,6 +44,6 @@ void MQTTTime_sleep(ELAPSED_TIME_TYPE milliseconds);
 START_TIME_TYPE MQTTTime_start_clock(void);
 START_TIME_TYPE MQTTTime_now(void);
 ELAPSED_TIME_TYPE MQTTTime_elapsed(START_TIME_TYPE milliseconds);
-DIFF_TIME_TYPE MQTTTime_difftime(START_TIME_TYPE new, START_TIME_TYPE old);
+DIFF_TIME_TYPE MQTTTime_difftime(START_TIME_TYPE t_new, START_TIME_TYPE t_old);
 
 #endif


### PR DESCRIPTION
## Proposal
Even if this is `C` library, maybe will be better to use **safer** names for params: `t_new` - instead of **`new`** (and symmetric `t_old` instead of `old`), which is reserved `C++` keyword.

## Warning fix
During built-in (not as library, but as directly compiled-into-binary) compilation, with `gcc`, for `c++`, compiler says: `MQTTTime.h:47:50: error: invalid parameter name: 'new' is a keyword`. This minor pull request fixes it. 

