### PR TITLE
Implement MQTTv5 Enhanced Authentication

### DIFF
--- a/src/Clients.h
+++ b/src/Clients.h
@@ -153,6 +153,7 @@ typedef struct
 	int sessionExpiry;              /**< MQTT 5 session expiry */
 	char* httpProxy;                /**< HTTP proxy */
 	char* httpsProxy;               /**< HTTPS proxy */
+	char* authMethod;               /**< MQTT 5 enhanced authentication method */
 #if defined(OPENSSL)
 	MQTTClient_SSLOptions *sslopts; /**< the SSL/TLS connect options */
 	SSL_SESSION* session;           /**< SSL session pointer for fast handhake */

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -562,7 +562,7 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 		goto exit;
 	}
 
-	if (strncmp(options->struct_id, "MQTC", 4) != 0 || options->struct_version < 0 || options->struct_version > 8)
+	if (strncmp(options->struct_id, "MQTC", 4) != 0 || options->struct_version < 0 || options->struct_version > 9)
 	{
 		rc = MQTTASYNC_BAD_STRUCTURE;
 		goto exit;
@@ -692,6 +692,11 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 			m->c->httpProxy = MQTTStrdup(options->httpProxy);
 		if (options->httpsProxy)
 			m->c->httpsProxy = MQTTStrdup(options->httpsProxy);
+	}
+	if (options->MQTTVersion >= MQTTVERSION_5 && options->struct_version >= 9)
+	{
+		if (options->authMethod)
+			m->c->authMethod = MQTTStrdup(options->authMethod);
 	}
 
 	if (m->c->will)
@@ -893,7 +898,6 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 			if (MQTTProperties_hasProperty(options->connectProperties, MQTTPROPERTY_CODE_SESSION_EXPIRY_INTERVAL))
 				m->c->sessionExpiry = MQTTProperties_getNumericValue(options->connectProperties,
 						MQTTPROPERTY_CODE_SESSION_EXPIRY_INTERVAL);
-
 		}
 		if (options->willProperties)
 		{
@@ -908,6 +912,50 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 			*m->willProps = MQTTProperties_copy(options->willProperties);
 		}
 		m->c->cleanstart = options->cleanstart;
+	}
+	if (options->struct_version >= 9)
+	{
+		if (m->c->authMethod)
+		{
+			MQTTAsync_authHandleData authData = MQTTAsync_authHandleData_initializer;
+			MQTTProperty property;
+			int authrc = 0;
+
+			if (!m->connectProps)
+			{
+				MQTTProperties initialized = MQTTProperties_initializer;
+
+				if ((m->connectProps = malloc(sizeof(MQTTProperties))) == NULL)
+				{
+					rc = PAHO_MEMORY_ERROR;
+					goto exit;
+				}
+
+				*m->connectProps = initialized;
+			}
+
+			property.identifier = MQTTPROPERTY_CODE_AUTHENTICATION_METHOD;
+			property.value.data.data = m->c->authMethod;
+			property.value.data.len = (int)strlen(m->c->authMethod);
+			rc = MQTTProperties_add(m->connectProps, &property);
+			if (rc)
+				goto exit;
+
+			if (m->auth_handle)
+			{
+				authrc = (*(m->auth_handle))(m->auth_handle_context, &authData);
+				if (authrc < 0)
+					goto exit;
+			}
+
+			property.identifier = MQTTPROPERTY_CODE_AUTHENTICATION_DATA;
+			property.value.data.data = authData.authDataOut.data;
+			property.value.data.len = authData.authDataOut.len;
+			rc = MQTTProperties_add(m->connectProps, &property);
+			free(authData.authDataOut.data);
+			if (rc)
+				goto exit;
+		}
 	}
 
 	/* Add connect request to operation queue */
@@ -1703,6 +1751,29 @@ int MQTTAsync_setAfterPersistenceRead(MQTTAsync handle, void* context, MQTTPersi
 	{
 		m->c->afterRead = co;
 		m->c->afterRead_context = context;
+	}
+
+	MQTTAsync_unlock_mutex(mqttasync_mutex);
+	FUNC_EXIT_RC(rc);
+	return rc;
+}
+
+
+int MQTTAsync_setHandleAuth(MQTTAsync handle, void *context,
+		MQTTAsync_authHandle *authenticate)
+{
+	int rc = MQTTASYNC_SUCCESS;
+	MQTTAsyncs *m = handle;
+
+	FUNC_ENTRY;
+	MQTTAsync_lock_mutex(mqttasync_mutex);
+
+	if (m == NULL || m->c->connect_state != NOT_IN_PROGRESS)
+		rc = MQTTASYNC_FAILURE;
+	else
+	{
+		m->auth_handle_context = context;
+		m->auth_handle = authenticate;
 	}
 
 	MQTTAsync_unlock_mutex(mqttasync_mutex);

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -952,7 +952,8 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 			property.value.data.data = authData.authDataOut.data;
 			property.value.data.len = authData.authDataOut.len;
 			rc = MQTTProperties_add(m->connectProps, &property);
-			free(authData.authDataOut.data);
+			if(authData.authDataOut.data)
+				free(authData.authDataOut.data);
 			if (rc)
 				goto exit;
 		}

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -565,7 +565,8 @@ typedef struct
  * This is a callback function which will allow the client application to update the
  * connection data.
  * @param data The connection data which can be modified by the application.
- * @return Return a zero or positive value to indicate sucess, a negative value on failure.
+ * @return a negative value to indicate not-authorized, a value of 0 to indicate success,
+ * a positive value to indicate continue.
  */
 typedef int MQTTAsync_authHandle(void* context, MQTTAsync_authHandleData* data);
 

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -530,6 +530,56 @@ LIBMQTT_API int MQTTAsync_setBeforePersistenceWrite(MQTTAsync handle, void* cont
  */
 LIBMQTT_API int MQTTAsync_setAfterPersistenceRead(MQTTAsync handle, void* context, MQTTPersistence_afterRead* co);
 
+/** The authentication data that is populated when MQTTv5 enhanced authentication
+ * is requested by an operation. */
+typedef struct
+{
+	/** The eyecatcher for this structure.  Will be MQAD. */
+	char struct_id[4];
+	/** The version number of this structure.  Will be 0 */
+	int struct_version;
+	/** The MQTT reason code received from the AUTH packet. */
+	enum MQTTReasonCodes reasonCode;
+	/**
+	 * The data received from the MQTTv5 AUTH packet AUTHENTICATION_DATA property.
+	 * Data is NULL if no AUTHENTICATION_DATA was received.
+	 */
+	struct {
+		int len;           /**< binary input AUTHENTICATION_DATA length */
+		const void* data;  /**< binary input AUTHENTICATION_DATA data */
+	} authDataIn;
+	/**
+	 * The data to populate the MQTTv5 AUTH packet AUTHENTICATION_DATA property.
+	 * Set data to NULL to remove.  To change, allocate new
+	 * storage with ::MQTTAsync_malloc - this will then be freed later by the library.
+	 */
+	struct {
+		int len;           /**< binary output AUTHENTICATION_DATA length */
+		void* data;        /**< binary output AUTHENTICATION_DATA data */
+	} authDataOut;
+} MQTTAsync_authHandleData;
+
+#define MQTTAsync_authHandleData_initializer {{'M', 'Q', 'A', 'D'}, 0, 0, {0, NULL}, {0, NULL}}
+
+/**
+ * This is a callback function which will allow the client application to update the
+ * connection data.
+ * @param data The connection data which can be modified by the application.
+ * @return Return a zero or positive value to indicate sucess, a negative value on failure.
+ */
+typedef int MQTTAsync_authHandle(void* context, MQTTAsync_authHandleData* data);
+
+/**
+ * Sets the MQTTAsync_authenticate() callback function for a client.
+ * @param handle A valid client handle from a successful call to MQTTAsync_create().
+ * @param context A pointer to any application-specific context. The
+ * the <i>context</i> pointer is passed to the callback function to
+ * provide access to the context information in the callback.
+ * @param co A pointer to an MQTTAsync_authHandle() callback
+ * function.  NULL removes the callback setting.
+ */
+LIBMQTT_API int MQTTAsync_setHandleAuth(MQTTAsync handle, void* context, MQTTAsync_authHandle* authenticate);
+
 
 /** The data returned on completion of an unsuccessful API call in the response callback onFailure. */
 typedef struct
@@ -1208,6 +1258,7 @@ typedef struct
       * 5 signifies no MQTTV5 properties
       * 6 signifies no HTTP headers option
       * 7 signifies no HTTP proxy and HTTPS proxy options
+      * 8 signifies no MQTTV5 enhanced authentication option
 	  */
 	int struct_version;
 	/** The "keep alive" interval, measured in seconds, defines the maximum time
@@ -1378,27 +1429,31 @@ typedef struct
 	 * HTTPS proxy
 	 */
 	const char* httpsProxy;
+	/**
+	 * MQTTv5  authentication method
+	 */
+	const char* authMethod;
 } MQTTAsync_connectOptions;
 
 /** Initializer for connect options for MQTT 3.1.1 non-WebSocket connections */
-#define MQTTAsync_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 8, 60, 1, 65535, NULL, NULL, NULL, 30, 0,\
-NULL, NULL, NULL, NULL, 0, NULL, MQTTVERSION_DEFAULT, 0, 1, 60, {0, NULL}, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL}
+#define MQTTAsync_connectOptions_initializer { {'M', 'Q', 'T', 'C'}, 9, 60, 1, 65535, NULL, NULL, NULL, 30, 0,\
+NULL, NULL, NULL, NULL, 0, NULL, MQTTVERSION_DEFAULT, 0, 1, 60, {0, NULL}, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}
 
 /** Initializer for connect options for MQTT 5.0 non-WebSocket connections */
-#define MQTTAsync_connectOptions_initializer5 { {'M', 'Q', 'T', 'C'}, 8, 60, 0, 65535, NULL, NULL, NULL, 30, 0,\
-NULL, NULL, NULL, NULL, 0, NULL, MQTTVERSION_5, 0, 1, 60, {0, NULL}, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL}
+#define MQTTAsync_connectOptions_initializer5 { {'M', 'Q', 'T', 'C'}, 9, 60, 0, 65535, NULL, NULL, NULL, 30, 0,\
+NULL, NULL, NULL, NULL, 0, NULL, MQTTVERSION_5, 0, 1, 60, {0, NULL}, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}
 
 /** Initializer for connect options for MQTT 3.1.1 WebSockets connections.
   * The keepalive interval is set to 45 seconds to avoid webserver 60 second inactivity timeouts.
   */
-#define MQTTAsync_connectOptions_initializer_ws { {'M', 'Q', 'T', 'C'}, 8, 45, 1, 65535, NULL, NULL, NULL, 30, 0,\
-NULL, NULL, NULL, NULL, 0, NULL, MQTTVERSION_DEFAULT, 0, 1, 60, {0, NULL}, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL}
+#define MQTTAsync_connectOptions_initializer_ws { {'M', 'Q', 'T', 'C'}, 9, 45, 1, 65535, NULL, NULL, NULL, 30, 0,\
+NULL, NULL, NULL, NULL, 0, NULL, MQTTVERSION_DEFAULT, 0, 1, 60, {0, NULL}, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}
 
 /** Initializer for connect options for MQTT 5.0 WebSockets connections.
   * The keepalive interval is set to 45 seconds to avoid webserver 60 second inactivity timeouts.
   */
-#define MQTTAsync_connectOptions_initializer5_ws { {'M', 'Q', 'T', 'C'}, 8, 45, 0, 65535, NULL, NULL, NULL, 30, 0,\
-NULL, NULL, NULL, NULL, 0, NULL, MQTTVERSION_5, 0, 1, 60, {0, NULL}, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL}
+#define MQTTAsync_connectOptions_initializer5_ws { {'M', 'Q', 'T', 'C'}, 9, 45, 0, 65535, NULL, NULL, NULL, 30, 0,\
+NULL, NULL, NULL, NULL, 0, NULL, MQTTVERSION_5, 0, 1, 60, {0, NULL}, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}
 
 
 /**

--- a/src/MQTTAsyncUtils.h
+++ b/src/MQTTAsyncUtils.h
@@ -113,6 +113,9 @@ typedef struct MQTTAsync_struct
 	MQTTAsync_selectInterface* selectInterface;
 	void* selectInterface_context;
 
+	MQTTAsync_authHandle* auth_handle;
+	void* auth_handle_context;
+
 	/* Each time connect is called, we store the options that were used.  These are reused in
 	   any call to reconnect, or an automatic reconnect attempt */
 	MQTTAsync_command connect;		/* Connect operation properties */

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -523,10 +523,14 @@ typedef struct
 /**
  * This is a callback function, which will be called when a MQTTv5 enhanced
  * authentication packet is either received from the server or needs to be
- * populated by the client.  This applies to MQTT V5 and above only.
+ * populated by the client, it applies to MQTT V5 and above only.
+ * The callback is not executed on a dedicated thread, do not call other MQTTClient
+ * functions inside of it.
  * @param context A pointer to the <i>context</i> value originally passed to
  * ::MQTTClient_setHandleAuth(), which contains any application-specific context.
  * @param data The MQTTClient_handleAuthData.
+ * @return a negative value to indicate not-authorized, a value of 0 to indicate success,
+ * a positive value to indicate continue.
  */
 typedef int MQTTClient_handleAuth(void* context, MQTTClient_handleAuthData* data);
 
@@ -1045,19 +1049,19 @@ typedef struct
 0, NULL, MQTTVERSION_DEFAULT, {NULL, 0, 0}, {0, NULL}, -1, 0, NULL, NULL, NULL, NULL}
 
 /** Initializer for connect options for MQTT 5.0 non-WebSocket connections */
-#define MQTTClient_connectOptions_initializer5 { {'M', 'Q', 'T', 'C'}, 8, 60, 0, 1, NULL, NULL, NULL, 30, 0, NULL,\
+#define MQTTClient_connectOptions_initializer5 { {'M', 'Q', 'T', 'C'}, 9, 60, 0, 1, NULL, NULL, NULL, 30, 0, NULL,\
 0, NULL, MQTTVERSION_5, {NULL, 0, 0}, {0, NULL}, -1, 1, NULL, NULL, NULL, NULL}
 
 /** Initializer for connect options for MQTT 3.1.1 WebSockets connections.
   * The keepalive interval is set to 45 seconds to avoid webserver 60 second inactivity timeouts.
   */
-#define MQTTClient_connectOptions_initializer_ws { {'M', 'Q', 'T', 'C'}, 8, 45, 1, 1, NULL, NULL, NULL, 30, 0, NULL,\
+#define MQTTClient_connectOptions_initializer_ws { {'M', 'Q', 'T', 'C'}, 9, 45, 1, 1, NULL, NULL, NULL, 30, 0, NULL,\
 0, NULL, MQTTVERSION_DEFAULT, {NULL, 0, 0}, {0, NULL}, -1, 0, NULL, NULL, NULL, NULL}
 
 /** Initializer for connect options for MQTT 5.0 WebSockets connections.
   * The keepalive interval is set to 45 seconds to avoid webserver 60 second inactivity timeouts.
   */
-#define MQTTClient_connectOptions_initializer5_ws { {'M', 'Q', 'T', 'C'}, 8, 45, 0, 1, NULL, NULL, NULL, 30, 0, NULL,\
+#define MQTTClient_connectOptions_initializer5_ws { {'M', 'Q', 'T', 'C'}, 9, 45, 0, 1, NULL, NULL, NULL, 30, 0, NULL,\
 0, NULL, MQTTVERSION_5, {NULL, 0, 0}, {0, NULL}, -1, 1, NULL, NULL, NULL, NULL}
 
 /**
@@ -1452,15 +1456,6 @@ LIBMQTT_API int MQTTClient_receive(MQTTClient handle, char** topicName, int* top
   * to be freed.
   */
 LIBMQTT_API void MQTTClient_freeMessage(MQTTClient_message** msg);
-
-/**
-  * This function is used to allocate memory to be used or freed by the MQTT C client library,
-  * especially the data in the ::MQTTPersistence_afterRead and ::MQTTPersistence_beforeWrite
-  * callbacks. This is needed on Windows when the client library and application
-  * program have been compiled with different versions of the C compiler.
-  * @param size The size of the memory to be allocated.
-  */
-LIBMQTT_API void* MQTTClient_malloc(size_t size);
 
 /**
   * This function frees memory allocated by the MQTT C client library, especially the

--- a/src/MQTTPacket.h
+++ b/src/MQTTPacket.h
@@ -225,6 +225,17 @@ typedef Ack Pubrec;
 typedef Ack Pubrel;
 typedef Ack Pubcomp;
 
+/**
+ * Data for the authentication packet.
+ */
+typedef struct
+{
+	Header header;			/**< MQTT header byte */
+	unsigned char rc;		/**< MQTT 5 reason code */
+	int MQTTVersion;		/**< the version of MQTT */
+	MQTTProperties properties;	/**< MQTT 5.0 properties */
+} Auth;
+
 int MQTTPacket_encode(char* buf, size_t length);
 int MQTTPacket_decode(networkHandles* net, size_t* value);
 int readInt(char** pptr);
@@ -249,10 +260,12 @@ void MQTTPacket_freePublish(Publish* pack);
 int MQTTPacket_send_publish(Publish* pack, int dup, int qos, int retained, networkHandles* net, const char* clientID);
 int MQTTPacket_send_puback(int MQTTVersion, int msgid, networkHandles* net, const char* clientID);
 void* MQTTPacket_ack(int MQTTVersion, unsigned char aHeader, char* data, size_t datalen);
+void* MQTTPacket_auth(int MQTTVersion, unsigned char aHeader, char* data, size_t datalen);
 
 void MQTTPacket_freeAck(Ack* pack);
 void MQTTPacket_freeSuback(Suback* pack);
 void MQTTPacket_freeUnsuback(Unsuback* pack);
+void MQTTPacket_freeAuth(Auth* pack);
 int MQTTPacket_send_pubrec(int MQTTVersion, int msgid, networkHandles* net, const char* clientID);
 int MQTTPacket_send_pubrel(int MQTTVersion, int msgid, int dup, networkHandles* net, const char* clientID);
 int MQTTPacket_send_pubcomp(int MQTTVersion, int msgid, networkHandles* net, const char* clientID);

--- a/src/MQTTPacketOut.h
+++ b/src/MQTTPacketOut.h
@@ -36,4 +36,6 @@ void* MQTTPacket_suback(int MQTTVersion, unsigned char aHeader, char* data, size
 int MQTTPacket_send_unsubscribe(List* topics, MQTTProperties* props, int msgid, int dup, Clients* client);
 void* MQTTPacket_unsuback(int MQTTVersion, unsigned char aHeader, char* data, size_t datalen);
 
+int MQTTPacket_send_auth(Clients* client, enum MQTTReasonCodes reason, MQTTProperties* props);
+
 #endif

--- a/src/MQTTProtocolOut.h
+++ b/src/MQTTProtocolOut.h
@@ -62,5 +62,6 @@ int MQTTProtocol_handleSubacks(void* pack, SOCKET sock);
 int MQTTProtocol_unsubscribe(Clients* client, List* topics, int msgID, MQTTProperties* props);
 int MQTTProtocol_handleUnsubacks(void* pack, SOCKET sock);
 int MQTTProtocol_handleDisconnects(void* pack, SOCKET sock);
+int MQTTProtocol_handleAuth(void* pack, SOCKET sock, enum MQTTReasonCodes reason, void *data, int dataLen);
 
 #endif


### PR DESCRIPTION
This PR adds MQTTv5 Enhanced Authentication to the library when using MQTTAsync.

The implementation on MQTTClient is currently incomplete and tests aren't yet provided, I will finish it once I receive feedback on the current implementation.

Implements: #465 