### PR TITLE
Fix usage of memset

### DIFF
--- a/src/Heap.c
+++ b/src/Heap.c
@@ -180,7 +180,7 @@ void* mymalloc(char* file, int line, size_t size)
 		free(s);
 		goto exit;
 	}
-	memset(s->file, 0, sizeof(filenamelen));
+	memset(s->file, 0, filenamelen);
 
 	space += filenamelen;
 	strcpy(s->file, file);
@@ -193,7 +193,7 @@ void* mymalloc(char* file, int line, size_t size)
 		free(s);
 		goto exit;
 	}
-	memset(s->stack, 0, sizeof(filenamelen));
+	memset(s->stack, 0, STACK_LEN);
 	StackTrace_get(Paho_thread_getid(), s->stack, STACK_LEN);
 #endif
 	s->line = line;


### PR DESCRIPTION
`memset` was called with `sizeof(filenamelen)` which is not the size of the allocated memory. This could result in not initializing all memory to 0 or in a write buffer overrun. The calls to `memset` have been fixed.

Signed-off-by: Harald Reif <haraldr@copadata.com>


