### PR TITLE
Update getaddrinfo options to support IPv6 hostname resolution

### DIFF
--- a/src/Socket.c
+++ b/src/Socket.c
@@ -1146,7 +1146,7 @@ int Socket_new(const char* addr, size_t addr_len, int port, SOCKET* sock)
 	sa_family_t family = AF_INET;
 #endif
 	struct addrinfo *result = NULL;
-	struct addrinfo hints = {0, AF_UNSPEC, SOCK_STREAM, IPPROTO_TCP, 0, NULL, NULL, NULL};
+	struct addrinfo hints = {AI_ADDRCONFIG, AF_UNSPEC, SOCK_STREAM, IPPROTO_TCP, 0, NULL, NULL, NULL};
 
 	FUNC_ENTRY;
 	*sock = SOCKET_ERROR;


### PR DESCRIPTION
Updated the `hints` struct so that it passes in the `AI_ADDRCONFIG` flag for the `ai_flags` property, in support of issue #1396.

This will enable auto-translation for hostnames to their proper IP address, depending on the IP address version used by the host. From the `getaddrinfo(3)` manual page:

```
     ai_flags       The ai_flags field to which the hints parameter points shall be set to zero or be the bitwise-inclusive OR of one or more of the values AI_ADDRCONFIG, AI_ALL, AI_CANONNAME, AI_NUMERICHOST, AI_NUMERICSERV, AI_PASSIVE, AI_V4MAPPED,
                    AI_V4MAPPED_CFG, and AI_DEFAULT.

                    AI_ADDRCONFIG   If the AI_ADDRCONFIG bit is set, IPv4 addresses shall be returned only if an IPv4 address is configured on the local system, and IPv6 addresses shall be returned only if an IPv6 address is configured on the local
                                    system.
``` 

This change has been tested on a linux platform, and I can confirm that I can now connect to a dual-stack endpoint broker from a device that only has IPv6 configured. I've also ensured that if only IPv4 is enabled for the device, it works as well.

All existing tests pass with zero regressions.