### PR TITLE
Enable building with BoringSSL

### DIFF
--- a/src/Base64.c
+++ b/src/Base64.c
@@ -48,40 +48,45 @@ static b64_size_t Base64_encodeDecode(
 	b64_size_t ret = 0u;
 	if ( in_len > 0u )
 	{
-		int rv;
-		BIO *bio, *b64, *b_in, *b_out;
-
-		b64 = BIO_new(BIO_f_base64());
-		bio = BIO_new(BIO_s_mem());
-		b64 = BIO_push(b64, bio);
-		BIO_set_flags(b64, BIO_FLAGS_BASE64_NO_NL); /* ignore new-lines */
-
 		if ( encode )
 		{
-			b_in = bio;
-			b_out = b64;
+			/* For encoding: output length is 4 * (input_length / 3) rounded up to nearest multiple of 4 */
+			b64_size_t required_len = ((in_len + 2) / 3) * 4;
+			if (out_len >= required_len + 1) /* +1 for null terminator */
+			{
+				int encoded_len = EVP_EncodeBlock((unsigned char*)out, (const unsigned char*)in, (int)in_len);
+				if (encoded_len > 0)
+				{
+					ret = (b64_size_t)encoded_len;
+					if (out_len > ret)
+						out[ret] = '\0';
+				}
+			}
 		}
 		else
 		{
-			b_in = b64;
-			b_out = bio;
-		}
-
-		rv = BIO_write(b_out, in, (int)in_len);
-		BIO_flush(b_out); /* indicate end of encoding */
-
-		if ( rv > 0 )
-		{
-			rv = BIO_read(b_in, out, (int)out_len);
-			if ( rv > 0 )
+			/* For decoding: output length is at most 3 * (input_length / 4) */
+			b64_size_t max_out_len = (in_len / 4) * 3;
+			if (out_len >= max_out_len + 1) /* +1 for null terminator */
 			{
-				ret = (b64_size_t)rv;
-				if ( out_len > ret )
-					out[ret] = '\0';
+				EVP_ENCODE_CTX *ctx = EVP_ENCODE_CTX_new();
+				if (ctx)
+				{
+					int decoded_len = 0;
+					int final_len = 0;
+					unsigned char *temp_out = (unsigned char*)out;
+					
+					EVP_DecodeInit(ctx);
+					EVP_DecodeUpdate(ctx, temp_out, &decoded_len, (const unsigned char*)in, (int)in_len);
+					EVP_DecodeFinal(ctx, temp_out + decoded_len, &final_len);
+					EVP_ENCODE_CTX_free(ctx);
+					
+					ret = (b64_size_t)(decoded_len + final_len);
+					if (out_len > ret)
+						out[ret] = '\0';
+				}
 			}
 		}
-
-		BIO_free_all(b64);  /* free all used memory */
 	}
 	return ret;
 }

--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -1864,7 +1864,7 @@ thread_return_type WINAPI MQTTAsync_sendThread(void* n)
 	MQTTAsync_unlock_mutex(mqttasync_mutex);
 
 #if defined(OPENSSL)
-#if ((OPENSSL_VERSION_NUMBER < 0x1010000fL) || defined(LIBRESSL_VERSION_NUMBER))
+#if ((OPENSSL_VERSION_NUMBER < 0x1010000fL) || defined(LIBRESSL_VERSION_NUMBER)) || defined(OPENSSL_IS_BORINGSSL)
 	ERR_remove_state(0);
 #else
 	OPENSSL_thread_stop();
@@ -2397,7 +2397,7 @@ thread_return_type WINAPI MQTTAsync_receiveThread(void* n)
 #endif
 
 #if defined(OPENSSL)
-#if ((OPENSSL_VERSION_NUMBER < 0x1010000fL) || defined(LIBRESSL_VERSION_NUMBER))
+#if ((OPENSSL_VERSION_NUMBER < 0x1010000fL) || defined(LIBRESSL_VERSION_NUMBER)) || defined(OPENSSL_IS_BORINGSSL)
 	ERR_remove_state(0);
 #else
 	OPENSSL_thread_stop();


### PR DESCRIPTION
I'm writing Bazel build files for paho.mqtt.c and want to link against BoringSSL instead of OpenSSL or LibreSSL.

`BIO_f_base64` (https://docs.openssl.org/3.3/man3/BIO_f_base64/) is deprecated and can't easily be used when using BoringSSL via Bazel: 
https://github.com/google/boringssl/blob/a553a9d65aa4e4f28a6c3007db14e9605e7c3bde/include/openssl/bio.h#L788-L797
This PR updates src/Base64.c to use the recommended `EVP_EncodeBlock`/`EVP_DecodeBase64` functions instead, which are available.


The other change in src/MQTTAsyncUtils.c is analogous to https://github.com/eclipse-paho/paho.mqtt.c/issues/1426 - BoringSSL targets OpenSSL 1.1.0 but not all APIs are actually implemented (see https://github.com/google/boringssl/blob/main/PORTING.md)