### PR TITLE
checkEyecatchers() used to crash if a heap problem was detected

### DIFF
--- a/src/Heap.c
+++ b/src/Heap.c
@@ -39,6 +39,7 @@ char* Broker_recordFFDC(char* symptoms);
 #include <string.h>
 #include <stdio.h>
 #include <stddef.h>
+#include <inttypes.h>
 
 #include "Heap.h"
 
@@ -57,8 +58,9 @@ static mutex_type heap_mutex = &heap_mutex_store;
 
 static heap_info state = {0, 0}; /**< global heap state information */
 
-typedef double eyecatcherType;
+typedef uint64_t eyecatcherType;
 static eyecatcherType eyecatcher = (eyecatcherType)0x8888888888888888;
+#define PRIeyecatcher PRIx64  /**< print eyecatcher in HEX notation */
 
 /*#define HEAP_STACK 1 */
 
@@ -224,7 +226,7 @@ static void checkEyecatchers(char* file, int line, void* p, size_t size)
 	eyecatcherType *sp = (eyecatcherType*)p;
 	char *cp = (char*)p;
 	eyecatcherType us;
-	static const char *msg = "Invalid %s eyecatcher %d in heap item at file %s line %d";
+	static const char *msg = "Invalid %s eyecatcher %" PRIeyecatcher " in heap item at file %s line %d";
 
 	if ((us = *--sp) != eyecatcher)
 		Log(LOG_ERROR, 13, msg, "start", us, file, line);


### PR DESCRIPTION
checkEyecatchers() used vsnprintf() with a format specifier "%d" to print the wrong eyecatcher content, but an eyecatcher was defined as 'double'. Since "%d" expects an 'int' on the stack (which is usually 32 bit in size) but gets a 'double' instead (which is usually 64 bit), the following 'file' argument will be retrieved as wrong pointer value from stack, resulting in a crash in Log() -> vsnprintf() -> strlen().

This was fixed by defining 'eyecatcher' as 'uint64_t' (instead of 'double') and printing an eyecatcher using 'PRIx64' (instead of "d").

Signed-off-by: Axel Sommerfeldt <axel.sommerfeldt@fastmail.de>


Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


