### PR TITLE
Lock socket_mutex on Socket_new()/Socket_close()

### DIFF
--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1234,6 +1234,7 @@ static MQTTResponse MQTTClient_connectURIVersion(MQTTClient handle, MQTTClient_c
 	}
 
 	Log(TRACE_MIN, -1, "Connecting to serverURI %s with MQTT version %d", serverURI, MQTTVersion);
+	Thread_lock_mutex(socket_mutex);
 #if defined(OPENSSL)
 #if defined(__GNUC__) && defined(__linux__)
 	rc = MQTTProtocol_connect(serverURI, m->c, m->ssl, m->websocket, MQTTVersion, connectProperties, willProperties,
@@ -1249,6 +1250,7 @@ static MQTTResponse MQTTClient_connectURIVersion(MQTTClient handle, MQTTClient_c
 	rc = MQTTProtocol_connect(serverURI, m->c, m->websocket, MQTTVersion, connectProperties, willProperties);
 #endif
 #endif
+	Thread_unlock_mutex(socket_mutex);
 	if (rc == SOCKET_ERROR)
 		goto exit;
 


### PR DESCRIPTION
I finally got approval to provide this fix for #1219. 🥳 
I see you already fixed the eyecatcher part by yourself, this adds the necessary locking to avoid corruption of `mod_s.saved.fds`.