### PR TITLE
Draft: avoid long delay in MQTTAsync_destroy #1107

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -2320,11 +2320,12 @@ static void MQTTAsync_stop(void)
 		{
 			int count = 0;
 			MQTTAsync_tostop = 1;
+			Socket_unblock();
 			while ((sendThread_state != STOPPED || receiveThread_state != STOPPED) && MQTTAsync_tostop != 0 && ++count < 100)
 			{
 				MQTTAsync_unlock_mutex(mqttasync_mutex);
 				Log(TRACE_MIN, -1, "sleeping");
-				MQTTAsync_sleep(100L);
+				MQTTAsync_sleep(20L);
 				MQTTAsync_lock_mutex(mqttasync_mutex);
 			}
 #if !defined(NOSTACKTRACE)

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -428,7 +428,14 @@ int MQTTClient_createWithOptions(MQTTClient* handle, const char* serverURI, cons
 		#endif
 		Log_initialize((Log_nameValue*)MQTTClient_getVersionInfo());
 		bstate->clients = ListInitialize();
-		Socket_outInitialize();
+		if ((rc = Socket_outInitialize()) != 0) {
+			ListFree(bstate->clients);
+			Log_terminate();
+			#if !defined(NO_HEAP_TRACKING)
+				Heap_terminate();
+			#endif
+			goto exit;
+		}
 		Socket_setWriteCompleteCallback(MQTTClient_writeComplete);
 		Socket_setWriteAvailableCallback(MQTTProtocol_writeAvailable);
 		handles = ListInitialize();

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -116,10 +116,11 @@ typedef struct
 	List* connect_pending; /**< list of sockets for which a connect is pending */
 	List* write_pending; /**< list of sockets for which a write is pending */
 	fd_set pending_wset; /**< socket pending write set for select */
+	int unblock_pipe[2]; /**< pipe to allow for unblocking selects waiting for reading */
 } Sockets;
 
 
-void Socket_outInitialize(void);
+int Socket_outInitialize(void);
 void Socket_outTerminate(void);
 int Socket_getReadySocket(int more_work, struct timeval *tp, mutex_type mutex, int* rc);
 int Socket_getch(int socket, char* c);
@@ -144,5 +145,7 @@ void Socket_setWriteCompleteCallback(Socket_writeComplete*);
 
 typedef void Socket_writeAvailable(int socket);
 void Socket_setWriteAvailableCallback(Socket_writeAvailable*);
+
+void Socket_unblock();
 
 #endif /* SOCKET_H */


### PR DESCRIPTION
This fixes #1107 by adding an additional pipe to the read file descriptors to enable writing to it when the select is waiting for a read. This unblocks the select.

There might be more elegant ways and I am open for other ideas or a completely other approach, but for me this at least avoids the 1 second delay of MQTTAsync_destroy for me. I have also reduced the sleep time in MQTTAsync_stop to further reduce the delay to 20 ms, but I am also OK with using the old sleep time of 100 ms.

Also it does not work for Windows yet.