### PR TITLE
Zero out MQTTProperty before reading

### DIFF
--- a/src/MQTTProperties.c
+++ b/src/MQTTProperties.c
@@ -240,6 +240,7 @@ int MQTTProperty_read(MQTTProperty* prop, char** pptr, char* enddata)
   int type = -1,
     len = -1;
 
+  memset(prop, 0, sizeof(MQTTProperty));
   prop->identifier = readChar(pptr);
   type = MQTTProperty_getType(prop->identifier);
   if (type >= MQTTPROPERTY_TYPE_BYTE && type <= MQTTPROPERTY_TYPE_UTF_8_STRING_PAIR)


### PR DESCRIPTION
This is a small nit...

It would be nice to zero out the `MQTTProperty` union/value before reading fields into it. That would leave any unused space predictably set to zero.

On advantage is that if you accidentally read an 8 or 16-bit value out using a larger field size (i.e. read as a u32) you still get the correct numeric value.

(Wonder what made me think to do this).