### PR TITLE
Prevent calling `SSL_read` with `num == 0`

### DIFF
--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -884,23 +884,26 @@ char *SSLSocket_getdata(SSL* ssl, int socket, size_t bytes, size_t* actual_len, 
 
 	buf = SocketBuffer_getQueuedData(socket, bytes, actual_len);
 
-	ERR_clear_error();
-	if ((*rc = SSL_read(ssl, buf + (*actual_len), (int)(bytes - (*actual_len)))) < 0)
+	if (*actual_len != bytes)
 	{
-		*rc = SSLSocket_error("SSL_read - getdata", ssl, socket, *rc, NULL, NULL);
-		if (*rc != SSL_ERROR_WANT_READ && *rc != SSL_ERROR_WANT_WRITE)
+		ERR_clear_error();
+		if ((*rc = SSL_read(ssl, buf + (*actual_len), (int)(bytes - (*actual_len)))) < 0)
+		{
+			*rc = SSLSocket_error("SSL_read - getdata", ssl, socket, *rc, NULL, NULL);
+			if (*rc != SSL_ERROR_WANT_READ && *rc != SSL_ERROR_WANT_WRITE)
+			{
+				buf = NULL;
+				goto exit;
+			}
+		}
+		else if (*rc == 0) /* rc 0 means the other end closed the socket */
 		{
 			buf = NULL;
 			goto exit;
 		}
+		else
+			*actual_len += *rc;
 	}
-	else if (*rc == 0) /* rc 0 means the other end closed the socket */
-	{
-		buf = NULL;
-		goto exit;
-	}
-	else
-		*actual_len += *rc;
 
 	if (*actual_len == bytes)
 	{


### PR DESCRIPTION
If whole packet was read from socket buffer, then `*actual_len == bytes`. But this means that `SSL_read` will be called with `num == 0`; in this case `ssl3_read_bytes` from OpenSSL, for example, return 0 and MQTT library treats connection as closed by remote peer.

Signed-off-by: Andrey Starodubtsev <andrey.starodubtsev@gmail.com>