### PR TITLE
add support for SSL key logging

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -816,6 +816,12 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 				m->c->sslopts->protos = (const unsigned char*)MQTTStrdup((const char*)options->ssl->protos);
 			m->c->sslopts->protos_len = options->ssl->protos_len;
 		}
+
+		if (options->ssl->ssl_keylog_cb)
+		{
+			m->c->sslopts->ssl_keylog_cb = options->ssl->ssl_keylog_cb;
+			m->c->sslopts->ssl_keylog_context = options->ssl->ssl_keylog_context;
+		}
 	}
 #else
 	if (options->struct_version != 0 && options->ssl)

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -1072,12 +1072,13 @@ typedef struct
 	/** The eyecatcher for this structure.  Must be MQTS */
 	char struct_id[4];
 
-	/** The version number of this structure. Must be 0, 1, 2, 3, 4 or 5.
+	/** The version number of this structure. Must be 0, 1, 2, 3, 4, 5 or 6.
 	 * 0 means no sslVersion
 	 * 1 means no verify, CApath
 	 * 2 means no ssl_error_context, ssl_error_cb
 	 * 3 means no ssl_psk_cb, ssl_psk_context, disableDefaultTrustStore
 	 * 4 means no protos, protos_len
+	 * 5 means no ssl_keylog_context or ssl_keylog_cb
 	 */
 	int struct_version;
 
@@ -1176,9 +1177,23 @@ typedef struct
 	 * Exists only if struct_version >= 5
 	 */
 	unsigned int protos_len;
+
+	/**
+	 * Callback function for handling the SSL keylogs.
+	 * line: the SSL keylog line.
+	 * ctx: pointer to context data set to ssl_keylog_context by the application.
+	 * Exists only if struct_version >= 6
+	 */
+	void (*ssl_keylog_cb) (const char *line, void *ctx);
+
+	/**
+	 * Application-specific contex for ssl_keylog_cb
+	 * Exists only if struct_version >= 6
+	 */
+	void* ssl_keylog_context;
 } MQTTAsync_SSLOptions;
 
-#define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 5, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0 }
+#define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 5, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, NULL, NULL }
 
 /** Utility structure where name/value pairs are needed */
 typedef struct

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1678,6 +1678,12 @@ static MQTTResponse MQTTClient_connectURI(MQTTClient handle, MQTTClient_connectO
 		    m->c->sslopts->protos = options->ssl->protos;
 		    m->c->sslopts->protos_len = options->ssl->protos_len;
 		}
+
+		if (options->ssl->ssl_keylog_cb)
+		{
+			m->c->sslopts->ssl_keylog_cb = options->ssl->ssl_keylog_cb;
+			m->c->sslopts->ssl_keylog_context = options->ssl->ssl_keylog_context;
+		}
 	}
 #endif
 

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -677,12 +677,13 @@ typedef struct
 	/** The eyecatcher for this structure.  Must be MQTS */
 	char struct_id[4];
 
-	/** The version number of this structure. Must be 0, 1, 2, 3, 4 or 5.
+	/** The version number of this structure. Must be 0, 1, 2, 3, 4, 5 or 6.
 	 * 0 means no sslVersion
 	 * 1 means no verify, CApath
 	 * 2 means no ssl_error_context, ssl_error_cb
 	 * 3 means no ssl_psk_cb, ssl_psk_context, disableDefaultTrustStore
 	 * 4 means no protos, protos_len
+	 * 5 means no ssl_keylog_context or ssl_keylog_cb
 	 */
 	int struct_version;
 
@@ -781,9 +782,23 @@ typedef struct
 	 * Exists only if struct_version >= 5
 	 */
 	unsigned int protos_len;
+
+	/**
+	 * Callback function for handling the SSL keylogs.
+	 * line: the SSL keylog line.
+	 * ctx: pointer to context data set to ssl_keylog_context by the application.
+	 * Exists only if struct_version >= 6
+	 */
+	void (*ssl_keylog_cb) (const char *line, void *ctx);
+
+	/**
+	 * Application-specific contex for ssl_keylog_cb
+	 * Exists only if struct_version >= 6
+	 */
+	void* ssl_keylog_context;
 } MQTTClient_SSLOptions;
 
-#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 5, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0 }
+#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 5, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, NULL, NULL }
 
 /**
   * MQTTClient_libraryInfo is used to store details relating to the currently used


### PR DESCRIPTION
- SSL keys are generated in the SSL/TLS handshake. they can be used to
  decrypt the packets for analysis by tools like wireshark.
- add support for the SSLKEYLOGFILE environment variable
- add support for a custom callback function to handle the keys.
- the callback can be used to encrypt the SSL key logs for confidentiality.
- apps can disable the SSLKEYLOGFILE env - for security reasons - by just
  setting the callback.