### PR TITLE
Fix build error due to bool keyword with gcc-15

### DIFF
--- a/src/MQTTPacket.h
+++ b/src/MQTTPacket.h
@@ -28,7 +28,9 @@
 #include "LinkedList.h"
 #include "Clients.h"
 
+#if defined __STDC__ && defined __STDC_VERSION__ && __STDC_VERSION__ <= 201710L
 typedef unsigned int bool;
+#endif
 typedef void* (*pf)(int, unsigned char, char*, size_t);
 
 #include "MQTTProperties.h"


### PR DESCRIPTION
* gcc-15 uses gnu23 for c. 'bool' is a keyword. TOPDIR/tmp/work/core2-64-oe-linux/paho-mqtt-c/1.3.14/git/src/MQTTPacket.h:31:22: error: 'bool' cannot be defined via 'typedef'
   31 | typedef unsigned int bool;
      |                      ^~~~
TOPDIR/tmp/work/core2-64-oe-linux/paho-mqtt-c/1.3.14/git/src/MQTTPacket.h:31:22: note: 'bool' is a keyword with '-std=c23' onwards
TOPDIR/tmp/work/core2-64-oe-linux/paho-mqtt-c/1.3.14/git/src/MQTTPacket.h:31:1: warning: useless type name in empty declaration
   31 | typedef unsigned int bool;
      | ^~~~~~~


Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


