### PR TITLE
Fix disconnect when there are pending writes

### DIFF
--- a/src/Clients.h
+++ b/src/Clients.h
@@ -137,6 +137,7 @@ typedef struct
 	List* inboundMsgs;              /**< inbound in flight messages */
 	List* outboundMsgs;				/**< outbound in flight messages */
 	List* messageQueue;             /**< inbound complete but undelivered messages */
+	List* outboundQueue;            /**< outbound queued messages */
 	unsigned int qentry_seqno;
 	void* phandle;                  /**< the persistence handle */
 	MQTTClient_persistence* persistence; /**< a persistence implementation */

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -356,6 +356,7 @@ int MQTTAsync_createWithOptions(MQTTAsync* handle, const char* serverURI, const 
 		bstate->clients = ListInitialize();
 		Socket_outInitialize();
 		Socket_setWriteCompleteCallback(MQTTAsync_writeComplete);
+		Socket_setWriteAvailableCallback(MQTTProtocol_writeAvailable);
 		MQTTAsync_handles = ListInitialize();
 		MQTTAsync_commands = ListInitialize();
 #if defined(OPENSSL)
@@ -408,9 +409,10 @@ int MQTTAsync_createWithOptions(MQTTAsync* handle, const char* serverURI, const 
 	m->c->outboundMsgs = ListInitialize();
 	m->c->inboundMsgs = ListInitialize();
 	m->c->messageQueue = ListInitialize();
+	m->c->outboundQueue = ListInitialize();
 	m->c->clientID = MQTTStrdup(clientId);
 	if (m->c->context == NULL || m->c->outboundMsgs == NULL || m->c->inboundMsgs == NULL ||
-			m->c->messageQueue == NULL || m->c->clientID == NULL)
+			m->c->messageQueue == NULL || m->c->outboundQueue == NULL || m->c->clientID == NULL)
 	{
 		rc = PAHO_MEMORY_ERROR;
 		goto exit;

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -428,6 +428,7 @@ int MQTTClient_createWithOptions(MQTTClient* handle, const char* serverURI, cons
 		bstate->clients = ListInitialize();
 		Socket_outInitialize();
 		Socket_setWriteCompleteCallback(MQTTClient_writeComplete);
+		Socket_setWriteAvailableCallback(MQTTProtocol_writeAvailable);
 		handles = ListInitialize();
 #if defined(OPENSSL)
 		SSLSocket_initialize();
@@ -486,6 +487,7 @@ int MQTTClient_createWithOptions(MQTTClient* handle, const char* serverURI, cons
 	m->c->outboundMsgs = ListInitialize();
 	m->c->inboundMsgs = ListInitialize();
 	m->c->messageQueue = ListInitialize();
+	m->c->outboundQueue = ListInitialize();
 	m->c->clientID = MQTTStrdup(clientId);
 	m->connect_sem = Thread_create_sem(&rc);
 	m->connack_sem = Thread_create_sem(&rc);

--- a/src/MQTTProtocolClient.h
+++ b/src/MQTTProtocolClient.h
@@ -55,6 +55,8 @@ void MQTTProtocol_freeMessageList(List* msgList);
 char* MQTTStrncpy(char *dest, const char* src, size_t num);
 char* MQTTStrdup(const char* src);
 
+void MQTTProtocol_writeAvailable(int socket);
+
 //#define MQTTStrdup(src) MQTTStrncpy(malloc(strlen(src)+1), src, strlen(src)+1)
 
 #endif

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -861,7 +861,12 @@ void Socket_setWriteCompleteCallback(Socket_writeComplete* mywritecomplete)
 	writecomplete = mywritecomplete;
 }
 
+static Socket_writeAvailable* writeAvailable = NULL;
 
+void Socket_setWriteAvailableCallback(Socket_writeAvailable* mywriteavailable)
+{
+	writeAvailable = mywriteavailable;
+}
 
 /**
  *  Continue an outstanding write for a particular socket
@@ -1009,6 +1014,9 @@ int Socket_continueWrites(fd_set* pwset, int* sock)
 				ListNextElement(mod_s.write_pending, &curpending);
 			}
 			curpending = mod_s.write_pending->current;
+
+			if (writeAvailable && rc > 0)
+				(*writeAvailable)(socket);
 
 			if (writecomplete)
 				(*writecomplete)(socket, rc);

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -142,4 +142,7 @@ void Socket_clearPendingWrite(int socket);
 typedef void Socket_writeComplete(int socket, int rc);
 void Socket_setWriteCompleteCallback(Socket_writeComplete*);
 
+typedef void Socket_writeAvailable(int socket);
+void Socket_setWriteAvailableCallback(Socket_writeAvailable*);
+
 #endif /* SOCKET_H */


### PR DESCRIPTION
There is a bug that occurs with QoS1 or QoS2 transmissions.
Here's the sequence of events:
1. The MQTT client attempts to send a large message. That message is broken up into chunks. At some point the socket buffer fills up and an SSL_ERROR_WANT_WRITE occurs. This prompts the library to store the in-flight message (that was just interrupted) as a pending write.
2. The MQTT broker sends a (different) QoS1 or QoS2 message to the client. This occurs while the socket buffer is still full.
3. The MQTT client checks to see if there are any pending writes. If there are, this means the socket is full and is not ready to send any more data.
4. Because there are pending writes, the MQTT client treats that as a SOCKET_ERROR.
5. This error gets propagated up the call stack. Eventually the socket is closed as a result of the SOCKET_ERROR.
6. Closing the socket results in a disconnection. This triggers the LWT in the MQTT broker.
7. Because persistence is turned on, once the client automatically reconnects, it attempts to send the large message from step 1 again.
8. Also, because the MQTT broker has not had its message from step 2 acknowledged, the broker attempts to send this message again.
9. This repeats ad infinitum.

To solve this problem, I've added a queue of ACKs to the client. Once the pending writes are done the MQTT client will attempt to acknowledge all the messages in the queue. So, step 4 will not result in a SOCKET_ERROR, rather, it will result in the ACK message getting queued.

I've attached a log of the problem titled BeforeFix.log. The errors start on line 3209.
[BeforeFix.log](https://github.com/eclipse/paho.mqtt.c/files/6882172/BeforeFix.log)


Signed-off-by: vm-vloz <73361520+vm-vloz@users.noreply.github.com>

