### PR TITLE
Fix build on GNU Hurd

### DIFF
--- a/src/SHA1.c
+++ b/src/SHA1.c
@@ -53,7 +53,7 @@ int SHA1_Final(unsigned char *md, SHA_CTX *c)
 }
 
 #else /* if defined(_WIN32) || defined(_WIN64) */
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__)
 #  include <endian.h>
 #elif defined(__APPLE__)
 #  include <libkern/OSByteOrder.h>


### PR DESCRIPTION
This pull request fixes a build error on systems running the GNU Hurd kernel - for example, Debian GNU/Hurd.

Example of failed build: https://buildd.debian.org/status/package.php?p=paho.mqtt.c

