### PR TITLE
Fix lock on ssl during MQTTProtocol_connect

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -1308,6 +1308,7 @@ static int MQTTAsync_processCommand(void)
 			else
 				command->command.details.conn.MQTTVersion = command->client->c->MQTTVersion;
 
+			MQTTAsync_unlock_mutex(mqttasync_mutex);
 			Log(TRACE_PROTOCOL, -1, "Connecting to serverURI %s with MQTT version %d", serverURI, command->command.details.conn.MQTTVersion);
 #if defined(OPENSSL)
 #if defined(__GNUC__) && defined(__linux__)
@@ -1326,6 +1327,7 @@ static int MQTTAsync_processCommand(void)
 					command->command.details.conn.MQTTVersion, command->client->connectProps, command->client->willProps);
 #endif
 #endif
+			MQTTAsync_lock_mutex(mqttasync_mutex);
 
 			if (command->client->c->connect_state == NOT_IN_PROGRESS)
 				rc = SOCKET_ERROR;

--- a/test/test4.c
+++ b/test/test4.c
@@ -1290,7 +1290,7 @@ int test7(struct Options options)
 
 	opts.will = &wopts;
 	opts.will->message = "will message";
-	opts.will->qos = 1;
+	opts.will->qos = subsqos;
 	opts.will->retained = 0;
 	opts.will->topicName = "will topic";
 	opts.will = NULL;
@@ -1333,7 +1333,7 @@ int test7(struct Options options)
 
 	pubmsg.payload = "a much longer message that we can shorten to the extent that we need to payload up to 11";
 	pubmsg.payloadlen = 11;
-	pubmsg.qos = 2;
+	pubmsg.qos = subsqos;
 	pubmsg.retained = 0;
 	rc = MQTTAsync_send(c, test_topic, pubmsg.payloadlen, pubmsg.payload, pubmsg.qos, pubmsg.retained, &ropts);
 	MyLog(LOGA_DEBUG, "Token was %d", ropts.token);
@@ -1346,7 +1346,7 @@ int test7(struct Options options)
 
 	test7_messageCount = 0;
 	int i = 0;
-	pubmsg.qos = 2;
+	pubmsg.qos = subsqos;
 	for (i = 0; i < msg_count; ++i)
 	{
 		pubmsg.payload = "a much longer message that we can shorten to the extent that we need to payload up to 11";


### PR DESCRIPTION
Problem : 
On MAQTTAsync with bad connectivity, MQTTProtocol_connect is blocking in SSL due to getaddrinfo.
The problem is with the mutex "mqttasync_mutex" it block all.

How to reproduce
On Linux to reproduce the bug I had to put a usleep(5000000L); on src/MQTTAsyncUtils.c
Then launch the test/test4 no--7 by adding some log.
You will see during 5 seconds mqtt is blocked.
If you do the same test with the fix mqtt is not blocked. 

Fix
Commit "Fix lock on ssl during MQTTProtocol_connect"


