### PR TITLE
Fix read/write race between in MQTTClient

### DIFF
--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -2875,15 +2875,14 @@ int MQTTClient_waitForCompletion(MQTTClient handle, MQTTClient_deliveryToken mdt
 	FUNC_ENTRY;
 	Thread_lock_mutex(mqttclient_mutex);
 
-	if (m == NULL || m->c == NULL)
-	{
-		rc = MQTTCLIENT_FAILURE;
-		goto exit;
-	}
-
 	elapsed = MQTTTime_elapsed(start);
 	while (elapsed < timeout)
 	{
+		if (m == NULL || m->c == NULL)
+		{
+			rc = MQTTCLIENT_FAILURE;
+			goto exit;
+		}
 		if (m->c->connected == 0)
 		{
 			rc = MQTTCLIENT_DISCONNECTED;


### PR DESCRIPTION
Valgrind reported this error to me recently:

==258178== Invalid read of size 8
==258178==    at 0x3579AB: MQTTClient_waitForCompletion (in /home/nhorman/git/privafy/test/microedge-c/test)
==258178==    by 0x1724BF: publish_msg (comms_connect.c:625)
==258178==    by 0x16F55A: _send_message (comms_register.c:294)
==258178==    by 0x16F605: send_message_sync (comms_register.c:311)
==258178==    by 0x178AEA: send_obj_write_resp_mqtt_message (day0_mqtt_state.c:49)
==258178==    by 0x178FE5: day0_obj_write_req_mqtt_handler (day0_mqtt_state.c:170)
==258178==    by 0x1777A5: service_state_machine_run (service_state_machine_handler.c:670)
==258178==    by 0x49EE12C: start_thread (pthread_create.c:442)
==258178==    by 0x4A6ED73: clone (clone.S:100)
==258178==  Address 0x5075e38 is 24 bytes inside a block of size 152 free'd
==258178==    at 0x48460E4: free (vg_replace_malloc.c:884)
==258178==    by 0x3673FD: ListUnlink (in /home/nhorman/git/privafy/test/microedge-c/test)
==258178==    by 0x3674C0: ListRemove (in /home/nhorman/git/privafy/test/microedge-c/test)
==258178==    by 0x35206D: MQTTClient_destroy (in /home/nhorman/git/privafy/test/microedge-c/test)
==258178==    by 0x171BBD: comms_run (comms_connect.c:445)
==258178==    by 0x49EE12C: start_thread (pthread_create.c:442)
==258178==    by 0x4A6ED73: clone (clone.S:100)
==258178==  Block was alloc'd at
==258178==    at 0x484386F: malloc (vg_replace_malloc.c:393)
==258178==    by 0x351A96: MQTTClient_createWithOptions (in /home/nhorman/git/privafy/test/microedge-c/test)
==258178==    by 0x171987: comms_run (comms_connect.c:409)
==258178==    by 0x49EE12C: start_thread (pthread_create.c:442)
==258178==    by 0x4A6ED73: clone (clone.S:100)

Its occuring because, in MQTTClient_waitForCompletion, the mqttclient_mutex is repeatedly dropped and re-aquired.  While thats fine to do, it creates the possibility for another thread to run between the time MQTClient_waitForCompletion calls MQTTClient_yield and the time it reaquires the lock.  Valgrind notes that during that period, if another thread calls MQTTCilent_destroy, the value of m->c in MQTTClient_waitForCompletion will change, triggering the above invalid read warning.

Fix is pretty easy, just move the if (m == NULL || m->c == NULL) conditional to inside the while loop, so that the value of m->c is revalidated after each lock re-aquisition.

Signed-off-by: Neil Horman <nhorman@gmail.com>


Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


