### PR TITLE
Added URI protocol prefixes, 'mqtt://' and 'mqtts://'

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -328,9 +328,11 @@ int MQTTAsync_createWithOptions(MQTTAsync* handle, const char* serverURI, const 
 	if (strstr(serverURI, "://") != NULL)
 	{
 		if (strncmp(URI_TCP, serverURI, strlen(URI_TCP)) != 0
+		 && strncmp(URI_MQTT, serverURI, strlen(URI_MQTT)) != 0
 		 && strncmp(URI_WS, serverURI, strlen(URI_WS)) != 0
 #if defined(OPENSSL)
-            && strncmp(URI_SSL, serverURI, strlen(URI_SSL)) != 0
+		 && strncmp(URI_SSL, serverURI, strlen(URI_SSL)) != 0
+		 && strncmp(URI_MQTTS, serverURI, strlen(URI_MQTTS)) != 0
 		 && strncmp(URI_WSS, serverURI, strlen(URI_WSS)) != 0
 #endif
 			)
@@ -380,6 +382,8 @@ int MQTTAsync_createWithOptions(MQTTAsync* handle, const char* serverURI, const 
 	memset(m, '\0', sizeof(MQTTAsyncs));
 	if (strncmp(URI_TCP, serverURI, strlen(URI_TCP)) == 0)
 		serverURI += strlen(URI_TCP);
+	else if (strncmp(URI_MQTT, serverURI, strlen(URI_MQTT)) == 0)
+		serverURI += strlen(URI_MQTT);
 	else if (strncmp(URI_WS, serverURI, strlen(URI_WS)) == 0)
 	{
 		serverURI += strlen(URI_WS);
@@ -389,6 +393,11 @@ int MQTTAsync_createWithOptions(MQTTAsync* handle, const char* serverURI, const 
 	else if (strncmp(URI_SSL, serverURI, strlen(URI_SSL)) == 0)
 	{
 		serverURI += strlen(URI_SSL);
+		m->ssl = 1;
+	}
+	else if (strncmp(URI_MQTTS, serverURI, strlen(URI_MQTTS)) == 0)
+	{
+		serverURI += strlen(URI_MQTTS);
 		m->ssl = 1;
 	}
 	else if (strncmp(URI_WSS, serverURI, strlen(URI_WSS)) == 0)

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -170,9 +170,14 @@
  */
 #define MQTTASYNC_SSL_NOT_SUPPORTED -13
 /**
- * Return code: protocol prefix in serverURI should be tcp://, ssl://, ws:// or wss://
- * The TLS enabled prefixes (ssl, wss) are only valid if the TLS version of the library
- * is linked with.
+ * Return code: protocol prefix in serverURI should be:
+ * @li @em tcp:// or @em mqtt:// - Insecure TCP
+ * @li @em ssl:// or @em mqtts:// - Encrypted SSL/TLS
+ * @li @em ws:// - Insecure websockets
+ * @li @em wss:// - Secure web sockets
+ *
+ * The TLS enabled prefixes (ssl, mqtts, wss) are only valid if the TLS
+ * version of the library is linked with.
  */
 #define MQTTASYNC_BAD_PROTOCOL -14
 /**
@@ -903,14 +908,22 @@ LIBMQTT_API int MQTTAsync_reconnect(MQTTAsync handle);
  * populated with a valid client reference following a successful return from
  * this function.
  * @param serverURI A null-terminated string specifying the server to
- * which the client will connect. It takes the form <i>protocol://host:port</i>.
- * <i>protocol</i> must be <i>tcp</i>, <i>ssl</i>, <i>ws</i> or <i>wss</i>.
- * The TLS enabled prefixes (ssl, wss) are only valid if a TLS version of
- * the library is linked with.
- * For <i>host</i>, you can
- * specify either an IP address or a host name. For instance, to connect to
- * a server running on the local machines with the default MQTT port, specify
- * <i>tcp://localhost:1883</i>.
+ * which the client will connect. It takes the form
+ * <i>protocol://host:port</i> where <i>protocol</i> must be:
+ * <br>
+ * @em tcp:// or @em mqtt:// - Insecure TCP
+ * <br>
+ * @em ssl:// or @em mqtts:// - Encrypted SSL/TLS
+ * <br>
+ * @em ws:// - Insecure websockets
+ * <br>
+ * @em wss:// - Secure web sockets
+ * <br>
+ * The TLS enabled prefixes (ssl, mqtts, wss) are only valid if a TLS
+ * version of the library is linked with.
+ * For <i>host</i>, you can specify either an IP address or a host name. For
+ * instance, to connect to a server running on the local machines with the
+ * default MQTT port, specify <i>tcp://localhost:1883</i>.
  * @param clientId The client identifier passed to the server when the
  * client connects to it. It is a null-terminated UTF-8 encoded string.
  * @param persistence_type The type of persistence to be used by the client:

--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -1290,6 +1290,8 @@ static int MQTTAsync_processCommand(void)
 
 					if (strncmp(URI_TCP, serverURI, strlen(URI_TCP)) == 0)
 						serverURI += strlen(URI_TCP);
+					else if (strncmp(URI_MQTT, serverURI, strlen(URI_MQTT)) == 0)
+						serverURI += strlen(URI_MQTT);
 					else if (strncmp(URI_WS, serverURI, strlen(URI_WS)) == 0)
 					{
 						serverURI += strlen(URI_WS);
@@ -1299,6 +1301,11 @@ static int MQTTAsync_processCommand(void)
 					else if (strncmp(URI_SSL, serverURI, strlen(URI_SSL)) == 0)
 					{
 						serverURI += strlen(URI_SSL);
+						command->client->ssl = 1;
+					}
+					else if (strncmp(URI_MQTTS, serverURI, strlen(URI_MQTTS)) == 0)
+					{
+						serverURI += strlen(URI_MQTTS);
 						command->client->ssl = 1;
 					}
 					else if (strncmp(URI_WSS, serverURI, strlen(URI_WSS)) == 0)
@@ -2731,6 +2738,8 @@ static int MQTTAsync_connecting(MQTTAsyncs* m)
 		/* skip URI scheme */
 		if (strncmp(URI_TCP, serverURI, strlen(URI_TCP)) == 0)
 			serverURI += strlen(URI_TCP);
+		else if (strncmp(URI_MQTT, serverURI, strlen(URI_MQTT)) == 0)
+			serverURI += strlen(URI_MQTT);
 		else if (strncmp(URI_WS, serverURI, strlen(URI_WS)) == 0)
 		{
 			serverURI += strlen(URI_WS);
@@ -2742,6 +2751,11 @@ static int MQTTAsync_connecting(MQTTAsyncs* m)
 		else if (strncmp(URI_SSL, serverURI, strlen(URI_SSL)) == 0)
 		{
 			serverURI += strlen(URI_SSL);
+			default_port = SECURE_MQTT_DEFAULT_PORT;
+		}
+		else if (strncmp(URI_MQTTS, serverURI, strlen(URI_MQTTS)) == 0)
+		{
+			serverURI += strlen(URI_MQTTS);
 			default_port = SECURE_MQTT_DEFAULT_PORT;
 		}
 		else if (strncmp(URI_WSS, serverURI, strlen(URI_WSS)) == 0)

--- a/src/MQTTAsyncUtils.h
+++ b/src/MQTTAsyncUtils.h
@@ -20,9 +20,10 @@
 #include "MQTTPacket.h"
 #include "Thread.h"
 
-#define URI_TCP "tcp://"
-#define URI_WS  "ws://"
-#define URI_WSS "wss://"
+#define URI_TCP  "tcp://"
+#define URI_MQTT "mqtt://"
+#define URI_WS   "ws://"
+#define URI_WSS  "wss://"
 
 enum MQTTAsync_threadStates
 {

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -70,14 +70,16 @@
 #if defined(OPENSSL)
 #include <openssl/ssl.h>
 #else
-#define URI_SSL "ssl://"
+#define URI_SSL   "ssl://"
+#define URI_MQTTS "mqtts://"
 #endif
 
 #include "OsWrapper.h"
 
-#define URI_TCP "tcp://"
-#define URI_WS "ws://"
-#define URI_WSS "wss://"
+#define URI_TCP  "tcp://"
+#define URI_MQTT "mqtt://"
+#define URI_WS   "ws://"
+#define URI_WSS  "wss://"
 
 #include "VersionInfo.h"
 #include "WebSocket.h"
@@ -403,9 +405,11 @@ int MQTTClient_createWithOptions(MQTTClient* handle, const char* serverURI, cons
 	if (strstr(serverURI, "://") != NULL)
 	{
 		if (strncmp(URI_TCP, serverURI, strlen(URI_TCP)) != 0
+		 && strncmp(URI_MQTT, serverURI, strlen(URI_MQTT)) != 0
 		 && strncmp(URI_WS, serverURI, strlen(URI_WS)) != 0
 #if defined(OPENSSL)
-            && strncmp(URI_SSL, serverURI, strlen(URI_SSL)) != 0
+         && strncmp(URI_SSL, serverURI, strlen(URI_SSL)) != 0
+         && strncmp(URI_MQTTS, serverURI, strlen(URI_MQTTS)) != 0
 		 && strncmp(URI_WSS, serverURI, strlen(URI_WSS)) != 0
 #endif
 			)
@@ -448,6 +452,8 @@ int MQTTClient_createWithOptions(MQTTClient* handle, const char* serverURI, cons
 	m->commandTimeout = 10000L;
 	if (strncmp(URI_TCP, serverURI, strlen(URI_TCP)) == 0)
 		serverURI += strlen(URI_TCP);
+	else if (strncmp(URI_MQTT, serverURI, strlen(URI_MQTT)) == 0)
+		serverURI += strlen(URI_MQTT);
 	else if (strncmp(URI_WS, serverURI, strlen(URI_WS)) == 0)
 	{
 		serverURI += strlen(URI_WS);
@@ -457,6 +463,16 @@ int MQTTClient_createWithOptions(MQTTClient* handle, const char* serverURI, cons
 	{
 #if defined(OPENSSL)
 		serverURI += strlen(URI_SSL);
+		m->ssl = 1;
+#else
+		rc = MQTTCLIENT_SSL_NOT_SUPPORTED;
+		goto exit;
+#endif
+	}
+	else if (strncmp(URI_MQTTS, serverURI, strlen(URI_MQTTS)) == 0)
+	{
+#if defined(OPENSSL)
+		serverURI += strlen(URI_MQTTS);
 		m->ssl = 1;
 #else
 		rc = MQTTCLIENT_SSL_NOT_SUPPORTED;
@@ -1829,6 +1845,8 @@ MQTTResponse MQTTClient_connectAll(MQTTClient handle, MQTTClient_connectOptions*
 
 			if (strncmp(URI_TCP, serverURI, strlen(URI_TCP)) == 0)
 				serverURI += strlen(URI_TCP);
+			else if (strncmp(URI_MQTT, serverURI, strlen(URI_MQTT)) == 0)
+				serverURI += strlen(URI_TCP);
 			else if (strncmp(URI_WS, serverURI, strlen(URI_WS)) == 0)
 			{
 				serverURI += strlen(URI_WS);
@@ -1838,6 +1856,11 @@ MQTTResponse MQTTClient_connectAll(MQTTClient handle, MQTTClient_connectOptions*
 			else if (strncmp(URI_SSL, serverURI, strlen(URI_SSL)) == 0)
 			{
 				serverURI += strlen(URI_SSL);
+				m->ssl = 1;
+			}
+			else if (strncmp(URI_MQTTS, serverURI, strlen(URI_MQTTS)) == 0)
+			{
+				serverURI += strlen(URI_MQTTS);
 				m->ssl = 1;
 			}
 			else if (strncmp(URI_WSS, serverURI, strlen(URI_WSS)) == 0)

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -179,9 +179,13 @@
   */
  #define MQTTCLIENT_BAD_MQTT_VERSION -11
 /**
- * Return code: protocol prefix in serverURI should be tcp://, ssl://, ws:// or wss://
- * The TLS enabled prefixes (ssl, wss) are only valid if a TLS version of the library
- * is linked with.
+ * Return code: protocol prefix in serverURI should be:
+ * @li @em tcp:// or @em mqtt:// - Insecure TCP
+ * @li @em ssl:// or @em mqtts:// - Encrypted SSL/TLS
+ * @li @em ws:// - Insecure websockets
+ * @li @em wss:// - Secure web sockets
+ * The TLS enabled prefixes (ssl, mqtts, wss) are only valid if a TLS
+ * version of the library is linked with.
  */
 #define MQTTCLIENT_BAD_PROTOCOL -14
  /**
@@ -494,13 +498,21 @@ LIBMQTT_API int MQTTClient_setPublished(MQTTClient handle, void* context, MQTTCl
  * this function.
  * @param serverURI A null-terminated string specifying the server to
  * which the client will connect. It takes the form <i>protocol://host:port</i>.
- * Currently, <i>protocol</i> must be <i>tcp</i>, <i>ssl</i>, <i>ws</i> or <i>wss</i>.
- * The TLS enabled prefixes (ssl, wss) are only valid if a TLS version of the library
- * is linked with.
- * For <i>host</i>, you can
- * specify either an IP address or a host name. For instance, to connect to
- * a server running on the local machines with the default MQTT port, specify
- * <i>tcp://localhost:1883</i>.
+ * Currently, <i>protocol</i> must be:
+ * <br>
+ * @em tcp:// or @em mqtt:// - Insecure TCP
+ * <br>
+ * @em ssl:// or @em mqtts:// - Encrypted SSL/TLS
+ * <br>
+ * @em ws:// - Insecure websockets
+ * <br>
+ * @em wss:// - Secure web sockets
+ * <br>
+ * The TLS enabled prefixes (ssl, mqtts, wss) are only valid if a TLS
+ * version of the library is linked with.
+ * For <i>host</i>, you can specify either an IP address or a host name. For
+ * instance, to connect to a server running on the local machines with the
+ * default MQTT port, specify <i>tcp://localhost:1883</i>.
  * @param clientId The client identifier passed to the server when the
  * client connects to it. It is a null-terminated UTF-8 encoded string.
  * @param persistence_type The type of persistence to be used by the client:

--- a/src/SSLSocket.h
+++ b/src/SSLSocket.h
@@ -30,7 +30,8 @@
 #include "SocketBuffer.h"
 #include "Clients.h"
 
-#define URI_SSL "ssl://"
+#define URI_SSL   "ssl://"
+#define URI_MQTTS "mqtts://"
 
 /** if we should handle openssl initialization (bool_value == 1) or depend on it to be initalized externally (bool_value == 0) */
 void SSLSocket_handleOpensslInit(int bool_value);

--- a/src/samples/MQTTAsync_publish_time.c
+++ b/src/samples/MQTTAsync_publish_time.c
@@ -44,7 +44,7 @@
 
 
 // Better not to flood a public broker. Test against localhost.
-#define ADDRESS         "tcp://localhost:1883"
+#define ADDRESS         "mqtt://localhost:1883"
 
 #define CLIENTID        "ExampleClientTimePub"
 #define TOPIC           "data/time"

--- a/test/test3.c
+++ b/test/test3.c
@@ -89,11 +89,11 @@ struct Options
 } options =
 {
 	"ssl://localhost:18883",
-	"ssl://localhost:18884",
+	"mqtts://localhost:18884",
 	"ssl://localhost:18887",
-	"ssl://localhost:18885",
+	"mqtts://localhost:18885",
 	"ssl://localhost:18886",
-	"ssl://localhost:18888",
+	"mqtts://localhost:18888",
 	NULL,
 	0,
 	"../../../test/ssl/client.pem",

--- a/test/test5.c
+++ b/test/test5.c
@@ -74,11 +74,11 @@ struct Options
 } options =
 {
 	"ssl://localhost:18883",
-	"ssl://localhost:18884",
+	"mqtts://localhost:18884",
 	"ssl://localhost:18887",
-	"ssl://localhost:18885",
+	"mqtts://localhost:18885",
 	"ssl://localhost:18886",
-	"ssl://localhost:18888",
+	"mqtts://localhost:18888",
 	NULL, // "../../../test/ssl/client.pem",
 	NULL,
 	NULL, // "../../../test/ssl/test-root-ca.crt",

--- a/test/test8.c
+++ b/test/test8.c
@@ -920,7 +920,7 @@ int test5a(struct Options options)
 	MQTTAsync_connectOptions opts = MQTTAsync_connectOptions_initializer;
 	int rc = 0;
 	char* test_topic = "C client test5a";
-	char* serverURIs[3] = {"tcp://localhost:1880", "tcp://localhost:1881", "tcp://localhost:1882"};
+	char* serverURIs[3] = {"tcp://localhost:1880", "mqtt://localhost:1881", "tcp://localhost:1882"};
 
 	failures = 0;
 	MyLog(LOGA_INFO, "Starting test 5a - All HA connections out of service");
@@ -982,7 +982,7 @@ int test5b(struct Options options)
 	MQTTAsync_connectOptions opts = MQTTAsync_connectOptions_initializer;
 	int rc = 0;
 	char* test_topic = "C client test5b";
-	char* serverURIs[3] = {"tcp://localhost:1880", "tcp://localhost:1881", options.connection};
+	char* serverURIs[3] = {"tcp://localhost:1880", "mqtt://localhost:1881", options.connection};
 
 	failures = 0;
 	MyLog(LOGA_INFO, "Starting test 5b - All HA connections out of service except the last one");


### PR DESCRIPTION
A number of other libraries and tools use the `mqtt://` and `mqtts://` schemes for MQTT URI's, which makes it difficult to mix in applications using Paho C/C++/Rust, since you need to know which tools were written with which libraries to create a URI.

The `mqtt://` and `mqtts://` schemes also appears on the MQTT.org wiki: 
https://github.com/mqtt/mqtt.org/wiki/URI-Scheme

This PR **adds** these two schemes without changing existing behavior:
```
    mqtt://   <==>  tcp://
    mqtts://  <==>  ssl://
```

This PR does _not_, however:
- Address the web sockets, which could probably do something similar to CoAP, like `mqtt+ws://`, etc
- Implement username and password in the URI, which would be a nice addition.