### PR TITLE
Some minor hardening of MQTTProperties functions

### DIFF
--- a/src/MQTTProperties.c
+++ b/src/MQTTProperties.c
@@ -86,7 +86,7 @@ int MQTTProperty_getType(enum MQTTPropertyCodes value)
 }
 
 
-int MQTTProperties_len(MQTTProperties* props)
+int MQTTProperties_len(const MQTTProperties* props)
 {
   /* properties length is an mbi */
   return (props == NULL) ? 1 : props->length + MQTTPacket_VBIlen(props->length);
@@ -103,6 +103,11 @@ int MQTTProperties_add(MQTTProperties* props, const MQTTProperty* prop)
 {
   int rc = 0, type;
 
+  if (props == NULL)
+  {
+    rc = PAHO_MEMORY_ERROR;
+    goto exit;
+  }
   if ((type = MQTTProperty_getType(prop->identifier)) < 0)
   {
 	/*StackTrace_printStack(stdout);*/
@@ -431,7 +436,7 @@ MQTTProperties MQTTProperties_copy(const MQTTProperties* props)
   MQTTProperties result = MQTTProperties_initializer;
 
   FUNC_ENTRY;
-  for (i = 0; i < props->count; ++i)
+  for (i = 0; props != NULL && i < props->count; ++i)
   {
 	int rc = 0;
 
@@ -444,12 +449,12 @@ MQTTProperties MQTTProperties_copy(const MQTTProperties* props)
 }
 
 
-int MQTTProperties_hasProperty(MQTTProperties *props, enum MQTTPropertyCodes propid)
+int MQTTProperties_hasProperty(const MQTTProperties *props, enum MQTTPropertyCodes propid)
 {
 	int i = 0;
 	int found = 0;
 
-	for (i = 0; i < props->count; ++i)
+	for (i = 0; props != NULL && i < props->count; ++i)
 	{
 		if (propid == props->array[i].identifier)
 		{
@@ -461,12 +466,12 @@ int MQTTProperties_hasProperty(MQTTProperties *props, enum MQTTPropertyCodes pro
 }
 
 
-int MQTTProperties_propertyCount(MQTTProperties *props, enum MQTTPropertyCodes propid)
+int MQTTProperties_propertyCount(const MQTTProperties *props, enum MQTTPropertyCodes propid)
 {
 	int i = 0;
 	int count = 0;
 
-	for (i = 0; i < props->count; ++i)
+	for (i = 0; props != NULL && i < props->count; ++i)
 	{
 		if (propid == props->array[i].identifier)
 			count++;
@@ -475,13 +480,13 @@ int MQTTProperties_propertyCount(MQTTProperties *props, enum MQTTPropertyCodes p
 }
 
 
-int MQTTProperties_getNumericValueAt(MQTTProperties *props, enum MQTTPropertyCodes propid, int index)
+int MQTTProperties_getNumericValueAt(const MQTTProperties *props, enum MQTTPropertyCodes propid, int index)
 {
 	int i = 0;
 	int rc = -9999999;
 	int cur_index = 0;
 
-	for (i = 0; i < props->count; ++i)
+	for (i = 0; props != NULL && i < props->count; ++i)
 	{
 		int id = props->array[i].identifier;
 
@@ -515,19 +520,19 @@ int MQTTProperties_getNumericValueAt(MQTTProperties *props, enum MQTTPropertyCod
 }
 
 
-int MQTTProperties_getNumericValue(MQTTProperties *props, enum MQTTPropertyCodes propid)
+int MQTTProperties_getNumericValue(const MQTTProperties *props, enum MQTTPropertyCodes propid)
 {
 	return MQTTProperties_getNumericValueAt(props, propid, 0);
 }
 
 
-MQTTProperty* MQTTProperties_getPropertyAt(MQTTProperties *props, enum MQTTPropertyCodes propid, int index)
+MQTTProperty* MQTTProperties_getPropertyAt(const MQTTProperties *props, enum MQTTPropertyCodes propid, int index)
 {
 	int i = 0;
 	MQTTProperty* result = NULL;
 	int cur_index = 0;
 
-	for (i = 0; i < props->count; ++i)
+	for (i = 0; props != 0 && i < props->count; ++i)
 	{
 		int id = props->array[i].identifier;
 
@@ -546,7 +551,7 @@ MQTTProperty* MQTTProperties_getPropertyAt(MQTTProperties *props, enum MQTTPrope
 }
 
 
-MQTTProperty* MQTTProperties_getProperty(MQTTProperties *props, enum MQTTPropertyCodes propid)
+MQTTProperty* MQTTProperties_getProperty(const MQTTProperties *props, enum MQTTPropertyCodes propid)
 {
 	return MQTTProperties_getPropertyAt(props, propid, 0);
 }

--- a/src/MQTTProperties.h
+++ b/src/MQTTProperties.h
@@ -124,7 +124,7 @@ typedef struct MQTTProperties
  * @param props an MQTT V5 property structure.
  * @return the length in bytes of the properties when serialized.
  */
-int MQTTProperties_len(MQTTProperties* props);
+int MQTTProperties_len(const MQTTProperties* props);
 
 /**
  * Add a property pointer to the property array. Memory is allocated in this function,
@@ -173,7 +173,7 @@ LIBMQTT_API MQTTProperties MQTTProperties_copy(const MQTTProperties* props);
  * @param propid the property id to check for.
  * @return 1 if found, 0 if not.
  */
-LIBMQTT_API int MQTTProperties_hasProperty(MQTTProperties *props, enum MQTTPropertyCodes propid);
+LIBMQTT_API int MQTTProperties_hasProperty(const MQTTProperties *props, enum MQTTPropertyCodes propid);
 
 /**
  * Returns the number of instances of a property id. Most properties can exist only once.
@@ -182,7 +182,7 @@ LIBMQTT_API int MQTTProperties_hasProperty(MQTTProperties *props, enum MQTTPrope
  * @param propid the property id to check for.
  * @return the number of times found.  Can be 0.
  */
-LIBMQTT_API int MQTTProperties_propertyCount(MQTTProperties *props, enum MQTTPropertyCodes propid);
+LIBMQTT_API int MQTTProperties_propertyCount(const MQTTProperties *props, enum MQTTPropertyCodes propid);
 
 /**
  * Returns the integer value of a specific property.  The property given must be a numeric type.
@@ -190,7 +190,7 @@ LIBMQTT_API int MQTTProperties_propertyCount(MQTTProperties *props, enum MQTTPro
  * @param propid the property id to check for.
  * @return the integer value of the property. -9999999 on failure.
  */
-LIBMQTT_API int MQTTProperties_getNumericValue(MQTTProperties *props, enum MQTTPropertyCodes propid);
+LIBMQTT_API int MQTTProperties_getNumericValue(const MQTTProperties *props, enum MQTTPropertyCodes propid);
 
 /**
  * Returns the integer value of a specific property when it's not the only instance.
@@ -200,7 +200,7 @@ LIBMQTT_API int MQTTProperties_getNumericValue(MQTTProperties *props, enum MQTTP
  * @param index the instance number, starting at 0.
  * @return the integer value of the property. -9999999 on failure.
  */
-LIBMQTT_API int MQTTProperties_getNumericValueAt(MQTTProperties *props, enum MQTTPropertyCodes propid, int index);
+LIBMQTT_API int MQTTProperties_getNumericValueAt(const MQTTProperties *props, enum MQTTPropertyCodes propid, int index);
 
 /**
  * Returns a pointer to the property structure for a specific property.
@@ -208,7 +208,7 @@ LIBMQTT_API int MQTTProperties_getNumericValueAt(MQTTProperties *props, enum MQT
  * @param propid the property id to check for.
  * @return the pointer to the property structure if found.  NULL if not found.
  */
-LIBMQTT_API MQTTProperty* MQTTProperties_getProperty(MQTTProperties *props, enum MQTTPropertyCodes propid);
+LIBMQTT_API MQTTProperty* MQTTProperties_getProperty(const MQTTProperties *props, enum MQTTPropertyCodes propid);
 
 /**
  * Returns a pointer to the property structure for a specific property when it's not the only instance.
@@ -217,6 +217,6 @@ LIBMQTT_API MQTTProperty* MQTTProperties_getProperty(MQTTProperties *props, enum
  * @param index the instance number, starting at 0.
  * @return the pointer to the property structure if found.  NULL if not found.
  */
-LIBMQTT_API MQTTProperty* MQTTProperties_getPropertyAt(MQTTProperties *props, enum MQTTPropertyCodes propid, int index);
+LIBMQTT_API MQTTProperty* MQTTProperties_getPropertyAt(const MQTTProperties *props, enum MQTTPropertyCodes propid, int index);
 
 #endif /* MQTTPROPERTIES_H */


### PR DESCRIPTION
Added const to MQTTProperties params in the property functions and made user-facing properties functions safe from null pointers passed in. The functions won't segfault if the user passes in a NULL pointer, and will return reasonable values (count of zero, property not found, etc).
