### PR TITLE
Added SSLPluginInterface.h to the Makefile alogside other exported he…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,7 @@ install: build
 	$(INSTALL_DATA) ${srcdir}/MQTTReasonCodes.h $(DESTDIR)${includedir}
 	$(INSTALL_DATA) ${srcdir}/MQTTSubscribeOpts.h $(DESTDIR)${includedir}	
 	$(INSTALL_DATA) ${srcdir}/MQTTExportDeclarations.h $(DESTDIR)${includedir}
+	$(INSTALL_DATA) ${srcdir}/SSLPluginInterface.h $(DESTDIR)${includedir}
 	- $(INSTALL_DATA) doc/man/man1/paho_c_pub.1 $(DESTDIR)${man1dir}
 	- $(INSTALL_DATA) doc/man/man1/paho_c_sub.1 $(DESTDIR)${man1dir}
 	- $(INSTALL_DATA) doc/man/man1/paho_cs_pub.1 $(DESTDIR)${man1dir}

--- a/src/SSLPluginInterface.h
+++ b/src/SSLPluginInterface.h
@@ -1,0 +1,11 @@
+#if defined(__cplusplus)
+extern "C" {
+#endif
+#include "MQTTExportDeclarations.h"
+#include <openssl/ssl.h>
+
+LIBMQTT_API void SSLPluginInterface_setcallback(int (*callback)(SSL*));
+
+#if defined(__cplusplus)
+}
+#endif


### PR DESCRIPTION
- Created and added SSLPluginInterface.h alongside other exported header files. 
- Added a callback function for handling the SSL object passed as an input parameter in the SSLSocket_Connect
function.

What does this functionality provide?
This functionality is essential in cybersecurity as it enables users to obtain an X509 Certificate from the SSL object and verify the device attempting to connect. Users can include the SSLPluginInterface.h file in their project and set the callback function "SSLPluginInterface_setcallback(int (callback)(SSL))" with their implementation.

Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


