### PR TITLE
Make sure to initialize the mask on the Publish struct

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -758,7 +758,7 @@ static int MQTTAsync_unpersistInflightMessages(Clients* c)
 #endif
 
 /**
- * List callback function for comparing client handles and command types being CONNECT or DISCONNECT 
+ * List callback function for comparing client handles and command types being CONNECT or DISCONNECT
  * @param a first MQTTAsync_queuedCommand pointer
  * @param b second MQTTAsync_queuedCommand pointer
  * @return boolean indicating whether a and b are equal
@@ -778,7 +778,7 @@ static int clientCompareConnectCommand(void* a, void* b)
 		}
 	}
 	return 0;	//Item NOT found in the list
-}								   
+}
 
 
 int MQTTAsync_addCommand(MQTTAsync_queuedCommand* command, int command_size)
@@ -801,7 +801,7 @@ int MQTTAsync_addCommand(MQTTAsync_queuedCommand* command, int command_size)
 		if (head != NULL && head->client == command->client && head->command.type == command->command.type)
 			MQTTAsync_freeCommand(command); /* ignore duplicate connect or disconnect command */
 		else
-		{ 
+		{
 			ListRemoveItem(MQTTAsync_commands, command, clientCompareConnectCommand); /* remove command from the list if already there */
 			ListInsert(MQTTAsync_commands, command, command_size, MQTTAsync_commands->first); /* add to the head of the list */
 		}
@@ -1369,6 +1369,9 @@ static int MQTTAsync_processCommand(void)
 			rc = PAHO_MEMORY_ERROR;
 			goto exit;
 		}
+
+		/* Initialize the mask */
+		memset(p->mask, 0, sizeof(p->mask));
 
 		p->payload = command->command.details.pub.payload;
 		p->payloadlen = command->command.details.pub.payloadlen;


### PR DESCRIPTION
After a lot of debugging we found this to be the root cause of the corruption reported in #1079

When not initializing the mask properly, the [check](https://github.com/eclipse/paho.mqtt.c/blob/master/src/WebSocket.c#L274) to see if a mask already exists might fail (depending on the existing data in that part of the memory) which then means that whatever is in the mask will be used for masking the data.

Fixes #1079

Signed-off-by: Sander van Harmelen <sander@vanharmelen.nl>