### PR TITLE
Removed unnecessary _WIN64 conditional checks

### DIFF
--- a/src/Base64.c
+++ b/src/Base64.c
@@ -16,7 +16,7 @@
 
 #include "Base64.h"
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #pragma comment(lib, "crypt32.lib")
 #include <windows.h>
 #include <wincrypt.h>
@@ -37,7 +37,7 @@ b64_size_t Base64_encode( char *out, b64_size_t out_len, const b64_data_t *in, b
 		ret = (b64_size_t)dw_out_len;
 	return ret;
 }
-#else /* if defined(_WIN32) || defined(_WIN64) */
+#else /* if defined(_WIN32) */
 
 #if defined(OPENSSL)
 #include <openssl/bio.h>
@@ -234,7 +234,7 @@ b64_size_t Base64_encode( char *out, b64_size_t out_len, const b64_data_t *in, b
 	return ret;
 }
 #endif /* else if defined(OPENSSL) */
-#endif /* if else defined(_WIN32) || defined(_WIN64) */
+#endif /* if else defined(_WIN32) */
 
 b64_size_t Base64_decodeLength( const char *in, b64_size_t in_len )
 {

--- a/src/Clients.h
+++ b/src/Clients.h
@@ -24,7 +24,7 @@
 
 #include <stdint.h>
 #include "MQTTTime.h"
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #include <winsock2.h>
 #endif
 #if defined(OPENSSL)

--- a/src/Heap.c
+++ b/src/Heap.c
@@ -49,7 +49,7 @@ char* Broker_recordFFDC(char* symptoms);
 #undef realloc
 #undef free
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 mutex_type heap_mutex;
 #else
 static pthread_mutex_t heap_mutex_store = PTHREAD_MUTEX_INITIALIZER;

--- a/src/Log.c
+++ b/src/Log.c
@@ -38,7 +38,7 @@
 #include <time.h>
 #include <string.h>
 
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 #include <syslog.h>
 #include <sys/stat.h>
 #define GETTIMEOFDAY 1
@@ -52,7 +52,7 @@
 	#include <sys/timeb.h>
 #endif
 
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 /**
  * _unlink mapping for linux
  */
@@ -123,7 +123,7 @@ struct timeb now_ts;
 #endif
 static char msg_buf[512];
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 mutex_type log_mutex;
 #else
 static pthread_mutex_t log_mutex_store = PTHREAD_MUTEX_INITIALIZER;
@@ -135,7 +135,7 @@ int Log_initialize(Log_nameValue* info)
 {
 	int rc = SOCKET_ERROR;
 	char* envval = NULL;
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 	struct stat buf;
 #endif
 
@@ -198,7 +198,7 @@ int Log_initialize(Log_nameValue* info)
 			info++;
 		}
 	}
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 	if (stat("/proc/version", &buf) != -1)
 	{
 		FILE* vfile;

--- a/src/Log.h
+++ b/src/Log.h
@@ -18,7 +18,7 @@
 #if !defined(LOG_H)
 #define LOG_H
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	#include <windows.h>
 	#define thread_id_type DWORD
 #else

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -41,7 +41,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 	#include <sys/time.h>
 #else
 	#if defined(_MSC_VER) && _MSC_VER < 1900
@@ -105,7 +105,7 @@ void MQTTAsync_global_init(MQTTAsync_init_options* inits)
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
 void MQTTAsync_init_rand(void)
 {
 	START_TIME_TYPE now = MQTTTime_start_clock();
@@ -125,7 +125,7 @@ void MQTTAsync_init_rand(void)
 }
 #endif
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 mutex_type mqttasync_mutex = NULL;
 mutex_type socket_mutex = NULL;
 mutex_type mqttcommand_mutex = NULL;
@@ -300,7 +300,7 @@ int MQTTAsync_createWithOptions(MQTTAsync* handle, const char* serverURI, const 
 	int rc = 0;
 	MQTTAsyncs *m = NULL;
 
-#if (defined(_WIN32) || defined(_WIN64)) && defined(PAHO_MQTT_STATIC)
+#if (defined(_WIN32)) && defined(PAHO_MQTT_STATIC)
 	 /* intializes mutexes once.  Must come before FUNC_ENTRY */
 	BOOL bStatus = InitOnceExecuteOnce(&g_InitOnce, InitMutexesOnce, NULL, NULL);
 #endif

--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -17,7 +17,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 	#include <sys/time.h>
 #endif
 
@@ -81,7 +81,7 @@ extern List* MQTTAsync_handles;
 extern List* MQTTAsync_commands;
 extern int MQTTAsync_tostop;
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	#if defined(_MSC_VER) && _MSC_VER < 1900
 		#define snprintf _snprintf
 	#endif
@@ -108,7 +108,7 @@ extern cond_type send_cond;
 void MQTTAsync_sleep(long milliseconds)
 {
 	FUNC_ENTRY;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);
@@ -936,7 +936,7 @@ int MQTTAsync_addCommand(MQTTAsync_queuedCommand* command, int command_size)
 	}
 exit:
 	MQTTAsync_unlock_mutex(mqttcommand_mutex);
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 	if ((rc1 = Thread_signal_cond(send_cond)) != 0)
 		Log(LOG_ERROR, 0, "Error %d from signal cond", rc1);
 #else
@@ -1847,7 +1847,7 @@ thread_return_type WINAPI MQTTAsync_sendThread(void* n)
 			command_count = MQTTAsync_commands->count;
 			MQTTAsync_unlock_mutex(mqttcommand_mutex);
 		}
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 		if ((rc = Thread_wait_cond(send_cond, timeout)) != 0 && rc != ETIMEDOUT)
 			Log(LOG_ERROR, -1, "Error %d waiting for condition variable", rc);
 #else
@@ -1872,7 +1872,7 @@ thread_return_type WINAPI MQTTAsync_sendThread(void* n)
 #endif
 
 	FUNC_EXIT;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	ExitThread(0);
 #endif
 	return 0;
@@ -2058,7 +2058,7 @@ static int MQTTAsync_completeConnection(MQTTAsyncs* m, Connack* connack)
 			}
 		}
 		m->pack = NULL;
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 		Thread_signal_cond(send_cond);
 #else
 		Thread_post_sem(send_sem);
@@ -2388,7 +2388,7 @@ thread_return_type WINAPI MQTTAsync_receiveThread(void* n)
 	receiveThread_state = STOPPED;
 	receiveThread_id = 0;
 	MQTTAsync_unlock_mutex(mqttasync_mutex);
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 	if (sendThread_state != STOPPED)
 		Thread_signal_cond(send_cond);
 #else
@@ -2405,7 +2405,7 @@ thread_return_type WINAPI MQTTAsync_receiveThread(void* n)
 #endif
 
 	FUNC_EXIT;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	ExitThread(0);
 #endif
 	return 0;
@@ -3134,7 +3134,7 @@ static MQTTPacket* MQTTAsync_cycle(SOCKET* sock, unsigned long timeout, int* rc)
 				{
 					*rc = MQTTProtocol_handlePubcomps(pack, *sock, &pubToRemove);
 					if (sendThread_state != STOPPED)
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 						Thread_signal_cond(send_cond);
 #else
 						Thread_post_sem(send_sem);
@@ -3146,7 +3146,7 @@ static MQTTPacket* MQTTAsync_cycle(SOCKET* sock, unsigned long timeout, int* rc)
 				{
 					*rc = MQTTProtocol_handlePubacks(pack, *sock, &pubToRemove);
 					if (sendThread_state != STOPPED)
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 						Thread_signal_cond(send_cond);
 #else
 						Thread_post_sem(send_sem);

--- a/src/MQTTAsyncUtils.h
+++ b/src/MQTTAsyncUtils.h
@@ -177,7 +177,7 @@ void MQTTAsync_writeComplete(SOCKET socket, int rc);
 void setRetryLoopInterval(int keepalive);
 void MQTTAsync_NULLPublishResponses(MQTTAsyncs* m);
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #else
 #define WINAPI
 #endif

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -46,7 +46,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 	#include <sys/time.h>
 #else
 	#if defined(_MSC_VER) && _MSC_VER < 1900
@@ -114,7 +114,7 @@ ClientStates* bstate = &ClientState;
 
 MQTTProtocol state;
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 static mutex_type mqttclient_mutex = NULL;
 mutex_type socket_mutex = NULL;
 static mutex_type subscribe_mutex = NULL;
@@ -370,7 +370,7 @@ int MQTTClient_createWithOptions(MQTTClient* handle, const char* serverURI, cons
 	int rc = 0;
 	MQTTClients *m = NULL;
 
-#if (defined(_WIN32) || defined(_WIN64)) && defined(PAHO_MQTT_STATIC)
+#if (defined(_WIN32)) && defined(PAHO_MQTT_STATIC)
 	/* intializes mutexes once.  Must come before FUNC_ENTRY */
 	BOOL bStatus = InitOnceExecuteOnce(&g_InitOnce, InitOnceFunction, NULL, NULL);
 #endif
@@ -1026,7 +1026,7 @@ static thread_return_type WINAPI MQTTClient_run(void* n)
 	running = tostop = 0;
 	Paho_thread_unlock_mutex(mqttclient_mutex);
 	FUNC_EXIT;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	ExitThread(0);
 #endif
 	return 0;

--- a/src/MQTTExportDeclarations.h
+++ b/src/MQTTExportDeclarations.h
@@ -17,7 +17,7 @@
 #if !defined(EXPORTDECLARATIONS_H)
 #define EXPORTDECLARATIONS_H
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #   if defined(PAHO_MQTT_EXPORTS)
 #       define LIBMQTT_API __declspec(dllexport)
 #   elif defined(PAHO_MQTT_IMPORTS)

--- a/src/MQTTPacket.c
+++ b/src/MQTTPacket.c
@@ -945,7 +945,7 @@ int MQTTPacket_send_publish(Publish* pack, int dup, int qos, int retained, netwo
 		memcpy(pack->mask, packetbufs.mask, sizeof(pack->mask));
 	}
 	{
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 		#define buflen 30
 #else
 		const int buflen = 30;

--- a/src/MQTTPersistence.c
+++ b/src/MQTTPersistence.c
@@ -31,7 +31,7 @@
 #include "MQTTProtocolClient.h"
 #include "Heap.h"
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	#define snprintf _snprintf
 #endif
 
@@ -658,7 +658,7 @@ void MQTTPersistence_wrapMsgID(Clients *client)
 int MQTTPersistence_unpersistQueueEntry(Clients* client, MQTTPersistence_qEntry* qe)
 {
 	int rc = 0;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #define KEYSIZE PERSISTENCE_MAX_KEY_LENGTH + 1
 #else
 	const size_t KEYSIZE = PERSISTENCE_MAX_KEY_LENGTH + 1;
@@ -688,7 +688,7 @@ int MQTTPersistence_persistQueueEntry(Clients* aclient, MQTTPersistence_qEntry* 
 {
 	int rc = 0;
 	int bufindex = 0;
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 	const size_t KEYSIZE = PERSISTENCE_MAX_KEY_LENGTH + 1;
 #endif
 	char key[KEYSIZE];

--- a/src/MQTTPersistenceDefault.c
+++ b/src/MQTTPersistenceDefault.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include <errno.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	#include <direct.h>
 	/* Windows doesn't have strtok_r, so remap it to strtok_s */
 	#define strtok_r strtok_s
@@ -167,7 +167,7 @@ int pstmkdir( char *pPathname )
 	int rc = 0;
 
 	FUNC_ENTRY;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	if ( _mkdir( pPathname ) != 0 )
 	{
 #else
@@ -346,7 +346,7 @@ int pstremove(void* handle, char* key)
 		rc = MQTTCLIENT_PERSISTENCE_ERROR;
 	else
 	{
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 		if ( _unlink(file) != 0 )
 		{
 #else
@@ -380,7 +380,7 @@ int pstclose(void* handle)
 		goto exit;
 	}
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	if ( _rmdir(clientDir) != 0 )
 	{
 #else
@@ -414,7 +414,7 @@ int pstcontainskey(void *handle, char *key)
 		goto exit;
 	}
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	rc = containskeyWin32(clientDir, key);
 #else
 	rc = containskeyUnix(clientDir, key);
@@ -426,13 +426,13 @@ exit:
 }
 
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 int containskeyWin32(char *dirname, char *key)
 {
 	int notFound = MQTTCLIENT_PERSISTENCE_ERROR;
 	int fFinished = 0;
 	char *filekey, *ptraux;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #define DIRSIZE MAX_PATH+1
 #else
 	const size_t DIRSIZE = MAX_PATH+1;
@@ -552,7 +552,7 @@ int pstclear(void *handle)
 		goto exit;
 	}
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	rc = clearWin32(clientDir);
 #else
 	rc = clearUnix(clientDir);
@@ -564,7 +564,7 @@ exit:
 }
 
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 int clearWin32(char *dirname)
 {
 	int rc = 0;
@@ -668,7 +668,7 @@ int pstkeys(void *handle, char ***keys, int *nkeys)
 		goto exit;
 	}
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	rc = keysWin32(clientDir, keys, nkeys);
 #else
 	rc = keysUnix(clientDir, keys, nkeys);
@@ -680,7 +680,7 @@ exit:
 }
 
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 int keysWin32(char *dirname, char ***keys, int *nkeys)
 {
 	int rc = 0;

--- a/src/MQTTProtocolClient.c
+++ b/src/MQTTProtocolClient.c
@@ -334,7 +334,7 @@ int MQTTProtocol_handlePublishes(void* pack, SOCKET sock)
 
 	/* Format and print publish data to trace */
 	{
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 		#define buflen 30
 #else
 		const int buflen = 30;

--- a/src/MQTTTime.c
+++ b/src/MQTTTime.c
@@ -17,7 +17,7 @@
 #include "MQTTTime.h"
 #include "StackTrace.h"
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #include <windows.h>
 #else
 #include <unistd.h>
@@ -27,7 +27,7 @@
 void MQTTTime_sleep(ELAPSED_TIME_TYPE milliseconds)
 {
 	FUNC_ENTRY;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	Sleep((DWORD)milliseconds);
 #else
 	usleep((useconds_t)(milliseconds*1000));
@@ -35,7 +35,7 @@ void MQTTTime_sleep(ELAPSED_TIME_TYPE milliseconds)
 	FUNC_EXIT;
 }
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 START_TIME_TYPE MQTTTime_start_clock(void)
 {
 #if WINVER >= _WIN32_WINNT_VISTA
@@ -69,7 +69,7 @@ START_TIME_TYPE MQTTTime_now(void)
 }
 
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 /*
  * @param t_new most recent time in milliseconds from GetTickCount()
  * @param t_old older time in milliseconds from GetTickCount()

--- a/src/MQTTTime.h
+++ b/src/MQTTTime.h
@@ -19,7 +19,7 @@
 
 #include <stdint.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #include <windows.h>
 #if WINVER >= _WIN32_WINNT_VISTA
 #define START_TIME_TYPE ULONGLONG

--- a/src/MQTTVersion.c
+++ b/src/MQTTVersion.c
@@ -26,7 +26,7 @@
 #include <ctype.h>
 #include "MQTTAsync.h"
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #include <windows.h>
 #include <tchar.h>
 #include <io.h>
@@ -138,7 +138,7 @@ int loadandcall(const char* libname)
 {
 	int rc = 0;
 	MQTTAsync_nameValue* (*func_address)(void) = NULL;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	HMODULE APILibrary = LoadLibraryA(libname);
 	if (APILibrary == NULL)
 		printf("Error loading library %s, error code %d\n", libname, GetLastError());
@@ -202,7 +202,7 @@ int main(int argc, char** argv)
 		{
 #if defined(__CYGWIN__)
 			snprintf(namebuf, sizeof(namebuf), "cyg%s-1.dll", libraries[i]);
-#elif defined(_WIN32) || defined(_WIN64)
+#elif defined(_WIN32)
 			snprintf(namebuf, sizeof(namebuf), "%s.dll", libraries[i]);
 #elif defined(OSX)
 			snprintf(namebuf, sizeof(namebuf), "lib%s.1.dylib", libraries[i]);

--- a/src/Proxy.c
+++ b/src/Proxy.c
@@ -19,7 +19,7 @@
 #include <string.h>
 // for timeout process in Proxy_connect()
 #include <time.h>
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	#include <windows.h>
 	/* Windows doesn't have strtok_r, so remap it to strtok_s */
 	#define strtok_r strtok_s
@@ -136,7 +136,7 @@ int Proxy_connect(networkHandles *net, int ssl, const char *hostname)
 				rc = SOCKET_ERROR;
 				break;
 			}
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 			Sleep(250);
 #else
 			usleep(250000);

--- a/src/SHA1.c
+++ b/src/SHA1.c
@@ -17,7 +17,7 @@
 #include "SHA1.h"
 
 #if !defined(OPENSSL)
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #pragma comment(lib, "crypt32.lib")
 
 int SHA1_Init(SHA_CTX *c)
@@ -52,7 +52,7 @@ int SHA1_Final(unsigned char *md, SHA_CTX *c)
 	return rv;
 }
 
-#else /* if defined(_WIN32) || defined(_WIN64) */
+#else /* if defined(_WIN32) */
 #if defined(__linux__) || defined(__CYGWIN__)
 #  include <endian.h>
 #elif defined(__APPLE__)
@@ -195,7 +195,7 @@ int SHA1_Update(SHA_CTX *ctx, const void *data, size_t len)
 	return 1;
 }
 
-#endif /* else if defined(_WIN32) || defined(_WIN64) */
+#endif /* else if defined(_WIN32) */
 #endif /* elif !defined(OPENSSL) */
 
 #if defined(SHA1_TEST)

--- a/src/SHA1.h
+++ b/src/SHA1.h
@@ -25,7 +25,7 @@
 
 #else /* if defined(OPENSSL) */
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #include <windows.h>
 #include <wincrypt.h>
 typedef struct SHA_CTX_S
@@ -33,7 +33,7 @@ typedef struct SHA_CTX_S
 	HCRYPTPROV hProv;
 	HCRYPTHASH hHash;
 } SHA_CTX;
-#else /* if defined(_WIN32) || defined(_WIN64) */
+#else /* if defined(_WIN32) */
 
 #include <stdint.h>
 typedef struct SHA_CTX_S {
@@ -45,7 +45,7 @@ typedef struct SHA_CTX_S {
 	unsigned int size;
 	unsigned int total;
 } SHA_CTX;
-#endif /* else if defined(_WIN32) || defined(_WIN64) */
+#endif /* else if defined(_WIN32) */
 
 #include <stddef.h>
 

--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -79,7 +79,7 @@ static ssl_mutex_type sslCoreMutex;
 /* Used to store MQTTClient_SSLOptions for TLS-PSK callback */
 static int tls_ex_index_ssl_opts;
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #define iov_len len
 #define iov_base buf
 #define snprintf _snprintf
@@ -346,7 +346,7 @@ int SSL_create_mutex(ssl_mutex_type* mutex)
 	int rc = 0;
 
 	FUNC_ENTRY;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	*mutex = CreateMutex(NULL, 0, NULL);
 #else
 	rc = pthread_mutex_init(mutex, NULL);
@@ -360,7 +360,7 @@ int SSL_lock_mutex(ssl_mutex_type* mutex)
 	int rc = -1;
 
 	/* don't add entry/exit trace points, as trace gets lock too, and it might happen quite frequently  */
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	if (WaitForSingleObject(*mutex, INFINITE) != WAIT_FAILED)
 #else
 	if ((rc = pthread_mutex_lock(mutex)) == 0)
@@ -375,7 +375,7 @@ int SSL_unlock_mutex(ssl_mutex_type* mutex)
 	int rc = -1;
 
 	/* don't add entry/exit trace points, as trace gets lock too, and it might happen quite frequently  */
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	if (ReleaseMutex(*mutex) != 0)
 #else
 	if ((rc = pthread_mutex_unlock(mutex)) == 0)
@@ -390,7 +390,7 @@ int SSL_destroy_mutex(ssl_mutex_type* mutex)
 	int rc = 0;
 
 	FUNC_ENTRY;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	rc = CloseHandle(*mutex);
 #else
 	rc = pthread_mutex_destroy(mutex);
@@ -404,7 +404,7 @@ int SSL_destroy_mutex(ssl_mutex_type* mutex)
 #if (OPENSSL_VERSION_NUMBER >= 0x010000000)
 extern void SSLThread_id(CRYPTO_THREADID *id)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	CRYPTO_THREADID_set_numeric(id, (unsigned long)GetCurrentThreadId());
 #else
 	CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
@@ -413,7 +413,7 @@ extern void SSLThread_id(CRYPTO_THREADID *id)
 #else
 extern unsigned long SSLThread_id(void)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	return (unsigned long)GetCurrentThreadId();
 #else
 	return (unsigned long)pthread_self();

--- a/src/SSLSocket.h
+++ b/src/SSLSocket.h
@@ -18,7 +18,7 @@
 #if !defined(SSLSOCKET_H)
 #define SSLSOCKET_H
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	#define ssl_mutex_type HANDLE
 #else
 	#include <pthread.h>

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -64,7 +64,7 @@ int Socket_continueWrite(SOCKET socket);
 char* Socket_getaddrname(struct sockaddr* sa, SOCKET sock);
 int Socket_abortWrite(SOCKET socket);
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #define iov_len len
 #define iov_base buf
 #define snprintf _snprintf
@@ -88,7 +88,7 @@ extern mutex_type socket_mutex;
 int Socket_setnonblocking(SOCKET sock)
 {
 	int rc;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	u_long flag = 1L;
 
 	FUNC_ENTRY;
@@ -116,7 +116,7 @@ int Socket_error(char* aString, SOCKET sock)
 {
 	int err;
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	err = WSAGetLastError();
 #else
 	err = errno;
@@ -129,7 +129,7 @@ int Socket_error(char* aString, SOCKET sock)
 	return err;
 }
 
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 void SIGPIPE_ignore()
 {
 #if defined(PAHO_IGNORE_WITH_SIGNAL)
@@ -151,7 +151,7 @@ void SIGPIPE_ignore()
  */
 void Socket_outInitialize(void)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	WORD    winsockVer = 0x0202;
 	WSADATA wsd;
 
@@ -208,7 +208,7 @@ void Socket_outTerminate(void)
 		free(mod_s.saved.fds_read);
 #endif
 	SocketBuffer_terminate();
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	WSACleanup();
 #endif
 	FUNC_EXIT;
@@ -335,7 +335,7 @@ int Socket_addSocket(SOCKET newSd)
 
 	mod_s.fds_read[mod_s.nfds - 1].fd = newSd;
 	mod_s.fds_write[mod_s.nfds - 1].fd = newSd;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	mod_s.fds_read[mod_s.nfds - 1].events = POLLIN;
 	mod_s.fds_write[mod_s.nfds - 1].events = POLLOUT;
 #else
@@ -784,7 +784,7 @@ int Socket_writev(SOCKET socket, iobuf* iovecs, int count, unsigned long* bytes)
 
 	FUNC_ENTRY;
 	*bytes = 0L;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	rc = WSASend(socket, iovecs, count, (LPDWORD)bytes, 0, NULL, NULL);
 	if (rc == SOCKET_ERROR)
 	{
@@ -955,7 +955,7 @@ int Socket_close_only(SOCKET socket)
 	int rc;
 
 	FUNC_ENTRY;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	if (shutdown(socket, SD_BOTH) == SOCKET_ERROR)
 		Socket_error("shutdown", socket);
 	if ((rc = closesocket(socket)) == SOCKET_ERROR)
@@ -1140,7 +1140,7 @@ int Socket_new(const char* addr, size_t addr_len, int port, SOCKET* sock)
 	struct sockaddr_in6 address6;
 #endif
 	int rc = SOCKET_ERROR;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	short family = AF_INET;
 #else
 	sa_family_t family = AF_INET;
@@ -1607,7 +1607,7 @@ char* Socket_getaddrname(struct sockaddr* sa, SOCKET sock)
 #define PORTLEN 10
 	static char addr_string[ADDRLEN + PORTLEN];
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	int buflen = ADDRLEN*2;
 	wchar_t buf[ADDRLEN*2];
 	if (WSAAddressToStringW(sa, sizeof(struct sockaddr_in6), NULL, buf, (LPDWORD)&buflen) == SOCKET_ERROR)

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -21,7 +21,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #include <errno.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>

--- a/src/SocketBuffer.c
+++ b/src/SocketBuffer.c
@@ -34,7 +34,7 @@
 
 #include "Heap.h"
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #define iov_len len
 #define iov_base buf
 #endif

--- a/src/SocketBuffer.h
+++ b/src/SocketBuffer.h
@@ -24,7 +24,7 @@
 #include <openssl/ssl.h>
 #endif
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	typedef WSABUF iobuf;
 #else
 	typedef struct iovec iobuf;

--- a/src/StackTrace.c
+++ b/src/StackTrace.c
@@ -25,7 +25,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #define snprintf _snprintf
 #endif
 
@@ -66,7 +66,7 @@ static int thread_count = 0;
 static threadEntry threads[MAX_THREADS];
 static threadEntry *my_thread = NULL;
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 mutex_type stack_mutex;
 #else
 static pthread_mutex_t stack_mutex_store = PTHREAD_MUTEX_INITIALIZER;

--- a/src/StackTrace.h
+++ b/src/StackTrace.h
@@ -38,7 +38,7 @@
 #define FUNC_EXIT_MED_RC(x)
 #define FUNC_EXIT_MAX_RC(x)
 #else
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #define inline __inline
 #define FUNC_ENTRY StackTrace_entry(__FUNCTION__, __LINE__, TRACE_MINIMUM)
 #define FUNC_ENTRY_NOLOG StackTrace_entry(__FUNCTION__, __LINE__, -1)

--- a/src/Thread.c
+++ b/src/Thread.c
@@ -38,7 +38,7 @@
 #undef realloc
 #undef free
 
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 #include <errno.h>
 #include <unistd.h>
 #include <sys/time.h>
@@ -58,7 +58,7 @@
  */
 void Paho_thread_start(thread_fn fn, void* parameter)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	thread_type thread = NULL;
 #else
 	thread_type thread = 0;
@@ -66,7 +66,7 @@ void Paho_thread_start(thread_fn fn, void* parameter)
 #endif
 
 	FUNC_ENTRY;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	thread = CreateThread(NULL, 0, fn, parameter, 0, NULL);
     CloseHandle(thread);
 #else
@@ -83,13 +83,13 @@ void Paho_thread_start(thread_fn fn, void* parameter)
 int Thread_set_name(const char* thread_name)
 {
 	int rc = 0;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #define MAX_THREAD_NAME_LENGTH 30
 	wchar_t wchars[MAX_THREAD_NAME_LENGTH];
 #endif
 	FUNC_ENTRY;
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 /* Using NTDDI_VERSION rather than WINVER for more detailed version targeting */
 /* Can't get this conditional compilation to work so remove it for now */
 /*#if NTDDI_VERSION >= NTDDI_WIN10_RS1
@@ -124,7 +124,7 @@ mutex_type Paho_thread_create_mutex(int* rc)
 
 	FUNC_ENTRY;
 	*rc = -1;
-	#if defined(_WIN32) || defined(_WIN64)
+	#if defined(_WIN32)
 		mutex = CreateMutex(NULL, 0, NULL);
 		*rc = (mutex == NULL) ? GetLastError() : 0;
 	#else
@@ -146,7 +146,7 @@ int Paho_thread_lock_mutex(mutex_type mutex)
 	int rc = -1;
 
 	/* don't add entry/exit trace points as the stack log uses mutexes - recursion beckons */
-	#if defined(_WIN32) || defined(_WIN64)
+	#if defined(_WIN32)
 		/* WaitForSingleObject returns WAIT_OBJECT_0 (0), on success */
 		rc = WaitForSingleObject(mutex, INFINITE);
 	#else
@@ -167,7 +167,7 @@ int Paho_thread_unlock_mutex(mutex_type mutex)
 	int rc = -1;
 
 	/* don't add entry/exit trace points as the stack log uses mutexes - recursion beckons */
-	#if defined(_WIN32) || defined(_WIN64)
+	#if defined(_WIN32)
 		/* if ReleaseMutex fails, the return value is 0 */
 		if (ReleaseMutex(mutex) == 0)
 			rc = GetLastError();
@@ -190,7 +190,7 @@ int Paho_thread_destroy_mutex(mutex_type mutex)
 	int rc = 0;
 
 	FUNC_ENTRY;
-	#if defined(_WIN32) || defined(_WIN64)
+	#if defined(_WIN32)
 		rc = CloseHandle(mutex);
 	#else
 		rc = pthread_mutex_destroy(mutex);
@@ -207,7 +207,7 @@ int Paho_thread_destroy_mutex(mutex_type mutex)
  */
 thread_id_type Paho_thread_getid(void)
 {
-	#if defined(_WIN32) || defined(_WIN64)
+	#if defined(_WIN32)
 		return GetCurrentThreadId();
 	#else
 		return pthread_self();
@@ -226,7 +226,7 @@ sem_type Thread_create_sem(int *rc)
 
 	FUNC_ENTRY;
 	*rc = -1;
-	#if defined(_WIN32) || defined(_WIN64)
+	#if defined(_WIN32)
 		sem = CreateEvent(
 		        NULL,               /* default security attributes */
 		        FALSE,              /* manual-reset event? */
@@ -259,7 +259,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
  * so I've used trywait in a loop instead. Ian Craggs 23/7/2010
  */
 	int rc = -1;
-#if !defined(_WIN32) && !defined(_WIN64) && !defined(OSX)
+#if !defined(_WIN32) && !defined(OSX)
 #define USE_TRYWAIT
 #if defined(USE_TRYWAIT)
 	int i = 0;
@@ -271,7 +271,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
 #endif
 
 	FUNC_ENTRY;
-	#if defined(_WIN32) || defined(_WIN64)
+	#if defined(_WIN32)
 		/* returns 0 (WAIT_OBJECT_0) on success, non-zero (WAIT_TIMEOUT) if timeout occurred */
 		rc = WaitForSingleObject(sem, timeout < 0 ? 0 : timeout);
 		if (rc == WAIT_TIMEOUT)
@@ -317,7 +317,7 @@ int Thread_wait_sem(sem_type sem, int timeout)
  */
 int Thread_check_sem(sem_type sem)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	/* if the return value is not 0, the semaphore will not have been decremented */
 	return WaitForSingleObject(sem, 0) == WAIT_OBJECT_0;
 #elif defined(OSX)
@@ -341,7 +341,7 @@ int Thread_post_sem(sem_type sem)
 	int rc = 0;
 
 	FUNC_ENTRY;
-	#if defined(_WIN32) || defined(_WIN64)
+	#if defined(_WIN32)
 		if (SetEvent(sem) == 0)
 			rc = GetLastError();
 	#elif defined(OSX)
@@ -369,7 +369,7 @@ int Thread_destroy_sem(sem_type sem)
 	int rc = 0;
 
 	FUNC_ENTRY;
-	#if defined(_WIN32) || defined(_WIN64)
+	#if defined(_WIN32)
 		rc = CloseHandle(sem);
 	#elif defined(OSX)
 	  dispatch_release(sem);
@@ -382,7 +382,7 @@ int Thread_destroy_sem(sem_type sem)
 }
 
 
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 
 /**
  * Create a new condition variable

--- a/src/Thread.h
+++ b/src/Thread.h
@@ -20,7 +20,7 @@
 #if !defined(THREAD_H)
 #define THREAD_H
 
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 #if defined(__GNUC__) && defined(__linux__)
 #if !defined(_GNU_SOURCE)
 // for pthread_setname
@@ -35,7 +35,7 @@
 
 #include "mutex_type.h" /* Needed for mutex_type */
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	#include <windows.h>
 	#define thread_type HANDLE
 	#define thread_id_type DWORD

--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -47,7 +47,7 @@
 #  define be64toh(x) OSSwapBigToHostInt64(x)
 #elif defined(__FreeBSD__) || defined(__NetBSD__)
 #  include <sys/endian.h>
-#elif defined(_WIN32) || defined(_WIN64)
+#elif defined(_WIN32)
 #  pragma comment(lib, "rpcrt4.lib")
 #  include <rpc.h>
 #  if !(defined(__MINGW32__))
@@ -92,7 +92,7 @@
 
 #define HTTP_PROTOCOL(x) x ? "https" : "http"
 
-#if !(defined(_WIN32) || defined(_WIN64))
+#if !(defined(_WIN32))
 #if defined(USE_LIBUUID)
 #include <uuid/uuid.h>
 #else /* if defined(USE_LIBUUID) */
@@ -142,7 +142,7 @@ static void uuid_unparse( uuid_t uu, char *out )
 }
 #endif
 #endif /* else if defined(USE_LIBUUID) */
-#endif /* if !(defined(_WIN32) || defined(_WIN64)) */
+#endif /* if !(defined(_WIN32)) */
 
 #include "Heap.h"
 
@@ -394,11 +394,11 @@ int WebSocket_connect( networkHandles *net, int ssl, const char *uri)
 	size_t hostname_len;
 	int port = 80;
 	const char *topic = NULL;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	UUID uuid;
-#else /* if defined(_WIN32) || defined(_WIN64) */
+#else /* if defined(_WIN32) */
 	uuid_t uuid;
-#endif /* else if defined(_WIN32) || defined(_WIN64) */
+#endif /* else if defined(_WIN32) */
 
 	FUNC_ENTRY;
 	/* Generate UUID */
@@ -422,14 +422,14 @@ int WebSocket_connect( networkHandles *net, int ssl, const char *uri)
 		rc = PAHO_MEMORY_ERROR;
 		goto exit;
 	}
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	ZeroMemory( &uuid, sizeof(UUID) );
 	UuidCreate( &uuid );
 	Base64_encode( net->websocket_key, 25u, (const b64_data_t*)&uuid, sizeof(UUID) );
-#else /* if defined(_WIN32) || defined(_WIN64) */
+#else /* if defined(_WIN32) */
 	uuid_generate( uuid );
 	Base64_encode( net->websocket_key, 25u, uuid, sizeof(uuid_t) );
-#endif /* else if defined(_WIN32) || defined(_WIN64) */
+#endif /* else if defined(_WIN32) */
 
 	hostname_len = MQTTProtocol_addressPort(uri, &port, &topic, ssl ? WSS_DEFAULT_PORT : WS_DEFAULT_PORT);
 

--- a/src/mutex_type.h
+++ b/src/mutex_type.h
@@ -14,7 +14,7 @@
 #if !defined(_MUTEX_TYPE_H_)
 #define _MUTEX_TYPE_H_
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	#include <windows.h>
 	#define mutex_type HANDLE
 #else

--- a/src/samples/MQTTAsync_publish_time.c
+++ b/src/samples/MQTTAsync_publish_time.c
@@ -38,7 +38,7 @@
 #include <OsWrapper.h>
 #endif
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #define snprintf _snprintf
 #endif
 

--- a/test/test2.c
+++ b/test/test2.c
@@ -279,7 +279,7 @@ void myassert(char* filename, int lineno, char* description, int value, char* fo
 }
 
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 mutex_type deliveryCompleted_mutex = NULL;
 #else
 pthread_mutex_t deliveryCompleted_mutex_store = PTHREAD_MUTEX_INITIALIZER;
@@ -679,7 +679,7 @@ int main(int argc, char** argv)
  	int (*tests[])(struct Options) = {NULL, test1};
 	int i;
 
-	#if defined(_WIN32) || defined(_WIN64)
+	#if defined(_WIN32)
 	deliveryCompleted_mutex = CreateMutex(NULL, 0, NULL);
 	#endif
 

--- a/test/test45.c
+++ b/test/test45.c
@@ -159,7 +159,7 @@ void MyLog(int LOGA_level, char* format, ...)
 
 void MySleep(long milliseconds)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);

--- a/test/test6.c
+++ b/test/test6.c
@@ -212,7 +212,7 @@ void MyLog(int LOGA_level, char* format, ...)
 
 void MySleep(long milliseconds)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);

--- a/test/test9.c
+++ b/test/test9.c
@@ -140,7 +140,7 @@ void MyLog(int LOGA_level, char* format, ...)
 
 void MySleep(long milliseconds)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);

--- a/test/test95.c
+++ b/test/test95.c
@@ -141,7 +141,7 @@ void MyLog(int LOGA_level, char* format, ...)
 
 void MySleep(long milliseconds)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);

--- a/test/test_connect_destroy.c
+++ b/test/test_connect_destroy.c
@@ -176,14 +176,14 @@ void MyLog(int LOGA_level, char* format, ...)
 
 void MySleep(long milliseconds)
 {
-#if defined(WIN32) || defined(WIN64)
+#if defined(_WIN32)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);
 #endif
 }
 
-#if defined(WIN32) || defined(_WINDOWS)
+#if defined(_WIN32) || defined(_WINDOWS)
 #define START_TIME_TYPE DWORD
 static DWORD start_time = 0;
 START_TIME_TYPE start_clock(void)
@@ -210,7 +210,7 @@ START_TIME_TYPE start_clock(void)
 #endif
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 long elapsed(START_TIME_TYPE start_time)
 {
 	return GetTickCount() - start_time;

--- a/test/test_issue373.c
+++ b/test/test_issue373.c
@@ -144,7 +144,7 @@ void MyLog(int LOGA_level, char* format, ...)
 
 void MySleep(long milliseconds)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);

--- a/test/test_persistence.c
+++ b/test/test_persistence.c
@@ -130,7 +130,7 @@ void MyLog(int LOGA_level, char* format, ...)
 
 void MySleep(long milliseconds)
 {
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 	Sleep(milliseconds);
 #else
 	usleep(milliseconds*1000);

--- a/test/thread.c
+++ b/test/thread.c
@@ -323,7 +323,7 @@ int test_sem(struct Options options)
 	return failures;
 }
 
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 thread_return_type cond_secondary(void* n)
 {
 	int rc = 0;
@@ -494,7 +494,7 @@ int main(int argc, char** argv)
  	int (*tests[])(struct Options) = {NULL,
  		test_mutex,
  		test_sem,
-#if !defined(_WIN32) && !defined(_WIN64)
+#if !defined(_WIN32)
 		test_cond
 #endif
  	}; /* indexed starting from 1 */


### PR DESCRIPTION
Minor nit to start some cleanup.... 

The `_WIN64` preprocessor macro is always defined by the Microsoft compiler when `_WIN32` is defined. So you don't need to check if one or the other is defined. You can just check for `_WIN32`.
```
#if defined(_WIN32)
    // Windows code (32 or 64-bit)
#else
    // Non-windows code (Linux, macOS, etc)
#endif
```

If you need code specific for 32-bit vs 64-bit, you need need to check for `_WIN64` first/else, or nest it, like:
```
#if defined(_WIN32)
    #if defined(_WIN64)
        // Windows 64-bit code
    #else
        // Windows 32-bit code
    #endif
#else
    // Non-windows code (Linux, macOS, etc)
#endif
```

but we're not making that distinction here. To just check if we're on Windows, checking for `_WIN32` is sufficient.

From the Microsoft documentation:

> - _WIN32 Defined as 1 when the compilation target is 32-bit ARM, 64-bit ARM, x86, or x64. Otherwise, undefined.
>
> - _WIN64 Defined as 1 when the compilation target is 64-bit ARM or x64. Otherwise, undefined.

https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170