### PR TITLE
Exporting the -static CMake targets when both shared and static libraries built.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -207,6 +207,7 @@ if(PAHO_BUILD_STATIC)
     )
   else()
     install(TARGETS paho-mqtt3c-static paho-mqtt3a-static
+      EXPORT eclipse-paho-mqtt-cTargets
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
   endif()
@@ -371,6 +372,7 @@ if(PAHO_WITH_SSL OR PAHO_WITH_LIBRESSL)
       )
     else()
       install(TARGETS paho-mqtt3cs-static paho-mqtt3as-static
+        EXPORT eclipse-paho-mqtt-cTargets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
       )
     endif()


### PR DESCRIPTION
When just the static library is built, the CMake targets are properly exported (i.e. _xxx-static_, like `eclipse-paho-mqtt-c::paho-mqtt3a-static`, etc).

But when both the shared _and_ static libraries are built, only the shared targets are exported. The static ones are not - but should be.

This fixes the issue so that the `-static` CMake targets are always exported when the static libraries are built.

This problem is causing broken builds for the Paho C++ library. See:
https://github.com/eclipse/paho.mqtt.cpp/issues/500