### PR TITLE
Support the IPv6 link-local address scope

### DIFF
--- a/src/Socket.c
+++ b/src/Socket.c
@@ -41,6 +41,9 @@
 #include <string.h>
 #include <signal.h>
 #include <ctype.h>
+#if !defined(_WIN32) && !defined(_WIN64)
+#include <net/if.h>
+#endif
 
 #include "Heap.h"
 
@@ -679,7 +682,7 @@ int Socket_new(const char* addr, size_t addr_len, int port, int* sock)
 #endif
 {
 	int type = SOCK_STREAM;
-	char *addr_mem, *ifname, *p;
+	char *addr_mem, *ifname = NULL, *p;
 	size_t ifname_len = 0;
 	struct sockaddr_in address;
 #if defined(AF_INET6)
@@ -703,7 +706,7 @@ int Socket_new(const char* addr, size_t addr_len, int port, int* sock)
 		++addr;
 		--addr_len;
 #if !defined(_WIN32) && !defined(_WIN64)
-		if (p = strchr(addr, (int)'%')) {
+		if ((p = strchr(addr, (int)'%'))) {
 			ifname_len = addr_len - (p - addr) - 1;
 			addr_len = p - addr;
 			p++;

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -679,7 +679,8 @@ int Socket_new(const char* addr, size_t addr_len, int port, int* sock)
 #endif
 {
 	int type = SOCK_STREAM;
-	char *addr_mem;
+	char *addr_mem, *ifname, *p;
+	size_t ifname_len = 0;
 	struct sockaddr_in address;
 #if defined(AF_INET6)
 	struct sockaddr_in6 address6;
@@ -701,6 +702,11 @@ int Socket_new(const char* addr, size_t addr_len, int port, int* sock)
 	{
 		++addr;
 		--addr_len;
+		if (p = strchr(addr, (int)'%')) {
+			ifname_len = addr_len - (p - addr) - 1;
+			addr_len = p - addr;
+			p++;
+		}
 	}
 
 	if ((addr_mem = malloc( addr_len + 1u )) == NULL)
@@ -710,6 +716,12 @@ int Socket_new(const char* addr, size_t addr_len, int port, int* sock)
 	}
 	memcpy( addr_mem, addr, addr_len );
 	addr_mem[addr_len] = '\0';
+
+	if (ifname_len) {
+		ifname = malloc( ifname_len + 1u );
+		memcpy( ifname, p, ifname_len );
+		ifname[ifname_len] = '\0';
+	}
 
 #if 0 /*defined(__GNUC__) && defined(__linux__)*/
 	/* Commented out because the CI tests get intermittent ECONNABORTED return values
@@ -765,6 +777,12 @@ int Socket_new(const char* addr, size_t addr_len, int port, int* sock)
 			address.sin_port = htons(port);
 			address.sin_family = family = AF_INET;
 			address.sin_addr = ((struct sockaddr_in*)(res->ai_addr))->sin_addr;
+			if (ifname) {
+				if ((address6.sin6_scope_id = if_nametoindex(ifname)) == 0) {
+					Log(LOG_ERROR, -1, "Could not maps the interface index for %s", ifname);
+					rc = -1;
+				}
+			}
 		}
 		else
 			rc = -1;
@@ -848,6 +866,8 @@ int Socket_new(const char* addr, size_t addr_len, int port, int* sock)
 exit:
 	if (addr_mem)
 		free(addr_mem);
+	if (ifname)
+		free(ifname);
 
 	FUNC_EXIT_RC(rc);
 	return rc;


### PR DESCRIPTION
I tried to make it possible to use link-local addresses.
The format of the serverURI is as follows.
 
      <protocol>://[<link-local address>%<scope>]:<port>
    ex.
       ssl://[fe80::f279:59ff:fe64:3dff%wm0]:8883

Windows is not supported because the handling of the if_nametoindex() function is unknown.
