### PR TITLE
 Update getaddrinfo options to support IPv6 hostname resolution

### DIFF
--- a/src/Socket.c
+++ b/src/Socket.c
@@ -1146,7 +1146,7 @@ int Socket_new(const char* addr, size_t addr_len, int port, SOCKET* sock)
 	sa_family_t family = AF_INET;
 #endif
 	struct addrinfo *result = NULL;
-	struct addrinfo hints = {0, AF_UNSPEC, SOCK_STREAM, IPPROTO_TCP, 0, NULL, NULL, NULL};
+	struct addrinfo hints = {AI_ADDRCONFIG, AF_UNSPEC, SOCK_STREAM, IPPROTO_TCP, 0, NULL, NULL, NULL};
 
 	FUNC_ENTRY;
 	*sock = SOCKET_ERROR;


### PR DESCRIPTION
Updated the `hints` struct to pass the `AI_ADDRCONFIG` flag to the `ai_flags` property, addressing issue #1396.

### Description:

This ensures hostnames are translated to the correct IP address based on the system’s network configuration, improving compatibility across different environments.

According to the `getaddrinfo(3)` manual:

```
     ai_flags       The ai_flags field to which the hints parameter points shall be set to zero or be the bitwise-inclusive OR of one or more of the values AI_ADDRCONFIG, AI_ALL, AI_CANONNAME, AI_NUMERICHOST, AI_NUMERICSERV, AI_PASSIVE, AI_V4MAPPED,
                    AI_V4MAPPED_CFG, and AI_DEFAULT.

                    AI_ADDRCONFIG   If the AI_ADDRCONFIG bit is set, IPv4 addresses shall be returned only if an IPv4 address is configured on the local system, and IPv6 addresses shall be returned only if an IPv6 address is configured on the local
                                    system.
``` 


### Cross-Platform Considerations:
This change has been tested on Linux, where it allows seamless connections to dual-stack endpoint brokers regardless of whether the device is configured for IPv4, IPv6, or both. While behavior may vary slightly across operating systems, `AI_ADDRCONFIG` is widely supported, including macOS and Linux variants. On Windows, `AI_ADDRCONFIG` is also respected on Windows Vista and later.

### Testing & Verification:
- Verified via the Linux platform
- Successfully connected to a dual-stack endpoint from an IPv6-only device.  
- Confirmed proper resolution and connectivity when only IPv4 is available.  
- Verified no regressions, with all existing tests passing.

This update enhances network flexibility while maintaining full backward compatibility.