### PR TITLE
Fix spelling error in environment variable for osx job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
       env: OPENSSL_ROOT_DIR= PAHO_BUILD_STATIC=TRUE PAHO_BUILD_SHARED=TRUE PAHO_HIGH_PERFORMANCE=TRUE
     - os: osx
       compiler: clang
-      env: OPENSSL_ROOT_DIR=/usr/local/opt/openssl PAHO_BUILD_STATIC=FALSE PAHO_BUILD_SHARED=TRUE PAHO_HIGH_PERFORMANC=FALSE
+      env: OPENSSL_ROOT_DIR=/usr/local/opt/openssl PAHO_BUILD_STATIC=FALSE PAHO_BUILD_SHARED=TRUE PAHO_HIGH_PERFORMANCE=FALSE
     - os: linux
       compiler: gcc
       dist: trusty


### PR DESCRIPTION
Fix a spelling error in an environment variable used by the osx travis job spec.

 Signed-off-by: Vince Chan vince@beamconnectivity.com
