### PR TITLE
Add cause to connection lost callback

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -950,7 +950,7 @@ void MQTTAsync_checkDisconnect(MQTTAsync handle, MQTTAsync_command* command)
 			if (m->cl && was_connected)
 			{
 				Log(TRACE_MIN, -1, "Calling connectionLost for client %s", m->c->clientID);
-				(*(m->cl))(m->clContext, NULL);
+				(*(m->cl))(m->clContext, "DISCONNECT");
 			}
 			MQTTAsync_startConnectRetry(m);
 		}
@@ -1612,7 +1612,7 @@ static void nextOrClose(MQTTAsyncs* m, int rc, char* message)
 		if (m->cl && was_connected)
 		{
 			Log(TRACE_MIN, -1, "Calling connectionLost for client %s", m->c->clientID);
-				(*(m->cl))(m->clContext, NULL);
+				(*(m->cl))(m->clContext, message);
 			connectionLost_called = 1;
 		}
 		/* put the connect command back to the head of the command queue, using the next serverURI */
@@ -1671,7 +1671,7 @@ static void nextOrClose(MQTTAsyncs* m, int rc, char* message)
 		if (connectionLost_called == 0 && m->cl && was_connected)
 		{
 			Log(TRACE_MIN, -1, "Calling connectionLost for client %s", m->c->clientID);
-				(*(m->cl))(m->clContext, NULL);
+				(*(m->cl))(m->clContext, message);
 		}
 		MQTTAsync_startConnectRetry(m);
 	}


### PR DESCRIPTION
I've noticed that the connection lost callback gets a string for the cause, but it is always set to null. It looks like upstream, many of the times, a cause is given, and I would like to propagate that.

This might not be the exactly correct approach, since I don't exactly understand the logic of the `nextOrClose` callback.