### PR TITLE
Fix usage of realloc

### DIFF
--- a/src/Heap.c
+++ b/src/Heap.c
@@ -338,17 +338,25 @@ void *myrealloc(char* file, int line, void* p, size_t size)
 		state.current_size += size - s->size;
 		if (state.current_size > state.max_size)
 			state.max_size = state.current_size;
-		if ((s->ptr = realloc(s->ptr, size + 2*sizeof(eyecatcherType))) == NULL)
+		void* newPtr = realloc(s->ptr, size + 2*sizeof(eyecatcherType));
+		if (newPtr == NULL)
 		{
 			Log(LOG_ERROR, 13, errmsg);
 			goto exit;
 		}
+		s->ptr = newPtr;
 		space += size + 2*sizeof(eyecatcherType) - s->size;
 		*(eyecatcherType*)(s->ptr) = eyecatcher; /* start eyecatcher */
 		*(eyecatcherType*)(((char*)(s->ptr)) + (sizeof(eyecatcherType) + size)) = eyecatcher; /* end eyecatcher */
 		s->size = size;
+		newPtr = realloc(s->file, filenamelen);
+		if (newPtr == NULL)
+		{
+			Log(LOG_ERROR, 13, errmsg);
+			goto exit;
+		}
 		space -= strlen(s->file);
-		s->file = realloc(s->file, filenamelen);
+		s->file = newPtr;
 		space += filenamelen;
 		strcpy(s->file, file);
 		s->line = line;

--- a/src/MQTTProperties.c
+++ b/src/MQTTProperties.c
@@ -117,7 +117,16 @@ int MQTTProperties_add(MQTTProperties* props, const MQTTProperty* prop)
   else if (props->count == props->max_count)
   {
     props->max_count += 10;
-    props->array = realloc(props->array, sizeof(MQTTProperty) * props->max_count);
+    void* newPtr = realloc(props->array, sizeof(MQTTProperty) * props->max_count);
+    if (newPtr == NULL)
+    {
+      free(props->array);
+      props->array = NULL;
+    }
+    else
+    {
+      props->array = newPtr;
+    }
   }
 
   if (props->array)
@@ -318,7 +327,18 @@ int MQTTProperties_read(MQTTProperties* properties, char** pptr, char* enddata)
     	if (properties->max_count == 10)
     	  properties->array = malloc(sizeof(MQTTProperty) * properties->max_count);
     	else
-    	  properties->array = realloc(properties->array, sizeof(MQTTProperty) * properties->max_count);
+      {
+        void* newPtr = realloc(properties->array, sizeof(MQTTProperty) * properties->max_count);
+        if (newPtr == NULL)
+        {
+          free(properties->array);
+        	properties->array = NULL;
+        }
+        else
+        {
+          properties->array = newPtr;
+        }
+      }
       }
       if (properties->array == NULL)
       {

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -273,7 +273,18 @@ int Socket_addSocket(SOCKET newSd)
 	Paho_thread_lock_mutex(socket_mutex);
 	mod_s.nfds++;
 	if (mod_s.fds_read)
-		mod_s.fds_read = realloc(mod_s.fds_read, mod_s.nfds * sizeof(mod_s.fds_read[0]));
+	{
+		void* newPtr = realloc(mod_s.fds_read, mod_s.nfds * sizeof(mod_s.fds_read[0]));
+		if (newPtr == NULL)
+		{
+			free(mod_s.fds_read);
+			mod_s.fds_read = NULL;
+		}
+		else
+		{
+			mod_s.fds_read = newPtr;
+		}
+	}
 	else
 		mod_s.fds_read = malloc(mod_s.nfds * sizeof(mod_s.fds_read[0]));
 	if (!mod_s.fds_read)
@@ -282,7 +293,18 @@ int Socket_addSocket(SOCKET newSd)
 		goto exit;
 	}
 	if (mod_s.fds_write)
-		mod_s.fds_write = realloc(mod_s.fds_write, mod_s.nfds * sizeof(mod_s.fds_write[0]));
+	{
+		void* newPtr = realloc(mod_s.fds_write, mod_s.nfds * sizeof(mod_s.fds_write[0]));
+		if (newPtr == NULL)
+		{
+			free(mod_s.fds_write);
+			mod_s.fds_write = NULL;
+		}
+		else
+		{
+			mod_s.fds_write = newPtr;
+		}
+	}
 	else
 		mod_s.fds_write = malloc(mod_s.nfds * sizeof(mod_s.fds_write[0]));
 	if (!mod_s.fds_write)
@@ -525,7 +547,18 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 				}
 			}
 			else if (mod_s.saved.fds_read)
-				mod_s.saved.fds_read = realloc(mod_s.saved.fds_read, mod_s.nfds * sizeof(struct pollfd));
+			{
+				void* newPtr = realloc(mod_s.saved.fds_read, mod_s.nfds * sizeof(struct pollfd));
+				if (newPtr == NULL)
+				{
+					free(mod_s.saved.fds_read);
+					mod_s.saved.fds_read = NULL;
+				}
+				else
+				{
+					mod_s.saved.fds_read = newPtr;
+				}
+			}
 			else
 				mod_s.saved.fds_read = malloc(mod_s.nfds * sizeof(struct pollfd));
 
@@ -538,7 +571,18 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 				}
 			}
 			else if (mod_s.saved.fds_write)
-				mod_s.saved.fds_write = realloc(mod_s.saved.fds_write, mod_s.nfds * sizeof(struct pollfd));
+			{
+				void* newPtr = realloc(mod_s.saved.fds_write, mod_s.nfds * sizeof(struct pollfd));
+				if (newPtr == NULL)
+				{
+					free(mod_s.saved.fds_write);
+					mod_s.saved.fds_write = NULL;
+				}
+				else
+				{
+					mod_s.saved.fds_write = newPtr;
+				}
+			}
 			else
 				mod_s.saved.fds_write = malloc(mod_s.nfds * sizeof(struct pollfd));
 		}
@@ -992,12 +1036,19 @@ int Socket_close(SOCKET socket)
 				/* shift array to remove the socket in question */
 				memmove(fd, fd + 1, (mod_s.nfds - (fd - mod_s.fds_read)) * sizeof(mod_s.fds_read[0]));
 			}
-			mod_s.fds_read = realloc(mod_s.fds_read, sizeof(mod_s.fds_read[0]) * mod_s.nfds);
-			if (mod_s.fds_read == NULL)
-			{
+	    void* newPtr = realloc(mod_s.fds_read, sizeof(mod_s.fds_read[0]) * mod_s.nfds);
+		  if (newPtr == NULL)
+		  {
+		    free(mod_s.fds_read);
+		  	mod_s.fds_read = NULL;
+
 				rc = PAHO_MEMORY_ERROR;
 				goto exit;
-			}
+		  }
+		  else
+		  {
+		    mod_s.fds_read = newPtr;
+		  }
 		}
 		Log(TRACE_MIN, -1, "Removed socket %d", socket);
 	}
@@ -1021,11 +1072,18 @@ int Socket_close(SOCKET socket)
 				/* shift array to remove the socket in question */
 				memmove(fd, fd + 1, (mod_s.nfds - (fd - mod_s.fds_write)) * sizeof(mod_s.fds_write[0]));
 			}
-			mod_s.fds_write = realloc(mod_s.fds_write, sizeof(mod_s.fds_write[0]) * mod_s.nfds);
-			if (mod_s.fds_write == NULL)
+			void* newPtr = realloc(mod_s.fds_write, sizeof(mod_s.fds_write[0]) * mod_s.nfds);
+			if (newPtr == NULL)
 			{
+				free(mod_s.fds_write);
+				mod_s.fds_write = NULL;
+
 				rc = PAHO_MEMORY_ERROR;
 				goto exit;
+			}
+			else
+			{
+				mod_s.fds_write = newPtr;
 			}
 		}
 		Log(TRACE_MIN, -1, "Removed socket %d", socket);

--- a/src/SocketBuffer.c
+++ b/src/SocketBuffer.c
@@ -207,7 +207,19 @@ char* SocketBuffer_getQueuedData(SOCKET socket, size_t bytes, size_t* actual_len
 			}
 		}
 		else
-			queue->buf = realloc(queue->buf, bytes);
+		{
+			void* newmem = realloc(queue->buf, bytes);
+			if (newmem)
+			{
+				queue->buf = newmem;
+			}
+			else
+			{
+				free(queue->buf);
+				queue->buf = NULL;
+				goto exit;
+			}
+		}
 		queue->buflen = bytes;
 	}
 exit:

--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -399,7 +399,18 @@ int WebSocket_connect( networkHandles *net, int ssl, const char *uri)
 	if (net->websocket_key == NULL)
 		net->websocket_key = malloc(25u);
 	else
-		net->websocket_key = realloc(net->websocket_key, 25u);
+	{
+		void* newPtr = realloc(net->websocket_key, 25u);
+		if (newPtr == NULL)
+		{
+			free(net->websocket_key);
+			net->websocket_key = NULL;
+		}
+		else
+		{
+			net->websocket_key = newPtr;
+		}
+	}
 	if (net->websocket_key == NULL)
 	{
 		rc = PAHO_MEMORY_ERROR;
@@ -844,7 +855,19 @@ char *WebSocket_getRawSocketData(networkHandles *net, size_t bytes, size_t* actu
 		// resize buffer
 		else
 		{
-			frame_buffer = realloc(frame_buffer, frame_buffer_data_len + *actual_len);
+			void* newPtr = realloc(frame_buffer, frame_buffer_data_len + *actual_len);
+			if (newPtr == NULL)
+			{
+				free(frame_buffer);
+				frame_buffer = NULL;
+
+				rv = NULL;
+				goto exit;
+			}
+			else
+			{
+				frame_buffer = newPtr;
+			}
 			frame_buffer_len = frame_buffer_data_len + *actual_len;
 
 			memcpy(frame_buffer + frame_buffer_data_len, rv, *actual_len);
@@ -1167,10 +1190,18 @@ int WebSocket_receiveFrame(networkHandles *net, size_t *actual_len)
 					res->pos = 0u;
 				} else
 				{
-					if ((res = realloc( res, sizeof(struct ws_frame) + cur_len + len )) == NULL)
+					void* newPtr = realloc( res, sizeof(struct ws_frame) + cur_len + len );
+					if (newPtr == NULL)
 					{
+						free(res);
+						res = NULL;
+
 						rc = PAHO_MEMORY_ERROR;
 						goto exit;
+					}
+					else
+					{
+						res = newPtr;
 					}
 				}
 				if (in_frames && in_frames->first)


### PR DESCRIPTION
When realloc returns `NULL`, the memory of the argument `ptr` remains allocated. Thus overwriting the variable that holds this argument directly with the return value would lead to memory leaks as the allocated address is overwritten with `NULL`. To fix this, the return value is buffered and checked for `NULL` before overwriting the address variable.

Signed-off-by: Harald Reif <haraldr@copadata.com>


