### PR TITLE
MacOS: fix usage of libdispatch and Availability macros in Thread

### DIFF
--- a/src/Thread.c
+++ b/src/Thread.c
@@ -98,7 +98,7 @@ int Thread_set_name(const char* thread_name)
 #endif*/
 #elif defined(OSX)
 	/* pthread_setname_np __API_AVAILABLE(macos(10.6), ios(3.2)) */
-#if defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_6
+#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
 	rc = pthread_setname_np(thread_name);
 #endif
 #else
@@ -449,7 +449,7 @@ int Thread_wait_cond(cond_type condvar, int timeout_ms)
 	interval.tv_sec = timeout_ms / 1000;
 	interval.tv_nsec = (timeout_ms % 1000) * 1000000L;
 
-#if defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 /* for older versions of MacOS */
+#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED < 101200 /* for older versions of MacOS */
 	struct timeval cur_time;
     gettimeofday(&cur_time, NULL);
     cond_timeout.tv_sec = cur_time.tv_sec;

--- a/src/Thread.c
+++ b/src/Thread.c
@@ -234,7 +234,7 @@ sem_type Thread_create_sem(int *rc)
 		        NULL                /* object name */
 		        );
 		*rc = (sem == NULL) ? GetLastError() : 0;
-	#elif defined(OSX)
+	#elif defined(OSX) && defined(HAS_DISPATCH)
 		sem = dispatch_semaphore_create(0L);
 		*rc = (sem == NULL) ? -1 : 0;
 	#else
@@ -259,7 +259,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
  * so I've used trywait in a loop instead. Ian Craggs 23/7/2010
  */
 	int rc = -1;
-#if !defined(_WIN32) && !defined(_WIN64) && !defined(OSX)
+#if !defined(_WIN32) && !defined(_WIN64) && !(defined(OSX) && defined(HAS_DISPATCH))
 #define USE_TRYWAIT
 #if defined(USE_TRYWAIT)
 	int i = 0;
@@ -276,7 +276,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
 		rc = WaitForSingleObject(sem, timeout < 0 ? 0 : timeout);
 		if (rc == WAIT_TIMEOUT)
 			rc = ETIMEDOUT;
-	#elif defined(OSX)
+	#elif defined(OSX) && defined(HAS_DISPATCH)
 		/* returns 0 on success, non-zero if timeout occurred */
 		rc = (int)dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeout*1000000L));
 		if (rc != 0)
@@ -320,7 +320,7 @@ int Thread_check_sem(sem_type sem)
 #if defined(_WIN32) || defined(_WIN64)
 	/* if the return value is not 0, the semaphore will not have been decremented */
 	return WaitForSingleObject(sem, 0) == WAIT_OBJECT_0;
-#elif defined(OSX)
+#elif defined(OSX) && defined(HAS_DISPATCH)
 	/* if the return value is not 0, the semaphore will not have been decremented */
 	return dispatch_semaphore_wait(sem, DISPATCH_TIME_NOW) == 0;
 #else
@@ -344,7 +344,7 @@ int Thread_post_sem(sem_type sem)
 	#if defined(_WIN32) || defined(_WIN64)
 		if (SetEvent(sem) == 0)
 			rc = GetLastError();
-	#elif defined(OSX)
+	#elif defined(OSX) && defined(HAS_DISPATCH)
 		rc = (int)dispatch_semaphore_signal(sem);
 	#else
 		int val;
@@ -371,7 +371,7 @@ int Thread_destroy_sem(sem_type sem)
 	FUNC_ENTRY;
 	#if defined(_WIN32) || defined(_WIN64)
 		rc = CloseHandle(sem);
-	#elif defined(OSX)
+	#elif defined(OSX) && defined(HAS_DISPATCH)
 	  dispatch_release(sem);
 	#else
 		rc = sem_destroy(sem);

--- a/src/Thread.h
+++ b/src/Thread.h
@@ -29,6 +29,13 @@
 #endif
 #endif
 
+#ifdef __APPLE__
+	#include <AvailabilityMacros.h>
+	#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 && !defined(__ppc__)
+	  #define HAS_DISPATCH
+	#endif
+#endif
+
 #include "MQTTExportDeclarations.h"
 
 #include "MQTTClient.h"
@@ -54,7 +61,7 @@
 	typedef thread_return_type (*thread_fn)(void*);
 	typedef struct { pthread_cond_t cond; pthread_mutex_t mutex; } cond_type_struct;
 	typedef cond_type_struct *cond_type;
-	#if defined(OSX)
+	#if defined(OSX) && defined(HAS_DISPATCH)
 	  #include <dispatch/dispatch.h>
 	  typedef dispatch_semaphore_t sem_type;
 	#else


### PR DESCRIPTION
1. Fix usage of Availability macros: they should not be prefixed with underscores (those are used by internal headers, unprefixed work correctly always).
2. Do not assume `libdispatch` is always available, that is not the case. Use it where it actually exists.