### PR TITLE
Fix thoretical possible memory leaks related to topic in error case

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -2320,6 +2320,10 @@ thread_return_type WINAPI MQTTAsync_receiveThread(void* n)
 					m->c->connected = 0; /* don't send disconnect packet back */
 					nextOrClose(m, discrc, "Received disconnect");
 				}
+				else
+				{
+					Log(LOG_ERROR, -1, "Unexpected packet type %d", pack->header.bits.type);
+				}
 			}
 		}
 	}

--- a/src/MQTTPacket.c
+++ b/src/MQTTPacket.c
@@ -575,6 +575,8 @@ void* MQTTPacket_publish(int MQTTVersion, unsigned char aHeader, char* data, siz
 	{
 		if (enddata - curdata < 2)  /* Is there enough data for the msgid? */
 		{
+			free(pack->topic);
+			pack->topic = NULL;
 			free(pack);
 			pack = NULL;
 			goto exit;
@@ -589,6 +591,8 @@ void* MQTTPacket_publish(int MQTTVersion, unsigned char aHeader, char* data, siz
 		pack->properties = props;
 		if (MQTTProperties_read(&pack->properties, &curdata, enddata) != 1)
 		{
+			free(pack->topic);
+			pack->topic = NULL;
 			if (pack->properties.array)
 				free(pack->properties.array);
 			if (pack)


### PR DESCRIPTION
This pull request:

- `MQTTPacket_publish()`: Release in error case the `topic` when also the `pack` structore is deleted, which hold the only pointer to `topic`
- `MQTTAsync_receiveThread()`: Add an error-log entry in case of unexpectedly not handled packages
