### PR TITLE
Fixed condition variable timed wait. 

### DIFF
--- a/src/Thread.c
+++ b/src/Thread.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2023 IBM Corp. and Ian Craggs
+ * Copyright (c) 2009, 2025 IBM Corp. and Ian Craggs
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -51,7 +51,9 @@
 
 #include "OsWrapper.h"
 
+#if !defined(NSEC_PER_SEC)
 #define NSEC_PER_SEC 1000000000L
+#endif
 
 /**
  * Start a new thread

--- a/src/Thread.c
+++ b/src/Thread.c
@@ -51,6 +51,8 @@
 
 #include "OsWrapper.h"
 
+#define NSEC_PER_SEC 1000000000L
+
 /**
  * Start a new thread
  * @param fn the function to run, must be of the correct signature
@@ -443,12 +445,8 @@ int Thread_wait_cond(cond_type condvar, int timeout_ms)
 {
 	int rc = 0;
 	struct timespec cond_timeout;
-	struct timespec interval;
 
 	FUNC_ENTRY;
-	interval.tv_sec = timeout_ms / 1000;
-	interval.tv_nsec = (timeout_ms % 1000) * 1000000L;
-
 #if defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 /* for older versions of MacOS */
 	struct timeval cur_time;
     gettimeofday(&cur_time, NULL);
@@ -458,13 +456,20 @@ int Thread_wait_cond(cond_type condvar, int timeout_ms)
 	clock_gettime(CLOCK_REALTIME, &cond_timeout);
 #endif
 
-	cond_timeout.tv_sec += interval.tv_sec;
-	cond_timeout.tv_nsec += (timeout_ms % 1000) * 1000000L;
+	if (timeout_ms > 0) {
+		struct timespec interval;
 
-	if (cond_timeout.tv_nsec >= 1000000000L)
-	{
-		cond_timeout.tv_sec++;
-		cond_timeout.tv_nsec += (cond_timeout.tv_nsec - 1000000000L);
+		interval.tv_sec = timeout_ms / 1000;
+		interval.tv_nsec = (timeout_ms % 1000) * 1000000L;
+
+		cond_timeout.tv_sec += interval.tv_sec;
+		cond_timeout.tv_nsec += interval.tv_nsec;
+
+		while (cond_timeout.tv_nsec >= NSEC_PER_SEC)
+		{
+			cond_timeout.tv_sec++;
+			cond_timeout.tv_nsec -= NSEC_PER_SEC;
+		}
 	}
 
 	pthread_mutex_lock(&condvar->mutex);

--- a/test/thread.c
+++ b/test/thread.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2024 IBM Corp.
+ * Copyright (c) 2009, 2025 IBM Corp.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -304,7 +304,11 @@ int test_sem(struct Options options)
 	start = start_clock();
 	rc = Thread_wait_sem(sem, 1500);
 	duration = elapsed(start);
-	assert("rc ETIMEDOUT from lock mutex", rc == ETIMEDOUT || rc == EAGAIN, "rc was %d", rc);
+	#if defined(EAGAIN)
+	    assert("rc ETIMEDOUT from lock mutex", rc == ETIMEDOUT || rc == EAGAIN, "rc was %d", rc);
+	#else
+	    assert("rc ETIMEDOUT from lock mutex", rc == ETIMEDOUT, "rc was %d", rc);
+	#endif
 	MyLog(LOGA_INFO, "Lock duration was %ld", duration);
 	assert("duration is 2s", duration >= 1500L, "duration was %ld", duration);
 


### PR DESCRIPTION
On doing some performance tests, I noticed that the condition variable timed wait function `Thread_wait_cond()` was occasionally returning EINVAL because the _timespec_ value given to it was not properly normalized.

This fixes the normalization, and also checks that the input value of `timeout_ms` is greater than zero. Anything <= 0 will timeout immediately, which seems sensible, but will not attempt any (possibly erroneous) time offset math,

This also updates the thread test app (test/thread.c)  for current implementation of the signal types. For example, the application was testing for a counting semaphore whereas the current implementation is of a binary semaphore. Thus, fixes #1557

