### PR TITLE
Fix possible memory leak

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -2322,8 +2322,7 @@ thread_return_type WINAPI MQTTAsync_receiveThread(void* n)
 				}
 				else
 				{
-					free(pack);
-					pack = NULL;
+					Log(TRACE_MIN, -1, "An unexpected packet type %u has been received", pack->header.bits.type);
 				}
 			}
 		}

--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -2320,6 +2320,11 @@ thread_return_type WINAPI MQTTAsync_receiveThread(void* n)
 					m->c->connected = 0; /* don't send disconnect packet back */
 					nextOrClose(m, discrc, "Received disconnect");
 				}
+				else
+				{
+					free(pack);
+					pack = NULL;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
In `MQTTAsync_receiveThread`, when `pack` is not `NULL` but none of the `if`-`else if`-conditions is fulfilled, `pack` is not freed. To fix this, an `else` block has been added to cleanup the memory of `pack`.

Signed-off-by: Harald Reif <haraldr@copadata.com>

