### PR TITLE
Build all the sample applications for the static library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.swp
 *.pyc
 /build.paho
+.vscode/

--- a/src/samples/CMakeLists.txt
+++ b/src/samples/CMakeLists.txt
@@ -53,24 +53,29 @@ if(PAHO_BUILD_SHARED)
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
-
   endif()
 
-  foreach(TARGET MQTTAsync_subscribe MQTTAsync_publish MQTTAsync_publish_time
-      MQTTClient_subscribe MQTTClient_publish MQTTClient_publish_async)
+  foreach(TARGET
+    MQTTAsync_subscribe
+    MQTTAsync_publish
+    MQTTAsync_publish_time
+    MQTTClient_subscribe
+    MQTTClient_publish
+    MQTTClient_publish_async
+  )
     add_executable(${TARGET} ${TARGET}.c)
     set_target_properties(${TARGET} PROPERTIES
       COMPILE_DEFINITIONS "PAHO_MQTT_IMPORTS=1"
-    )    
+  )
   endforeach()
 
-  target_link_libraries(MQTTAsync_subscribe paho-mqtt3a)
-  target_link_libraries(MQTTAsync_publish paho-mqtt3a)
-  target_link_libraries(MQTTAsync_publish_time paho-mqtt3a)
+  foreach(TARGET MQTTAsync_subscribe MQTTAsync_publish MQTTAsync_publish_time)
+    target_link_libraries(${TARGET} paho-mqtt3a)
+  endforeach()
 
-  target_link_libraries(MQTTClient_subscribe paho-mqtt3c)
-  target_link_libraries(MQTTClient_publish paho-mqtt3c)
-  target_link_libraries(MQTTClient_publish_async paho-mqtt3c)
+  foreach(TARGET MQTTClient_subscribe MQTTClient_publish MQTTClient_publish_async)
+    target_link_libraries(${TARGET} paho-mqtt3c)
+  endforeach()
 
   install(
     TARGETS
@@ -86,23 +91,57 @@ if(PAHO_BUILD_SHARED)
   )
 endif()
 
-if(PAHO_BUILD_STATIC AND PAHO_WITH_SSL)
-  foreach(TARGET paho_c_pub paho_c_sub paho_cs_pub paho_cs_sub)
-    add_executable(${TARGET}_static ${TARGET}.c pubsub_opts.c)
+if(PAHO_BUILD_STATIC)
+  if(PAHO_WITH_SSL)
+    foreach(TARGET paho_c_pub paho_c_sub paho_cs_pub paho_cs_sub)
+      add_executable(${TARGET}_static ${TARGET}.c pubsub_opts.c)
+    endforeach()
+
+    target_link_libraries(paho_c_pub_static paho-mqtt3as-static)
+    target_link_libraries(paho_c_sub_static paho-mqtt3as-static)
+
+    target_link_libraries(paho_cs_pub_static paho-mqtt3cs-static)
+    target_link_libraries(paho_cs_sub_static paho-mqtt3cs-static)
+
+    install(
+      TARGETS
+        paho_c_sub_static
+        paho_c_pub_static
+        paho_cs_sub_static
+        paho_cs_pub_static
+
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+  endif()
+
+  foreach(TARGET
+    MQTTAsync_subscribe
+    MQTTAsync_publish
+    MQTTAsync_publish_time
+    MQTTClient_subscribe
+    MQTTClient_publish
+    MQTTClient_publish_async
+  )
+    add_executable(${TARGET}_static ${TARGET}.c)
   endforeach()
 
-  target_link_libraries(paho_c_pub_static paho-mqtt3as-static)
-  target_link_libraries(paho_c_sub_static paho-mqtt3as-static)
+  foreach(TARGET MQTTAsync_subscribe MQTTAsync_publish MQTTAsync_publish_time)
+    target_link_libraries(${TARGET}_static paho-mqtt3a-static)
+  endforeach()
 
-  target_link_libraries(paho_cs_pub_static paho-mqtt3cs-static)
-  target_link_libraries(paho_cs_sub_static paho-mqtt3cs-static)
+  foreach(TARGET MQTTClient_subscribe MQTTClient_publish MQTTClient_publish_async)
+    target_link_libraries(${TARGET}_static paho-mqtt3c-static)
+  endforeach()
 
   install(
     TARGETS
-      paho_c_sub_static
-      paho_c_pub_static
-      paho_cs_sub_static
-      paho_cs_pub_static
+      MQTTAsync_subscribe_static
+      MQTTAsync_publish_static
+      MQTTAsync_publish_time_static
+      MQTTClient_subscribe_static
+      MQTTClient_publish_static
+      MQTTClient_publish_async_static
 
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
I was testing the combination of builds across platforms (shared vs static) and noticed that we're only building a few of the sample apps for the static library, which is a little unfortunate, especially when only building the static lib. This builds the rest of them. 

Keeping with the existing conventions, each of the static executables gets a `_static` suffix.