### PR TITLE
fix mingw build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,15 @@ SET(PAHO_ENABLE_CPACK TRUE CACHE BOOL "Enable CPack")
 SET(PAHO_HIGH_PERFORMANCE FALSE CACHE BOOL "Disable tracing and heap tracking")
 SET(PAHO_USE_SELECT FALSE CACHE BOOL "Revert to select system call instead of poll")
 
+IF (MINGW)
+  ADD_DEFINITIONS(-D_WINDOWS)
+  # Require at least Windows Vista (0x0600) for poll support
+  ## https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170#remarks
+  IF (NOT PAHO_SELECT_USE_SELECT)
+    ADD_DEFINITIONS(-DWINVER=0x0600 -D_WIN32_WINNT=0x0600)
+  ENDIF()
+ENDIF()
+
 IF (PAHO_HIGH_PERFORMANCE)
   ADD_DEFINITIONS(-DHIGH_PERFORMANCE=1)
 ENDIF()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,7 +58,8 @@ IF (NOT PAHO_HIGH_PERFORMANCE)
 ENDIF()
 
 IF (WIN32)
-    SET(LIBS_SYSTEM ws2_32 crypt32 RpcRT4)
+    # use all lowercase names for mingw compatibility
+    SET(LIBS_SYSTEM ws2_32 crypt32 rpcrt4)
 ELSEIF (UNIX)
     IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
         SET(LIBS_SYSTEM c dl pthread rt)


### PR DESCRIPTION
This adds a few fixes for building with mingw_w64 to cross compile for Windows from Linux.
- If poll is enabled, set minimum windows version to Windows Vista. This resolves `invalid use of undefined type ‘struct pollfd’`.
- Defines `_WINDOWS` to make tests compile as is
- Change `rpcrt4` to be all lowercase to be compatible with mingw (since Windows is case-insensitive).

Starts to address: https://github.com/eclipse/paho.mqtt.cpp/issues/123
