### PR TITLE
Fix doc comment for MQTTAsync_disconnected

### DIFF
--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -438,8 +438,7 @@ typedef void MQTTAsync_connected(void* context, char* cause);
  * @param context A pointer to the <i>context</i> value originally passed to
  * MQTTAsync_setCallbacks(), which contains any application-specific context.
  * @param properties the properties in the disconnect packet.
- * @param properties the reason code from the disconnect packet
- * Currently, <i>cause</i> is always set to NULL.
+ * @param reasonCode the reason code from the disconnect packet
  */
 typedef void MQTTAsync_disconnected(void* context, MQTTProperties* properties,
 		enum MQTTReasonCodes reasonCode);


### PR DESCRIPTION
Minor fix to a doc comment, but it was causing a lot of build warnings when using clang "document warnings" `-Wdocumentation` turned on.