### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -1377,8 +1377,8 @@ int MQTTAsync_isComplete(MQTTAsync handle, MQTTAsync_token dt)
 		current = NULL;
 		while (ListNextElement(m->c->outboundMsgs, &current))
 		{
-			Messages* m = (Messages*)(current->content);
-			if (m->msgid == dt)
+			Messages* m2 = (Messages*)(current->content);
+			if (m2->msgid == dt)
 				goto exit;
 		}
 	}
@@ -1493,8 +1493,8 @@ int MQTTAsync_getPendingTokens(MQTTAsync handle, MQTTAsync_token **tokens)
 		current = NULL;
 		while (ListNextElement(m->c->outboundMsgs, &current))
 		{
-			Messages* m = (Messages*)(current->content);
-			(*tokens)[count++] = m->msgid;
+			Messages* m2 = (Messages*)(current->content);
+			(*tokens)[count++] = m2->msgid;
 		}
 	}
 	(*tokens)[count] = -1; /* indicate end of list */

--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -843,7 +843,7 @@ int MQTTAsync_addCommand(MQTTAsync_queuedCommand* command, int command_size)
 				; /* don't persist QoS0 if that create option is set to 0 */
 			else
 			{
-				int rc = MQTTAsync_persistCommand(command);
+				rc = MQTTAsync_persistCommand(command);
 				if (command->command.type == PUBLISH && rc == 0)
 				{
 					char key[PERSISTENCE_MAX_KEY_LENGTH + 1];

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1439,8 +1439,8 @@ static MQTTResponse MQTTClient_connectURIVersion(MQTTClient handle, MQTTClient_c
 
 					while (ListNextElement(m->c->outboundMsgs, &outcurrent))
 					{
-						Messages* m = (Messages*)(outcurrent->content);
-						memset(&m->lastTouch, '\0', sizeof(m->lastTouch));
+						Messages* m2 = (Messages*)(outcurrent->content);
+						memset(&m2->lastTouch, '\0', sizeof(m2->lastTouch));
 					}
 					MQTTProtocol_retry(zero, 1, 1);
 					if (m->c->connected != 1)
@@ -2933,8 +2933,8 @@ int MQTTClient_getPendingDeliveryTokens(MQTTClient handle, MQTTClient_deliveryTo
 		}
 		while (ListNextElement(m->c->outboundMsgs, &current))
 		{
-			Messages* m = (Messages*)(current->content);
-			(*tokens)[count++] = m->msgid;
+			Messages* m2 = (Messages*)(current->content);
+			(*tokens)[count++] = m2->msgid;
 		}
 		(*tokens)[count] = -1;
 	}

--- a/src/MQTTPersistence.c
+++ b/src/MQTTPersistence.c
@@ -187,7 +187,7 @@ int MQTTPersistence_restorePackets(Clients *c)
 	int rc = 0;
 	char **msgkeys = NULL,
 		 *buffer = NULL;
-	int nkeys, buflen;
+	int nkeys = 0, buflen;
 	int i = 0;
 	int msgs_sent = 0;
 	int msgs_rcvd = 0;
@@ -353,7 +353,6 @@ int MQTTPersistence_restorePackets(Clients *c)
 exit:
 	if (msgkeys)
 	{
-		int i = 0;
 		for (i = 0; i < nkeys; ++i)
 		{
 			if (msgkeys[i])

--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -1033,7 +1033,6 @@ int SSLSocket_putdatas(SSL* ssl, SOCKET socket, char* buf0, size_t buf0len, Pack
 		free(iovec.iov_base);
 	else
 	{
-		int i;
 		free(buf0);
 		for (i = 0; i < bufs.count; ++i)
 		{

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -1062,7 +1062,7 @@ int Socket_new(const char* addr, size_t addr_len, int port, SOCKET* sock)
 #endif
 	int rc = SOCKET_ERROR;
 #if defined(_WIN32) || defined(_WIN64)
-	short family;
+	short family = AF_INET;
 #else
 	sa_family_t family = AF_INET;
 #endif
@@ -1198,7 +1198,7 @@ int Socket_new(const char* addr, size_t addr_len, int port, SOCKET* sock)
 				if (rc == EINPROGRESS || rc == EWOULDBLOCK)
 				{
 					SOCKET* pnewSd = (SOCKET*)malloc(sizeof(SOCKET));
-					ListElement* result = NULL;
+					ListElement* listResult = NULL;
 
 					if (!pnewSd)
 					{
@@ -1207,9 +1207,9 @@ int Socket_new(const char* addr, size_t addr_len, int port, SOCKET* sock)
 					}
 					*pnewSd = *sock;
 					Paho_thread_lock_mutex(socket_mutex);
-					result = ListAppend(mod_s.connect_pending, pnewSd, sizeof(SOCKET));
+					listResult = ListAppend(mod_s.connect_pending, pnewSd, sizeof(SOCKET));
 					Paho_thread_unlock_mutex(socket_mutex);
-					if (!result)
+					if (!listResult)
 					{
 						free(pnewSd);
 						rc = PAHO_MEMORY_ERROR;

--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -701,8 +701,7 @@ char *WebSocket_getdata(networkHandles *net, size_t bytes, size_t* actual_len)
 		/* no current frame, so let's go receive one for the network */
 		if ( !frame )
 		{
-			const int rc =
-				WebSocket_receiveFrame( net, actual_len );
+			rc = WebSocket_receiveFrame( net, actual_len );
 
 			if ( rc == TCPSOCKET_COMPLETE && in_frames && in_frames->first)
 				frame = in_frames->first->content;
@@ -715,7 +714,7 @@ char *WebSocket_getdata(networkHandles *net, size_t bytes, size_t* actual_len)
 
 
 			while (*actual_len < bytes) {
-				const int rc = WebSocket_receiveFrame(net, actual_len);
+				rc = WebSocket_receiveFrame(net, actual_len);
 
 				if (rc != TCPSOCKET_COMPLETE) {
 					goto exit;


### PR DESCRIPTION
There are several locations where a local variable in a scope hides a local variable in a superior scope. Some were different variables: they have been renamed. Some were redefinitions of an existing variable: the redefinition has been replaced with a reuse of the existing variable. Additionally, some uninitialized memory warnings have been resolved.

Signed-off-by: Harald Reif <haraldr@copadata.com>

