### PR TITLE
With MQTTCLIENT_PERSISTENCE_DEFAULT the paho code crashes for MQTTVER…

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -259,8 +259,9 @@ static int MQTTAsync_persistCommand(MQTTAsync_queuedCommand* qcmd)
 	switch (command->type)
 	{
 		case SUBSCRIBE:
+			int multiplier = (aclient->c->MQTTVersion >= MQTTVERSION_5) ? 3 : 2;
 			nbufs = ((aclient->c->MQTTVersion >= MQTTVERSION_5) ? 4 : 3) +
-				(command->details.sub.count * 2);
+				(command->details.sub.count * multiplier);
 
 			if (((lens = (int*)malloc(nbufs * sizeof(int))) == NULL) ||
 					((bufs = malloc(nbufs * sizeof(char *))) == NULL))
@@ -282,12 +283,9 @@ static int MQTTAsync_persistCommand(MQTTAsync_queuedCommand* qcmd)
 				bufs[bufindex] = command->details.sub.topics[i];
 				lens[bufindex++] = (int)strlen(command->details.sub.topics[i]) + 1;
 
-				if (aclient->c->MQTTVersion < MQTTVERSION_5)
-				{
-					bufs[bufindex] = &command->details.sub.qoss[i];
-					lens[bufindex++] = sizeof(command->details.sub.qoss[i]);
-				}
-				else
+				bufs[bufindex] = &command->details.sub.qoss[i];
+				lens[bufindex++] = sizeof(command->details.sub.qoss[i]);
+				if (aclient->c->MQTTVersion >= MQTTVERSION_5)
 				{
 					if (command->details.sub.count == 1)
 					{
@@ -456,7 +454,7 @@ static MQTTAsync_queuedCommand* MQTTAsync_restoreCommand(char* buffer, int bufle
 	switch (command->type)
 	{
 		case SUBSCRIBE:
-			if (qcommand->not_restored == 0)
+			if (qcommand->not_restored == 1)
 				break;
 			if (&ptr[sizeof(int)] > endpos)
 				goto error_exit;
@@ -467,16 +465,17 @@ static MQTTAsync_queuedCommand* MQTTAsync_restoreCommand(char* buffer, int bufle
 			{
 				if ((command->details.sub.topics = (char **)malloc(sizeof(char *) * command->details.sub.count)) == NULL)
 					goto error_exit;
-				if (MQTTVersion < MQTTVERSION_5)
+				if ((command->details.sub.qoss = (int *)malloc(sizeof(int) * command->details.sub.count)) == NULL)
+					goto error_exit;
+
+				if ((MQTTVersion >= MQTTVERSION_5))
 				{
-					if ((command->details.sub.qoss = (int *)malloc(sizeof(int) * command->details.sub.count)) == NULL)
-						goto error_exit;
-				}
-				else if (command->details.sub.count > 1)
-				{
-					command->details.sub.optlist = (MQTTSubscribe_options*)malloc(sizeof(MQTTSubscribe_options) * command->details.sub.count);
-					if (command->details.sub.optlist == NULL)
-						goto error_exit;
+					if (command->details.sub.count > 1)
+					{
+						command->details.sub.optlist = (MQTTSubscribe_options*)malloc(sizeof(MQTTSubscribe_options) * command->details.sub.count);
+						if (command->details.sub.optlist == NULL)
+							goto error_exit;
+					}
 				}
 			}
 
@@ -488,18 +487,15 @@ static MQTTAsync_queuedCommand* MQTTAsync_restoreCommand(char* buffer, int bufle
 
 				if ((command->details.sub.topics[i] = malloc(data_size)) == NULL)
 					goto error_exit;
-
 				strcpy(command->details.sub.topics[i], ptr);
 				ptr += data_size;
 
-				if (MQTTVersion < MQTTVERSION_5)
-				{
-					if (&ptr[sizeof(int)] > endpos)
-						goto error_exit;
-					command->details.sub.qoss[i] = *(int*)ptr;
-					ptr += sizeof(int);
-				}
-				else
+				if (&ptr[sizeof(int)] > endpos)
+					goto error_exit;
+				command->details.sub.qoss[i] = *(int*)ptr;
+				ptr += sizeof(int);
+
+				if (MQTTVersion >= MQTTVERSION_5)
 				{
 					if (&ptr[sizeof(MQTTSubscribe_options)] > endpos)
 						goto error_exit;
@@ -518,7 +514,7 @@ static MQTTAsync_queuedCommand* MQTTAsync_restoreCommand(char* buffer, int bufle
 			break;
 
 		case UNSUBSCRIBE:
-			if (qcommand->not_restored == 0)
+			if (qcommand->not_restored == 1)
 				break;
 
 			if (&ptr[sizeof(int)] > endpos)


### PR DESCRIPTION
…SION_5 #1108

For MQTTVERSION_5 for SUBSCRIBE command qoss details were not added in persistent folder.
Also at restoring command for SUBSCRIBE & UNSUBSCRIBE the ptr value was not updated to point to the MQTTProperties value in buffer.
Because of which qcommand was getting freed and there was crash later down the call stack.

This fix address above issues.

Signed-off-by: ajit bansal ajitvkb1@hotmail.com


