### PR TITLE
    Fix array out of bound issue when receive invalid suback packet.

### DIFF
--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -2079,6 +2079,11 @@ MQTTResponse MQTTClient_subscribeMany5(MQTTClient handle, int count, char* const
 			}
 			else
 			{
+				if (count < sub->qoss->count)
+				{
+					rc = MQTTCLIENT_FAILURE;
+					goto exit;
+				}
 				ListElement* current = NULL;
 				i = 0;
 				while (ListNextElement(sub->qoss, &current))


### PR DESCRIPTION
    WHAT: when call MQTTClient_subscribe interface to subscribe topics,
    the SUBSCRIBE packet would be sent to broker, the according SUBACK
    packet would be returned, if the SUBACK packet returncodes amount
    is not consist with the SUBSCRIBE packet topic amount, the array
    out of bound issue could hanppend.

    WHY: In MQTTClient_subscribeMany5 function, after internal
    MQTTClient_waitfor function called, the SUBACK packet is received,
    traverse the qoss list to get the qos, the qos info would be stored
    in the current function param array "qos", but the array bound is
    not check when accessing, therefore, the out-of-bound issue would
    taken place.

    How: check the size of array "qos" to avoid out-of-bound issue

    Reviewed by: caojianlong <caojianlong@huawei.com>

    Test by: shilei <shilei10@huawei.com>

Signed-off-by: chenzhenhua5 <chenzhenhua5@huawei.com>
