### PR TITLE
Fixed the link to the EPL-v2.0 web page in the sources.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@
 #  and Eclipse Distribution License v1.0 which accompany this distribution.
 #
 #  The Eclipse Public License is available at
-#     https://www.eclipse.org/legal/epl-2.0/
+#     https://www.eclipse.org/legal/epl-v20.html
 #  and the Eclipse Distribution License is available at
-#    http://www.eclipse.org/org/documents/edl-v10.php.
+#    http://www.eclipse.org/org/documents/edl-v10.php
 #
 #  Contributors:
 #     Rainer Poisel - initial version

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@
 #  and Eclipse Distribution License v1.0 which accompany this distribution.
 #
 #  The Eclipse Public License is available at
-#     https://www.eclipse.org/legal/epl-2.0/
+#     https://www.eclipse.org/legal/epl-v20.html
 #  and the Eclipse Distribution License is available at
-#    http://www.eclipse.org/org/documents/edl-v10.php.
+#    http://www.eclipse.org/org/documents/edl-v10.php
 #
 #  Contributors:
 #     Ian Craggs - initial API and implementation and/or initial documentation

--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
 indicated below, the Content is provided to you under the terms and conditions of the
 Eclipse Public License Version 2.0 ("EPL") and Eclipse Distribution License Version 1.0 ("EDL").
 A copy of the EPL is available at 
-<a href="https://www.eclipse.org/legal/epl-2.0/">https://www.eclipse.org/legal/epl-2.0/</a> 
+<a href="https://www.eclipse.org/legal/epl-v20.html">https://www.eclipse.org/legal/epl-v20.html</a> 
 and a copy of the EDL is available at 
 <a href="http://www.eclipse.org/org/documents/edl-v10.php">http://www.eclipse.org/org/documents/edl-v10.php</a>. 
 For purposes of the EPL, "Program" will mean the Content.</p>

--- a/build.xml
+++ b/build.xml
@@ -6,9 +6,9 @@
   and Eclipse Distribution License v1.0 which accompany this distribution.
 
   The Eclipse Public License is available at
-     https://www.eclipse.org/legal/epl-2.0/
+     https://www.eclipse.org/legal/epl-v20.html
   and the Eclipse Distribution License is available at
-    http://www.eclipse.org/org/documents/edl-v10.php.
+    http://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Ian Craggs - initial API and implementation and/or initial documentation

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -6,9 +6,9 @@
 #  and Eclipse Distribution License v1.0 which accompany this distribution. 
 # 
 #  The Eclipse Public License is available at 
-#     https://www.eclipse.org/legal/epl-2.0/
+#     https://www.eclipse.org/legal/epl-v20.html
 #  and the Eclipse Distribution License is available at 
-#    http://www.eclipse.org/org/documents/edl-v10.php.
+#    http://www.eclipse.org/org/documents/edl-v10.php
 # 
 #  Contributors:
 #     Rainer Poisel - initial version

--- a/notice.html
+++ b/notice.html
@@ -22,7 +22,7 @@
 <h3>Applicable Licenses</h3>
 
 <p>Unless otherwise indicated, all Content made available by the Eclipse Foundation is provided to you under the terms and conditions of the Eclipse Public License Version 2.0
-   (&quot;EPL&quot;).  A copy of the EPL is provided with this Content and is also available at <a href="https://www.eclipse.org/legal/epl-2.0/">https://www.eclipse.org/legal/epl-2.0/</a>.
+   (&quot;EPL&quot;).  A copy of the EPL is provided with this Content and is also available at <a href="https://www.eclipse.org/legal/epl-v20.html">https://www.eclipse.org/legal/epl-v20.html</a>.
    For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
 
 <p>Content includes, but is not limited to, source code, object code, documentation and other files maintained in the Eclipse Foundation source code

--- a/src/Base64.c
+++ b/src/Base64.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Keith Holman - initial implementation and documentation

--- a/src/Base64.h
+++ b/src/Base64.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Keith Holman - initial implementation and documentation

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,9 +6,9 @@
 #  and Eclipse Distribution License v1.0 which accompany this distribution.
 #
 #  The Eclipse Public License is available at
-#     https://www.eclipse.org/legal/epl-2.0/
+#     https://www.eclipse.org/legal/epl-v20.html
 #  and the Eclipse Distribution License is available at
-#    http://www.eclipse.org/org/documents/edl-v10.php.
+#    http://www.eclipse.org/org/documents/edl-v10.php
 #
 #  Contributors:
 #     Rainer Poisel - initial version

--- a/src/Clients.c
+++ b/src/Clients.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/Clients.h
+++ b/src/Clients.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/Heap.c
+++ b/src/Heap.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/Heap.h
+++ b/src/Heap.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/LinkedList.c
+++ b/src/LinkedList.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/LinkedList.h
+++ b/src/LinkedList.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/Log.c
+++ b/src/Log.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/Log.h
+++ b/src/Log.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial implementation and documentation

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation

--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial implementation and documentation

--- a/src/MQTTAsyncUtils.h
+++ b/src/MQTTAsyncUtils.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial implementation and documentation

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTClientPersistence.h
+++ b/src/MQTTClientPersistence.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTExportDeclarations.h
+++ b/src/MQTTExportDeclarations.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Andreas Walter - initially moved export declarations into separate fle

--- a/src/MQTTPacket.c
+++ b/src/MQTTPacket.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTPacket.h
+++ b/src/MQTTPacket.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTPacketOut.c
+++ b/src/MQTTPacketOut.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTPacketOut.h
+++ b/src/MQTTPacketOut.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTPersistence.c
+++ b/src/MQTTPersistence.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTPersistence.h
+++ b/src/MQTTPersistence.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTPersistenceDefault.c
+++ b/src/MQTTPersistenceDefault.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTPersistenceDefault.h
+++ b/src/MQTTPersistenceDefault.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTProperties.c
+++ b/src/MQTTProperties.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTProperties.h
+++ b/src/MQTTProperties.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTProtocol.h
+++ b/src/MQTTProtocol.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTProtocolClient.c
+++ b/src/MQTTProtocolClient.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTProtocolClient.h
+++ b/src/MQTTProtocolClient.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTProtocolOut.c
+++ b/src/MQTTProtocolOut.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTProtocolOut.h
+++ b/src/MQTTProtocolOut.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTReasonCodes.c
+++ b/src/MQTTReasonCodes.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTReasonCodes.h
+++ b/src/MQTTReasonCodes.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTSubscribeOpts.h
+++ b/src/MQTTSubscribeOpts.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/MQTTTime.c
+++ b/src/MQTTTime.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial implementation

--- a/src/MQTTTime.h
+++ b/src/MQTTTime.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial implementation

--- a/src/MQTTVersion.c
+++ b/src/MQTTVersion.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/Messages.c
+++ b/src/Messages.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/Messages.h
+++ b/src/Messages.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/OsWrapper.c
+++ b/src/OsWrapper.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Gunter Raidl - timer support for VxWorks

--- a/src/OsWrapper.h
+++ b/src/OsWrapper.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Gunter Raidl - timer support for VxWorks

--- a/src/Proxy.c
+++ b/src/Proxy.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Keith Holman - initial implementation and documentation

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Sven Gambel - move WebSocket proxy support to generic proxy support

--- a/src/SHA1.c
+++ b/src/SHA1.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Keith Holman - initial implementation and documentation

--- a/src/SHA1.h
+++ b/src/SHA1.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Keith Holman - initial implementation and documentation

--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs, Allan Stockdill-Mander - initial implementation

--- a/src/SSLSocket.h
+++ b/src/SSLSocket.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs, Allan Stockdill-Mander - initial implementation 

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial implementation and documentation

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial implementation and documentation

--- a/src/SocketBuffer.c
+++ b/src/SocketBuffer.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/SocketBuffer.h
+++ b/src/SocketBuffer.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/StackTrace.c
+++ b/src/StackTrace.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/StackTrace.h
+++ b/src/StackTrace.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/Thread.c
+++ b/src/Thread.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial implementation

--- a/src/Thread.h
+++ b/src/Thread.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial implementation

--- a/src/Tree.c
+++ b/src/Tree.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial implementation and documentation

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial implementation and documentation

--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Keith Holman - initial implementation and documentation

--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Keith Holman - initial implementation and documentation

--- a/src/mutex_type.h
+++ b/src/mutex_type.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  *******************************************************************************/
 #if !defined(_MUTEX_TYPE_H_)

--- a/src/samples/CMakeLists.txt
+++ b/src/samples/CMakeLists.txt
@@ -6,9 +6,9 @@
 #  and Eclipse Distribution License v1.0 which accompany this distribution.
 #
 #  The Eclipse Public License is available at
-#     https://www.eclipse.org/legal/epl-2.0/
+#     https://www.eclipse.org/legal/epl-v20.html
 #  and the Eclipse Distribution License is available at
-#    http://www.eclipse.org/org/documents/edl-v10.php.
+#    http://www.eclipse.org/org/documents/edl-v10.php
 #
 #  Contributors:
 #     Rainer Poisel - initial version

--- a/src/samples/MQTTAsync_publish.c
+++ b/src/samples/MQTTAsync_publish.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *   https://www.eclipse.org/legal/epl-2.0/
+ *   https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial contribution

--- a/src/samples/MQTTAsync_publish_time.c
+++ b/src/samples/MQTTAsync_publish_time.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *   https://www.eclipse.org/legal/epl-2.0/
+ *   https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial contribution

--- a/src/samples/MQTTAsync_subscribe.c
+++ b/src/samples/MQTTAsync_subscribe.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *   https://www.eclipse.org/legal/epl-2.0/
+ *   https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial contribution

--- a/src/samples/MQTTClient_publish.c
+++ b/src/samples/MQTTClient_publish.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *   https://www.eclipse.org/legal/epl-2.0/
+ *   https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial contribution

--- a/src/samples/MQTTClient_publish_async.c
+++ b/src/samples/MQTTClient_publish_async.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial contribution

--- a/src/samples/MQTTClient_subscribe.c
+++ b/src/samples/MQTTClient_subscribe.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *   https://www.eclipse.org/legal/epl-2.0/
+ *   https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial contribution

--- a/src/samples/paho_c_pub.c
+++ b/src/samples/paho_c_pub.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *   https://www.eclipse.org/legal/epl-2.0/
+ *   https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial contribution

--- a/src/samples/paho_c_sub.c
+++ b/src/samples/paho_c_sub.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *   https://www.eclipse.org/legal/epl-2.0/
+ *   https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial contribution

--- a/src/samples/paho_cs_pub.c
+++ b/src/samples/paho_cs_pub.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *   https://www.eclipse.org/legal/epl-2.0/
+ *   https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial contribution

--- a/src/samples/paho_cs_sub.c
+++ b/src/samples/paho_cs_sub.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *   https://www.eclipse.org/legal/epl-2.0/
+ *   https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial contribution

--- a/src/samples/pubsub_opts.c
+++ b/src/samples/pubsub_opts.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *   https://www.eclipse.org/legal/epl-2.0/
+ *   https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial contribution

--- a/src/samples/pubsub_opts.h
+++ b/src/samples/pubsub_opts.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *   https://www.eclipse.org/legal/epl-2.0/
+ *   https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial contribution

--- a/src/utf-8.c
+++ b/src/utf-8.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/src/utf-8.h
+++ b/src/utf-8.h
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/MQTTV311.py
+++ b/test/MQTTV311.py
@@ -7,9 +7,9 @@
   and Eclipse Distribution License v1.0 which accompany this distribution.
 
   The Eclipse Public License is available at
-     https://www.eclipse.org/legal/epl-2.0/
+     https://www.eclipse.org/legal/epl-v20.html
   and the Eclipse Distribution License is available at
-    http://www.eclipse.org/org/documents/edl-v10.php.
+    http://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Ian Craggs - initial implementation and/or documentation

--- a/test/MQTTV3112.py
+++ b/test/MQTTV3112.py
@@ -7,9 +7,9 @@
   and Eclipse Distribution License v1.0 which accompany this distribution. 
  
   The Eclipse Public License is available at 
-     https://www.eclipse.org/legal/epl-2.0/
+     https://www.eclipse.org/legal/epl-v20.html
   and the Eclipse Distribution License is available at 
-    http://www.eclipse.org/org/documents/edl-v10.php.
+    http://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Ian Craggs - initial implementation and/or documentation

--- a/test/MQTTV5.py
+++ b/test/MQTTV5.py
@@ -7,9 +7,9 @@
   and Eclipse Distribution License v1.0 which accompany this distribution.
 
   The Eclipse Public License is available at
-     https://www.eclipse.org/legal/epl-2.0/
+     https://www.eclipse.org/legal/epl-v20.html
   and the Eclipse Distribution License is available at
-    http://www.eclipse.org/org/documents/edl-v10.php.
+    http://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Ian Craggs - initial implementation and/or documentation

--- a/test/mqttsas.py
+++ b/test/mqttsas.py
@@ -7,9 +7,9 @@
   and Eclipse Distribution License v1.0 which accompany this distribution.
 
   The Eclipse Public License is available at
-     https://www.eclipse.org/legal/epl-2.0/
+     https://www.eclipse.org/legal/epl-v20.html
   and the Eclipse Distribution License is available at
-    http://www.eclipse.org/org/documents/edl-v10.php.
+    http://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Ian Craggs - initial implementation and/or documentation

--- a/test/sync_client_test.c
+++ b/test/sync_client_test.c
@@ -6,9 +6,9 @@
   and Eclipse Distribution License v1.0 which accompany this distribution. 
  
   The Eclipse Public License is available at 
-     https://www.eclipse.org/legal/epl-2.0/
+     https://www.eclipse.org/legal/epl-v20.html
   and the Eclipse Distribution License is available at 
-    http://www.eclipse.org/org/documents/edl-v10.php.
+    http://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Ian Craggs - initial implementation and/or documentation

--- a/test/test1.c
+++ b/test/test1.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test10.c
+++ b/test/test10.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test11.c
+++ b/test/test11.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test15.c
+++ b/test/test15.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test2.c
+++ b/test/test2.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test3.c
+++ b/test/test3.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Allan Stockdill-Mander - initial API and implementation and/or initial documentation

--- a/test/test4.c
+++ b/test/test4.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test45.c
+++ b/test/test45.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test5.c
+++ b/test/test5.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Allan Stockdill-Mander - initial API and implementation and/or initial documentation

--- a/test/test6.c
+++ b/test/test6.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test8.c
+++ b/test/test8.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test9.c
+++ b/test/test9.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test95.c
+++ b/test/test95.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test_connect_destroy.c
+++ b/test/test_connect_destroy.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Michal Kasperek - initial API and implementation and/or initial documentation

--- a/test/test_issue373.c
+++ b/test/test_issue373.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *******************************************************************************/

--- a/test/test_mqtt4async.c
+++ b/test/test_mqtt4async.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test_mqtt4sync.c
+++ b/test/test_mqtt4sync.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution. 
  *
  * The Eclipse Public License is available at 
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at 
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test_persistence.c
+++ b/test/test_persistence.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation

--- a/test/test_sync_session_present.c
+++ b/test/test_sync_session_present.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - Test program utilities

--- a/test/thread.c
+++ b/test/thread.c
@@ -6,9 +6,9 @@
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    https://www.eclipse.org/legal/epl-2.0/
+ *    https://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
- *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *   http://www.eclipse.org/org/documents/edl-v10.php
  *
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation


### PR DESCRIPTION
It appears that the URL link to the EPL-v2.0 web page in all the sources is broken. This should fix it. I think I got them all.

