### PR TITLE
Add support for Unix sockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,14 @@ option(PAHO_ENABLE_CPACK "Enable CPack" TRUE)
 option(PAHO_HIGH_PERFORMANCE "Disable tracing and heap tracking" FALSE)
 option(PAHO_USE_SELECT "Revert to select system call instead of poll" FALSE)
 
+if(NOT WIN32)
+    option(PAHO_WITH_UNIX_SOCKETS "Flag that defines whether to enable Unix-domain sockets" FALSE)
+
+    if(PAHO_WITH_UNIX_SOCKETS)
+      add_definitions(-DUNIXSOCK=1)
+    endif()
+endif()
+
 if(PAHO_HIGH_PERFORMANCE)
   add_definitions(-DHIGH_PERFORMANCE=1)
 endif()

--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ Some potentially useful blog posts:
 
 [Various MQTT and MQTT-SN talks I've given.](https://modelbasedtesting.co.uk/talks-ive-given/)
 
+### Supported Network Protocols
+
+The library supports connecting to an MQTT server using TCP, SSL/TLS, Unix-domain sockets, and websockets (secure and insecure). This is chosen by the client using the URI supplied in the connect options. It can be specified as:
+
+    "mqtt://<host>:<port>"         - TCP, unsecure
+     "tcp://<host>:<port>"           (same)
+
+    "mqtts://<host>:<port>"        - SSL/TLS
+     "ssl://<host>:<port>"           (same)
+
+    "unix:///path/to/socket        - UNIX-domain socket (*nix systems only)
+
+    "ws://<host>:<port>[/path]"    - Websockets, unsecure
+    "wss://<host>:<port>[/path]"   - Websockets, secure
+
+The "mqtt://" and "tcp://" schemas are identical. They indicate an insecure connection over TCP. The "mqtt://" variation is new for the library, but becoming more common across different MQTT libraries.
+
+Similarly, the "mqtts://" and "ssl://" schemas are identical. They specify a secure connection over SSL/TLS sockets. The use any of the secure connect options requires that you compile the library with the `PAHO_WITH_SSL=TRUE` CMake option to include OpenSSL. In addition, you _must_ specify `ssl_options` when you connect to the broker - i.e. you must add an instance of `ssl_options` to the `connect_options` when calling `connect()`.
+
+The use of Unix-domain sockets requires the build option of `PAHO_WITH_UNIX_SOCKETS=TRUE` is required. This is only available on *nix-style systems like Linux and macOS. It is not vailable on Windows.
+
 ## Runtime tracing
 
 A number of environment variables control runtime tracing of the C library.
@@ -161,10 +182,11 @@ Variable | Default Value | Description
 PAHO_BUILD_SHARED | TRUE | Build a shared version of the libraries
 PAHO_BUILD_STATIC | FALSE | Build a static version of the libraries
 PAHO_HIGH_PERFORMANCE | FALSE | When set to true, the debugging aids internal tracing and heap tracking are not included.
-PAHO_WITH_SSL | FALSE | Flag that defines whether to build ssl-enabled binaries too. 
+PAHO_WITH_SSL | FALSE | Flag that defines whether to build ssl-enabled binaries too.
 OPENSSL_ROOT_DIR | "" (system default) | Directory containing your OpenSSL installation (i.e. `/usr/local` when headers are in `/usr/local/include` and libraries are in `/usr/local/lib`)
 PAHO_WITH_LIBRESSL | FALSE | Flag that defines whether to build ssl-enabled binaries with LibreSSL instead of OpenSSL.  
 LIBRESSL_ROOT_DIR | "" (system default) | Directory containing your LibreSSL installation (i.e. `/usr/local` when headers are in `/usr/local/include` and libraries are in `/usr/local/lib`)
+PAHO_WITH_UNIX_SOCKETS | FALSE | (*nix systems only) Flag to enable support for UNIX-domain sockets
 PAHO_BUILD_DOCUMENTATION | FALSE | Create and install the HTML based API documentation (requires Doxygen)
 PAHO_BUILD_SAMPLES | FALSE | Build sample programs
 PAHO_ENABLE_TESTING | TRUE | Build test and run

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -329,6 +329,9 @@ int MQTTAsync_createWithOptions(MQTTAsync* handle, const char* serverURI, const 
 	{
 		if (strncmp(URI_TCP, serverURI, strlen(URI_TCP)) != 0
 		 && strncmp(URI_MQTT, serverURI, strlen(URI_MQTT)) != 0
+#if defined(UNIXSOCK)
+		 && strncmp(URI_UNIX, serverURI, strlen(URI_UNIX)) != 0
+#endif
 		 && strncmp(URI_WS, serverURI, strlen(URI_WS)) != 0
 #if defined(OPENSSL)
 		 && strncmp(URI_SSL, serverURI, strlen(URI_SSL)) != 0
@@ -384,6 +387,13 @@ int MQTTAsync_createWithOptions(MQTTAsync* handle, const char* serverURI, const 
 		serverURI += strlen(URI_TCP);
 	else if (strncmp(URI_MQTT, serverURI, strlen(URI_MQTT)) == 0)
 		serverURI += strlen(URI_MQTT);
+#if defined(UNIXSOCK)
+	else if (strncmp(URI_UNIX, serverURI, strlen(URI_UNIX)) == 0)
+	{
+		serverURI += strlen(URI_UNIX);
+		m->unixsock = 1;
+	}
+#endif
 	else if (strncmp(URI_WS, serverURI, strlen(URI_WS)) == 0)
 	{
 		serverURI += strlen(URI_WS);

--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -1390,6 +1390,13 @@ static int MQTTAsync_processCommand(void)
 						serverURI += strlen(URI_TCP);
 					else if (strncmp(URI_MQTT, serverURI, strlen(URI_MQTT)) == 0)
 						serverURI += strlen(URI_MQTT);
+#if defined(UNIXSOCK)
+					else if (strncmp(URI_UNIX, serverURI, strlen(URI_UNIX)) == 0)
+					{
+						serverURI += strlen(URI_UNIX);
+						command->client->unixsock = 1;
+					}
+#endif
 					else if (strncmp(URI_WS, serverURI, strlen(URI_WS)) == 0)
 					{
 						serverURI += strlen(URI_WS);
@@ -1429,18 +1436,18 @@ static int MQTTAsync_processCommand(void)
 			Log(TRACE_PROTOCOL, -1, "Connecting to serverURI %s with MQTT version %d", serverURI, command->command.details.conn.MQTTVersion);
 #if defined(OPENSSL)
 #if defined(__GNUC__) && defined(__linux__)
-			rc = MQTTProtocol_connect(serverURI, command->client->c, command->client->ssl, command->client->websocket,
+			rc = MQTTProtocol_connect(serverURI, command->client->c, command->client->unixsock, command->client->ssl, command->client->websocket,
 					command->command.details.conn.MQTTVersion, command->client->connectProps, command->client->willProps, 100);
 #else
-			rc = MQTTProtocol_connect(serverURI, command->client->c, command->client->ssl, command->client->websocket,
+			rc = MQTTProtocol_connect(serverURI, command->client->c, command->client->unixsock, command->client->ssl, command->client->websocket,
 					command->command.details.conn.MQTTVersion, command->client->connectProps, command->client->willProps);
 #endif
 #else
 #if defined(__GNUC__) && defined(__linux__)
-			rc = MQTTProtocol_connect(serverURI, command->client->c, command->client->websocket,
+			rc = MQTTProtocol_connect(serverURI, command->client->c, command->client->unixsock, command->client->websocket,
 					command->command.details.conn.MQTTVersion, command->client->connectProps, command->client->willProps, 100);
 #else
-			rc = MQTTProtocol_connect(serverURI, command->client->c, command->client->websocket,
+			rc = MQTTProtocol_connect(serverURI, command->client->c, command->client->unixsock, command->client->websocket,
 					command->command.details.conn.MQTTVersion, command->client->connectProps, command->client->willProps);
 #endif
 #endif

--- a/src/MQTTAsyncUtils.h
+++ b/src/MQTTAsyncUtils.h
@@ -24,6 +24,7 @@
 #define URI_MQTT "mqtt://"
 #define URI_WS   "ws://"
 #define URI_WSS  "wss://"
+#define URI_UNIX "unix://"
 
 enum MQTTAsync_threadStates
 {
@@ -89,6 +90,7 @@ typedef struct
 typedef struct MQTTAsync_struct
 {
 	char* serverURI;
+	int unixsock;
 	int ssl;
 	int websocket;
 	Clients* c;

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -80,6 +80,7 @@
 #define URI_MQTT "mqtt://"
 #define URI_WS   "ws://"
 #define URI_WSS  "wss://"
+#define URI_UNIX "unix://"
 
 #include "VersionInfo.h"
 #include "WebSocket.h"
@@ -294,6 +295,7 @@ typedef struct
 {
 	char* serverURI;
 	const char* currentServerURI; /* when using HA options, set the currently used serverURI */
+	int unixsock;
 #if defined(OPENSSL)
 	int ssl;
 #endif
@@ -407,6 +409,9 @@ int MQTTClient_createWithOptions(MQTTClient* handle, const char* serverURI, cons
          && strncmp(URI_MQTTS, serverURI, strlen(URI_MQTTS)) != 0
 		 && strncmp(URI_WSS, serverURI, strlen(URI_WSS)) != 0
 #endif
+#if defined(UNIXSOCK)
+		 && strncmp(URI_UNIX, serverURI, strlen(URI_UNIX)) != 0
+#endif
 			)
 		{
 			rc = MQTTCLIENT_BAD_PROTOCOL;
@@ -486,6 +491,13 @@ int MQTTClient_createWithOptions(MQTTClient* handle, const char* serverURI, cons
 		goto exit;
 #endif
 	}
+#if defined(UNIXSOCK)
+	else if (strncmp(URI_UNIX, serverURI, strlen(URI_UNIX)) == 0)
+	{
+		serverURI += strlen(URI_UNIX);
+		m->unixsock = 1;
+	}
+#endif
 	m->serverURI = MQTTStrdup(serverURI);
 	ListAppend(handles, m, sizeof(MQTTClients));
 
@@ -1238,17 +1250,17 @@ static MQTTResponse MQTTClient_connectURIVersion(MQTTClient handle, MQTTClient_c
 	Log(TRACE_MIN, -1, "Connecting to serverURI %s with MQTT version %d", serverURI, MQTTVersion);
 #if defined(OPENSSL)
 #if defined(__GNUC__) && defined(__linux__)
-	rc = MQTTProtocol_connect(serverURI, m->c, m->ssl, m->websocket, MQTTVersion, connectProperties, willProperties,
+	rc = MQTTProtocol_connect(serverURI, m->c, m->unixsock, m->ssl, m->websocket, MQTTVersion, connectProperties, willProperties,
 			millisecsTimeout - MQTTTime_elapsed(start));
 #else
-	rc = MQTTProtocol_connect(serverURI, m->c, m->ssl, m->websocket, MQTTVersion, connectProperties, willProperties);
+	rc = MQTTProtocol_connect(serverURI, m->c, m->unixsock, m->ssl, m->websocket, MQTTVersion, connectProperties, willProperties);
 #endif
 #else
 #if defined(__GNUC__) && defined(__linux__)
-	rc = MQTTProtocol_connect(serverURI, m->c, m->websocket, MQTTVersion, connectProperties, willProperties,
+	rc = MQTTProtocol_connect(serverURI, m->c, m->unixsock, m->websocket, MQTTVersion, connectProperties, willProperties,
 			millisecsTimeout - MQTTTime_elapsed(start));
 #else
-	rc = MQTTProtocol_connect(serverURI, m->c, m->websocket, MQTTVersion, connectProperties, willProperties);
+	rc = MQTTProtocol_connect(serverURI, m->c, m->unixsock, m->websocket, MQTTVersion, connectProperties, willProperties);
 #endif
 #endif
 	if (rc == SOCKET_ERROR)
@@ -1899,6 +1911,13 @@ MQTTResponse MQTTClient_connectAll(MQTTClient handle, MQTTClient_connectOptions*
 				serverURI += strlen(URI_WSS);
 				m->ssl = 1;
 				m->websocket = 1;
+			}
+#endif
+#if defined(UNIXSOCK)
+			else if (strncmp(URI_UNIX, serverURI, strlen(URI_UNIX)) == 0)
+			{
+				serverURI += strlen(URI_UNIX);
+				m->unixsock = 1;
 			}
 #endif
 			rc = MQTTClient_connectURI(handle, options, serverURI, connectProperties, willProperties);

--- a/src/MQTTProtocolOut.h
+++ b/src/MQTTProtocolOut.h
@@ -40,18 +40,18 @@ size_t MQTTProtocol_addressPort(const char* uri, int* port, const char **topic, 
 void MQTTProtocol_reconnect(const char* ip_address, Clients* client);
 #if defined(OPENSSL)
 #if defined(__GNUC__) && defined(__linux__)
-int MQTTProtocol_connect(const char* ip_address, Clients* acClients, int ssl, int websocket, int MQTTVersion,
+int MQTTProtocol_connect(const char* ip_address, Clients* acClients, int unixsock, int ssl, int websocket, int MQTTVersion,
 		MQTTProperties* connectProperties, MQTTProperties* willProperties, long timeout);
 #else
-int MQTTProtocol_connect(const char* ip_address, Clients* acClients, int ssl, int websocket, int MQTTVersion,
+int MQTTProtocol_connect(const char* ip_address, Clients* acClients, int unixsock, int ssl, int websocket, int MQTTVersion,
 		MQTTProperties* connectProperties, MQTTProperties* willProperties);
 #endif
 #else
 #if defined(__GNUC__) && defined(__linux__)
-int MQTTProtocol_connect(const char* ip_address, Clients* acClients, int websocket, int MQTTVersion,
+int MQTTProtocol_connect(const char* ip_address, Clients* acClients, int unixsock, int websocket, int MQTTVersion,
 		MQTTProperties* connectProperties, MQTTProperties* willProperties, long timeout);
 #else
-int MQTTProtocol_connect(const char* ip_address, Clients* acClients, int websocket, int MQTTVersion,
+int MQTTProtocol_connect(const char* ip_address, Clients* acClients, int unixsock, int websocket, int MQTTVersion,
 		MQTTProperties* connectProperties, MQTTProperties* willProperties);
 #endif
 #endif

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -47,6 +47,10 @@
 
 #include "Heap.h"
 
+#if defined(UNIXSOCK)
+#include <sys/un.h>
+#endif
+
 #if defined(USE_SELECT)
 int isReady(int socket, fd_set* read_set, fd_set* write_set);
 int Socket_continueWrites(fd_set* pwset, SOCKET* socket, mutex_type mutex);
@@ -1114,6 +1118,7 @@ exit:
 /**
  *  Create a new socket and TCP connect to an address/port
  *  @param addr the address string
+ *  @param assr_len the length of the address string
  *  @param port the TCP port
  *  @param sock returns the new socket
  *  @param timeout the timeout in milliseconds
@@ -1276,14 +1281,14 @@ int Socket_new(const char* addr, size_t addr_len, int port, SOCKET* sock)
 	return codes from send, for testing only!
 */
 #if defined(SMALL_TCP_BUFFER_TESTING)
-        if (1)
-				{
-					int optsend = 100; //2 * 1440;
-					printf("Setting optsend to %d\n", optsend);
-					if (setsockopt(*sock, SOL_SOCKET, SO_SNDBUF, (void*)&optsend, sizeof(optsend)) != 0)
-						Log(LOG_ERROR, -1, "Could not set SO_SNDBUF for socket %d", *sock);
-				}
-	#endif
+			if (1)
+			{
+				int optsend = 100; //2 * 1440;
+				printf("Setting optsend to %d\n", optsend);
+				if (setsockopt(*sock, SOL_SOCKET, SO_SNDBUF, (void*)&optsend, sizeof(optsend)) != 0)
+					Log(LOG_ERROR, -1, "Could not set SO_SNDBUF for socket %d", *sock);
+			}
+#endif
 			if (interface_name)
 			{
 				rc = Socket_setInterface(*sock, interface_name, interface_family);
@@ -1355,6 +1360,58 @@ exit:
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
+
+#if defined(UNIXSOCK)
+/**
+ *  Create a new socket and TCP connect to an address/port
+ *  @param addr the address string, which is a file path
+ *  @param assr_len the length of the address string
+ *  @param sock returns the new socket
+ *  @return completion code 0=good, SOCKET_ERROR=fail
+ */
+int Socket_unix_new(const char* addr, size_t addr_len, SOCKET* sock)
+{
+	struct sockaddr_un address;
+	int rc = SOCKET_ERROR;
+
+	FUNC_ENTRY;
+
+	if (addr_len >= sizeof(address.sun_path)) {
+		rc = PAHO_MEMORY_ERROR;
+	}
+	else {
+		address.sun_family = AF_UNIX;
+		memcpy(&address.sun_path, addr, addr_len);
+		address.sun_path[addr_len] = '\0';
+
+		*sock =	socket(AF_UNIX, SOCK_STREAM, 0);
+		if (*sock == INVALID_SOCKET)
+			rc = Socket_error("socket", *sock);
+		else
+		{
+#if defined(NOSIGPIPE)
+			int opt = 1;
+			if (setsockopt(*sock, SOL_SOCKET, SO_NOSIGPIPE, (void*)&opt, sizeof(opt)) != 0)
+				Log(LOG_ERROR, -1, "Could not set SO_NOSIGPIPE for socket %d", *sock);
+#endif
+			Log(TRACE_MIN, -1, "New UNIX socket %d for %s",	*sock, addr);
+			if (Socket_addSocket(*sock) == SOCKET_ERROR)
+				rc = Socket_error("addSocket", *sock);
+			else
+			{
+				/* this will complete immediately, even though we are non-blocking */
+				rc = connect(*sock, (struct sockaddr*)&address, sizeof(address));
+				if (rc == SOCKET_ERROR)
+					rc = Socket_error("connect", *sock);
+			}
+		}
+	}
+
+exit:
+	FUNC_EXIT_RC(rc);
+	return rc;
+}
+#endif
 
 static Socket_writeContinue* writecontinue = NULL;
 

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -167,6 +167,7 @@ int Socket_new(const char* addr, size_t addr_len, int port, SOCKET* socket, long
 #else
 int Socket_new(const char* addr, size_t addr_len, int port, SOCKET* socket);
 #endif
+int Socket_unix_new(const char* addr, size_t addr_len, SOCKET* sock);
 
 int Socket_noPendingWrites(SOCKET socket);
 char* Socket_getpeer(SOCKET sock);

--- a/src/samples/MQTTAsync_publish.c
+++ b/src/samples/MQTTAsync_publish.c
@@ -146,7 +146,10 @@ int main(int argc, char* argv[])
 	MQTTAsync_connectOptions conn_opts = MQTTAsync_connectOptions_initializer;
 	int rc;
 
-	if ((rc = MQTTAsync_create(&client, ADDRESS, CLIENTID, MQTTCLIENT_PERSISTENCE_NONE, NULL)) != MQTTASYNC_SUCCESS)
+	const char* uri = (argc > 1) ? argv[1] : ADDRESS;
+	printf("Using server at %s\n", uri);
+
+	if ((rc = MQTTAsync_create(&client, uri, CLIENTID, MQTTCLIENT_PERSISTENCE_NONE, NULL)) != MQTTASYNC_SUCCESS)
 	{
 		printf("Failed to create client object, return code %d\n", rc);
 		exit(EXIT_FAILURE);

--- a/src/samples/MQTTAsync_subscribe.c
+++ b/src/samples/MQTTAsync_subscribe.c
@@ -137,7 +137,10 @@ int main(int argc, char* argv[])
 	int rc;
 	int ch;
 
-	if ((rc = MQTTAsync_create(&client, ADDRESS, CLIENTID, MQTTCLIENT_PERSISTENCE_NONE, NULL))
+	const char* uri = (argc > 1) ? argv[1] : ADDRESS;
+	printf("Using server at %s\n", uri);
+
+	if ((rc = MQTTAsync_create(&client, uri, CLIENTID, MQTTCLIENT_PERSISTENCE_NONE, NULL))
 			!= MQTTASYNC_SUCCESS)
 	{
 		printf("Failed to create client, return code %d\n", rc);

--- a/src/samples/MQTTClient_publish.c
+++ b/src/samples/MQTTClient_publish.c
@@ -34,7 +34,10 @@ int main(int argc, char* argv[])
     MQTTClient_deliveryToken token;
     int rc;
 
-    if ((rc = MQTTClient_create(&client, ADDRESS, CLIENTID,
+    const char* uri = (argc > 1) ? argv[1] : ADDRESS;
+    printf("Using server at %s\n", uri);
+
+    if ((rc = MQTTClient_create(&client, uri, CLIENTID,
         MQTTCLIENT_PERSISTENCE_NONE, NULL)) != MQTTCLIENT_SUCCESS)
     {
          printf("Failed to create client, return code %d\n", rc);

--- a/src/samples/MQTTClient_publish_async.c
+++ b/src/samples/MQTTClient_publish_async.c
@@ -65,7 +65,10 @@ int main(int argc, char* argv[])
     MQTTClient_deliveryToken token;
     int rc;
 
-    if ((rc = MQTTClient_create(&client, ADDRESS, CLIENTID,
+    const char* uri = (argc > 1) ? argv[1] : ADDRESS;
+    printf("Using server at %s\n", uri);
+
+    if ((rc = MQTTClient_create(&client, uri, CLIENTID,
         MQTTCLIENT_PERSISTENCE_NONE, NULL)) != MQTTCLIENT_SUCCESS)
     {
         printf("Failed to create client, return code %d\n", rc);

--- a/src/samples/MQTTClient_subscribe.c
+++ b/src/samples/MQTTClient_subscribe.c
@@ -57,7 +57,10 @@ int main(int argc, char* argv[])
     MQTTClient_connectOptions conn_opts = MQTTClient_connectOptions_initializer;
     int rc;
 
-    if ((rc = MQTTClient_create(&client, ADDRESS, CLIENTID,
+    const char* uri = (argc > 1) ? argv[1] : ADDRESS;
+    printf("Using server at %s\n", uri);
+
+    if ((rc = MQTTClient_create(&client, uri, CLIENTID,
         MQTTCLIENT_PERSISTENCE_NONE, NULL)) != MQTTCLIENT_SUCCESS)
     {
         printf("Failed to create client, return code %d\n", rc);


### PR DESCRIPTION
Adds support for UNIX-domain sockets on *nix platforms.
It implements issue #864.

This allows clients to communicate with an MQTT server over UNIX-domain sockets on *nix systems. (Not on Windows). This is opt-in with a CMake build option, `PAHO_WITH_UNIX_SOCKETS`.

This can increase performance and reduce latency since UNIX sockets have a much simpler network stack than TCP. But perhaps more importantly, it provides increased security with more fine-grained control when clients reside on the same host as the broker. Access to the broker can be done using file permissions (with groups, owners, etc).

The clients can request a socket of this type using a URI of `unix:///path/to/socket/file`. The socket file is created by the server when it binds and listens on the UNIX socket.

The implementation here is fairly trivial. The library must now recognize the `unix://` scheme in the URI, then create and connect to a socket using a *sockaddr_un* socket address containing the path to the socket file.

After that all communications and closing the socket are handled by the same code that manages TCP connections. A socket is a socket.

This was tested on Linux and macOS with the _mosquitto_ server. By definition it requires a broker running on the same host whereby it communicates with the clients using the local file system.

The mosquitto configuration file can be as simple as:
```
allow_anonymous true    
listener 0 /tmp/mosquitto.sock
```

This PR also updates several of the simple sample apps to take a URI at the command line, allowing them to be used to try this out, like:
```
MQTTAsync_publish unix:///tmp/mosquitto.sock
```
