### PR TITLE
Update MQTTAsync.c

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -791,7 +791,8 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 		}
 		if (m->c->sslopts->struct_version >= 5)
 		{
-			m->c->sslopts->protos = MQTTStrdup(options->ssl->protos);
+			if (options->ssl->protos)
+				m->c->sslopts->protos = MQTTStrdup(options->ssl->protos);
 			m->c->sslopts->protos_len = options->ssl->protos_len;
 		}
 	}

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -791,7 +791,7 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 		}
 		if (m->c->sslopts->struct_version >= 5)
 		{
-			m->c->sslopts->protos = options->ssl->protos;
+			m->c->sslopts->protos = MQTTStrdup(options->ssl->protos);
 			m->c->sslopts->protos_len = options->ssl->protos_len;
 		}
 	}


### PR DESCRIPTION
Fix for protos string becoming invalidated due to owner going out of scope.

Added MQTTStrdup() call to duplicate the protos string (as other strings are in the struct).