### PR TITLE
Small cleanup of OpenSSL/LibreSSL CMake (2nd try)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ project("Eclipse Paho C"
 message(STATUS "CMake version: " ${CMAKE_VERSION})
 message(STATUS "CMake system name: " ${CMAKE_SYSTEM_NAME})
 
-set(CMAKE_SCRIPTS "${CMAKE_SOURCE_DIR}/cmake")
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+set(CMAKE_SCRIPTS "${PROJECT_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
 
 ## Project Version
 ## Previously we read in the version from these files, but now we use the 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,20 +230,15 @@ install(
 
 if(PAHO_WITH_SSL OR PAHO_WITH_LIBRESSL)
   if(PAHO_WITH_LIBRESSL)
-    set(LIBRESSL_ROOT_DIR "" CACHE PATH "Directory containing LibreSSL libraries and includes")
     find_package(LibreSSL REQUIRED)
-    set(SSL_INCLUDE_DIR ${LIBRESSL_INCLUDE_DIR} CACHE PATH "Directory containing SSL includes")
-    set(SSL_LIBRARY_NAME LibreSSL CACHE STRING "Name of the used SSL library")
-    set(SSL_ROOT_DIR ${LIBRESSL_ROOT_DIR} CACHE PATH "Directory containing SSL libraries and includes")
+    set(SSL_LIBRARY_NAME LibreSSL)
+    message(STATUS "Using LibreSSL with headers at ${LIBRESSL_INCLUDE_DIR}, lib ${LIBRESSL_SSL_LIBRARY}")
   else()
-    set(OPENSSL_ROOT_DIR "" CACHE PATH "Directory containing OpenSSL libraries and includes")
     find_package(OpenSSL REQUIRED)
-    set(SSL_INCLUDE_DIR ${OPENSSL_INCLUDE_DIR} CACHE PATH "Directory containing SSL includes")
-    set(SSL_LIBRARY_NAME OpenSSL CACHE STRING "Name of the used SSL library")
-    set(SSL_ROOT_DIR ${OPENSSL_ROOT_DIR} CACHE PATH "Directory containing SSL libraries and includes")
+    set(SSL_LIBRARY_NAME OpenSSL)
+    message(STATUS "Using OpenSSL with headers at ${OPENSSL_INCLUDE_DIR}, lib ${OPENSSL_SSL_LIBRARY}")
   endif()
-  message("Use ${SSL_LIBRARY_NAME} at ${SSL_ROOT_DIR}")
-  message("SSL_INCLUDE_DIR: ${SSL_INCLUDE_DIR} ${LIBRESSL_SSL_LIBRARY} ${LIBRESSL_CRYPTO_LIBRARY}")
+
 
   if(PAHO_BUILD_SHARED)
     ## common compilation for libpaho-mqtt3cs and libpaho-mqtt3as

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -232,13 +232,15 @@ if(PAHO_WITH_SSL OR PAHO_WITH_LIBRESSL)
   if(PAHO_WITH_LIBRESSL)
     find_package(LibreSSL REQUIRED)
     set(SSL_LIBRARY_NAME LibreSSL)
-    message(STATUS "Using LibreSSL with headers at ${LIBRESSL_INCLUDE_DIR}, lib ${LIBRESSL_SSL_LIBRARY}")
+    set(SSL_INCLUDE_DIR ${LIBRESSL_INCLUDE_DIR})
+    set(SSL_ROOT_DIR ${LIBRESSL_ROOT_DIR})
   else()
     find_package(OpenSSL REQUIRED)
     set(SSL_LIBRARY_NAME OpenSSL)
-    message(STATUS "Using OpenSSL with headers at ${OPENSSL_INCLUDE_DIR}, lib ${OPENSSL_SSL_LIBRARY}")
+    set(SSL_INCLUDE_DIR ${OPENSSL_INCLUDE_DIR})
+    set(SSL_ROOT_DIR ${OPENSSL_ROOT_DIR})
   endif()
-
+  message(STATUS "Using ${SSL_LIBRARY_NAME} with headers at ${SSL_INCLUDE_DIR}")
 
   if(PAHO_BUILD_SHARED)
     ## common compilation for libpaho-mqtt3cs and libpaho-mqtt3as


### PR DESCRIPTION
Second attempt for PR #1504 

This implements the fix for the SSL CMake issue I commented on in https://github.com/eclipse-paho/paho.mqtt.c/pull/1451, https://github.com/eclipse/paho.mqtt.c/pull/1451#issuecomment-2240902289

But perhaps more importantly, it also fixes the absolute path for `CMAKE_SCRIPTS` and `CMAKE_MODULE_PATH` allowing the project to be used as a subdirectory/submodule from other projects like the Paho C++ library.
