### PR TITLE
fix(man): fix format

### DIFF
--- a/doc/man/man1/paho_c_pub.1
+++ b/doc/man/man1/paho_c_pub.1
@@ -110,7 +110,7 @@ Do not print error messages.
 .TP
 .PD
 .B \-\-trace
-Print library internal trace.  Valid levels are \fBmin\fR, \fBmax\fR, \fBerror\fR and \fprotocol\fR.
+Print library internal trace.  Valid levels are \fBmin\fR, \fBmax\fR, \fBerror\fR and \fBprotocol\fR.
 .TP
 .PD 0
 .BI \-r

--- a/doc/man/man1/paho_c_sub.1
+++ b/doc/man/man1/paho_c_sub.1
@@ -102,7 +102,7 @@ Do not print error messages.
 .TP
 .PD
 .B \-\-trace
-Print library internal trace.  Valid levels are \fBmin\fR, \fBmax\fR, \fBerror\fR and \fprotocol\fR.
+Print library internal trace.  Valid levels are \fBmin\fR, \fBmax\fR, \fBerror\fR and \fBprotocol\fR.
 .TP
 .PD 0
 .BI \-R

--- a/doc/man/man1/paho_cs_pub.1
+++ b/doc/man/man1/paho_cs_pub.1
@@ -110,7 +110,7 @@ Do not print error messages.
 .TP
 .PD
 .B \-\-trace
-Print library internal trace.  Valid levels are \fBmin\fR, \fBmax\fR, \fBerror\fR and \fprotocol\fR.
+Print library internal trace.  Valid levels are \fBmin\fR, \fBmax\fR, \fBerror\fR and \fBprotocol\fR.
 .TP
 .PD 0
 .BI \-r

--- a/doc/man/man1/paho_cs_sub.1
+++ b/doc/man/man1/paho_cs_sub.1
@@ -102,7 +102,7 @@ Do not print error messages.
 .TP
 .PD
 .B \-\-trace
-Print library internal trace.  Valid levels are \fBmin\fR, \fBmax\fR, \fBerror\fR and \fprotocol\fR.
+Print library internal trace.  Valid levels are \fBmin\fR, \fBmax\fR, \fBerror\fR and \fBprotocol\fR.
 .TP
 .PD 0
 .BI \-R


### PR DESCRIPTION
Fixes format of man1 manpages.


Format issues were reported by lintian during packaging for Debian-based distributions:
```
W: paho.mqtt.c-examples: groff-message troff:<standard input>:105: warning: cannot select font 'p' [usr/share/man/man1/paho_c_sub.1L.gz:1]
N: 
N:   A manual page provoked warnings or errors from the man program. Here are some common ones:
N:   
N:   "cannot adjust" or "can't break" are issues with paragraph filling. They are usually related to long lines. Justifying text on the left hand side can help with adjustments. Hyphenation can help with breaks.
N:   
N:   For more information, please see "Manipulating Filling and Adjusting" and "Manipulating Hyphenation" in the Groff manual (see info groff).
N:   
N:   "can't find numbered character" usually means that the input was in a national legacy encoding. The warning means that some characters were dropped. Please use escapes such as \[:a] as described on the groff_char manual page.
N:   
N:   Other common warnings are formatting typos. String arguments to .IP require quotes. Usually, some text is lost or mangled. See the groff_man (or groff_mdoc if using mdoc) manual page for details on macros.
N:   
N:   The check for manual pages uses the --warnings option to man to catch common problems, like a . or a ' at the beginning of a line as literal text. They are interpreted as Groff commands. Just reformat the paragraph so the characters are not at the beginning of a line. You can
N:   also add a zero-width space (\&) in front of them.
N:   
N:   Aside from overrides, warnings can be disabled with the .warn directive. Please see "Debugging" in the Groff manual.
N:   
N:   You can see the warnings yourself by running the command used by Lintian:
N:   
N:       LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 \
N:           man --warnings -E UTF-8 -l -Tutf8 -Z <file> >/dev/null
N: 
N:   Please refer to the groff_man(7) manual page and the groff_mdoc(7) manual page for details.
N: 
N:   Visibility: warning
N:   Show-Always: no
N:   Check: documentation/manual
N:   Renamed from: manpage-has-errors-from-man
N: 
N:
W: paho.mqtt.c-examples: groff-message troff:<standard input>:105: warning: cannot select font 'p' [usr/share/man/man1/paho_cs_sub.1L.gz:1]
N:
W: paho.mqtt.c-examples: groff-message troff:<standard input>:113: warning: cannot select font 'p' [usr/share/man/man1/paho_c_pub.1L.gz:1]
N:
W: paho.mqtt.c-examples: groff-message troff:<standard input>:113: warning: cannot select font 'p' [usr/share/man/man1/paho_cs_pub.1L.gz:1]
```