### PR TITLE
 Unable to connect to mqtt broker via WEB Socket protocol #1185

### DIFF
--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -452,29 +452,55 @@ int WebSocket_connect( networkHandles *net, const char *uri)
 		*headers_buf_cur = '\0';
 	}
 
+  bool is_default_port = port == WS_DEFAULT_PORT || port == 443;
+  
 	for ( i = 0; i < 2; ++i )
-	{
-		buf_len = snprintf( buf, (size_t)buf_len,
-			"GET %s HTTP/1.1\r\n"
-			"Host: %.*s:%d\r\n"
-			"Upgrade: websocket\r\n"
-			"Connection: Upgrade\r\n"
-			"Origin: %s://%.*s:%d\r\n"
-			"Sec-WebSocket-Key: %s\r\n"
-			"Sec-WebSocket-Version: 13\r\n"
-			"Sec-WebSocket-Protocol: mqtt\r\n"
-			"%s"
-			"\r\n", topic,
-			(int)hostname_len, uri, port,
+{
+    if (is_default_port) {
+      buf_len = snprintf(buf, (size_t) buf_len,
+              "GET %s HTTP/1.1\r\n"
+              "Host: %.*s\r\n"
+              "Upgrade: websocket\r\n"
+              "Connection: Upgrade\r\n"
+              "Origin: %s://%.*s:%d\r\n"
+              "Sec-WebSocket-Key: %s\r\n"
+              "Sec-WebSocket-Version: 13\r\n"
+              "Sec-WebSocket-Protocol: mqtt\r\n"
+              "%s"
+              "\r\n", topic,
+              (int) hostname_len, uri,
 #if defined(OPENSSL)
-			HTTP_PROTOCOL(net->ssl),
+              HTTP_PROTOCOL(net->ssl),
 #else
-			HTTP_PROTOCOL(0),
+              HTTP_PROTOCOL(0),
 #endif
-			
-			(int)hostname_len, uri, port,
-			net->websocket_key,
-			headers_buf ? headers_buf : "");
+
+              (int) hostname_len, uri, port,
+              net->websocket_key,
+              headers_buf ? headers_buf : "");
+    } else {
+      buf_len = snprintf(buf, (size_t) buf_len,
+              "GET %s HTTP/1.1\r\n"
+              "Host: %.*s:%d\r\n"
+              "Upgrade: websocket\r\n"
+              "Connection: Upgrade\r\n"
+              "Origin: %s://%.*s:%d\r\n"
+              "Sec-WebSocket-Key: %s\r\n"
+              "Sec-WebSocket-Version: 13\r\n"
+              "Sec-WebSocket-Protocol: mqtt\r\n"
+              "%s"
+              "\r\n", topic,
+              (int) hostname_len, uri, port,
+#if defined(OPENSSL)
+              HTTP_PROTOCOL(net->ssl),
+#else
+              HTTP_PROTOCOL(0),
+#endif
+
+              (int) hostname_len, uri, port,
+              net->websocket_key,
+              headers_buf ? headers_buf : "");
+    }
 
 		if ( i == 0 && buf_len > 0 )
 		{


### PR DESCRIPTION
We use a URI to connect to mqtt broker like this: wss://example.com/topic1?param1=value

When trying to connect, we get an error with the following log:
20211223 130825.077 getaddrinfo failed for addr example.com/topic1?param1=value
Here it is obvious that the library could not separate the topic name from the host name and, as a result, the host name was not resolved.

If we explicitly add a port to the URI (like this: wss://example.com:443/topic1?param1=value), the server name will be decoupled since the port allows you to explicitly decouple the host name.
But the connection to the server still fails. This happens because the library, when trying to establish a connection, sends the "Host" header with an explicit port indication (like this: "Host: example.com:443"). The server does not accept this request because it does not expect a port number in this header.

We found a workaround for establishing connections. For the case when the default port is used, there is no need to specify the port in the "Host" header (like this: "Host: example.com"). But for this, unfortunately, we need to edit the source code of WebSocket.c.

See issue #1185
