### PR TITLE
Async sample callback context fix.

### DIFF
--- a/src/samples/MQTTAsync_publish.c
+++ b/src/samples/MQTTAsync_publish.c
@@ -152,7 +152,7 @@ int main(int argc, char* argv[])
 		exit(EXIT_FAILURE);
 	}
 
-	if ((rc = MQTTAsync_setCallbacks(client, NULL, connlost, messageArrived, NULL)) != MQTTASYNC_SUCCESS)
+	if ((rc = MQTTAsync_setCallbacks(client, client, connlost, messageArrived, NULL)) != MQTTASYNC_SUCCESS)
 	{
 		printf("Failed to set callback, return code %d\n", rc);
 		exit(EXIT_FAILURE);

--- a/src/samples/MQTTAsync_publish_time.c
+++ b/src/samples/MQTTAsync_publish_time.c
@@ -158,7 +158,7 @@ int main(int argc, char* argv[])
 		exit(EXIT_FAILURE);
 	}
 
-	if ((rc = MQTTAsync_setCallbacks(client, NULL, connlost, messageArrived, NULL)) != MQTTASYNC_SUCCESS)
+	if ((rc = MQTTAsync_setCallbacks(client, client, connlost, messageArrived, NULL)) != MQTTASYNC_SUCCESS)
 	{
 		printf("Failed to set callback, return code %d\n", rc);
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
Fixing MQTTAsync sample callback context: within the callback, the context is casted to the client handle but configured as 'NULL'. This causes a crash when the connection is lost.

## Repro steps
- Set a breakpoint in `onConnect`

- In another terminal:
```sh
netstat | grep 1883
tcp        0      0 mydevstation:32132 137.135.83.217:1883     ESTABLISHED

sudo ss -K dst 137.135.83.217 dport = 1883
```

- Resume execution after the connection is dropped

__Expected__: sample reconnects (`connlost` is called).
__Actual__: crash in `MQTTAsync_connect` as `client` is NULL.
