### PR TITLE
Bugfix in paho_cs_pub.c and paho_cs_sub.c

### DIFF
--- a/src/samples/paho_cs_pub.c
+++ b/src/samples/paho_cs_pub.c
@@ -107,14 +107,14 @@ int myconnect(MQTTClient* client)
 		MQTTResponse response = MQTTResponse_initializer;
 
 		conn_opts.cleanstart = 1;
-		response = MQTTClient_connect5(client, &conn_opts, &props, &willProps);
+		response = MQTTClient_connect5(*client, &conn_opts, &props, &willProps);
 		rc = response.reasonCode;
 		MQTTResponse_free(response);
 	}
 	else
 	{
 		conn_opts.cleansession = 1;
-		rc = MQTTClient_connect(client, &conn_opts);
+		rc = MQTTClient_connect(*client, &conn_opts);
 	}
 
 	if (opts.verbose && rc == MQTTCLIENT_SUCCESS)

--- a/src/samples/paho_cs_pub.c
+++ b/src/samples/paho_cs_pub.c
@@ -52,7 +52,7 @@ struct pubsub_opts opts =
 };
 
 
-int myconnect(MQTTClient* client)
+int myconnect(MQTTClient client)
 {
 	MQTTClient_connectOptions conn_opts = MQTTClient_connectOptions_initializer;
 	MQTTClient_SSLOptions ssl_opts = MQTTClient_SSLOptions_initializer;
@@ -107,14 +107,14 @@ int myconnect(MQTTClient* client)
 		MQTTResponse response = MQTTResponse_initializer;
 
 		conn_opts.cleanstart = 1;
-		response = MQTTClient_connect5(*client, &conn_opts, &props, &willProps);
+		response = MQTTClient_connect5(client, &conn_opts, &props, &willProps);
 		rc = response.reasonCode;
 		MQTTResponse_free(response);
 	}
 	else
 	{
 		conn_opts.cleansession = 1;
-		rc = MQTTClient_connect(*client, &conn_opts);
+		rc = MQTTClient_connect(client, &conn_opts);
 	}
 
 	if (opts.verbose && rc == MQTTCLIENT_SUCCESS)

--- a/src/samples/paho_cs_sub.c
+++ b/src/samples/paho_cs_sub.c
@@ -49,7 +49,7 @@ struct pubsub_opts opts =
 };
 
 
-int myconnect(MQTTClient* client)
+int myconnect(MQTTClient client)
 {
 	MQTTClient_connectOptions conn_opts = MQTTClient_connectOptions_initializer;
 	MQTTClient_SSLOptions ssl_opts = MQTTClient_SSLOptions_initializer;
@@ -243,7 +243,7 @@ int main(int argc, char** argv)
 			MQTTClient_free(topicName);
 		}
 		if (rc != 0)
-			myconnect(&client);
+			myconnect(client);
 	}
 
 exit:


### PR DESCRIPTION
In the function **MQTTClient_connect()**, first variable **client** should be MQTTClient type, but in function **myconnect()** var client is a pointer of MQTTClient type. So I think it should be *client.
Signed-off-by: Ashechol <ashechol@qq.com>