### PR TITLE
Update MQTTAsync_subscribe.c

### DIFF
--- a/src/samples/MQTTAsync_subscribe.c
+++ b/src/samples/MQTTAsync_subscribe.c
@@ -40,6 +40,9 @@ int disc_finished = 0;
 int subscribed = 0;
 int finished = 0;
 
+void onConnect(void* context, MQTTAsync_successData* response);       
+void onConnectFailure(void* context, MQTTAsync_failureData* response);
+
 void connlost(void *context, char *cause)
 {
 	MQTTAsync client = (MQTTAsync)context;
@@ -53,6 +56,9 @@ void connlost(void *context, char *cause)
 	printf("Reconnecting\n");
 	conn_opts.keepAliveInterval = 20;
 	conn_opts.cleansession = 1;
+	conn_opts.onSuccess = onConnect;       
+        conn_opts.onFailure = onConnectFailure;
+        conn_opts.context = client;            
 	if ((rc = MQTTAsync_connect(client, &conn_opts)) != MQTTASYNC_SUCCESS)
 	{
 		printf("Failed to start connect, return code %d\n", rc);


### PR DESCRIPTION
fix reconnecting bug: reconnect will not active on message arrive.


Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


